### PR TITLE
fix(discord): support explicit bot or user token auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 `discrawl` mirrors Discord guild data into local SQLite so you can search, inspect, and query server history without depending on Discord search.
 
-It is a bot-token crawler. No user-token hacks. Data stays local.
+It supports both bot tokens and user tokens. Data stays local.
 
 ## What It Does
 
@@ -20,12 +20,19 @@ Search defaults to all guilds. `sync` and `tail` default to the configured defau
 ## Requirements
 
 - Go `1.26+`
-- a Discord bot token the bot can use to read the target guilds
-- bot permissions for the channels you want archived
+- a Discord token (bot or user) that can read the target guilds
+- for bot tokens: bot permissions for the channels you want archived
 
-### Discord Bot Setup
+### Discord Auth Setup
 
-`discrawl` needs a real bot token. Not a user token.
+`discrawl` can authenticate with either:
+
+- a bot token (`Bot <token>` or raw token text)
+- a user token (raw token text)
+
+When a raw token is provided, `discrawl` tries bot auth first, then falls back to user auth if Discord rejects the bot prefix.
+
+### Discord Bot Setup (optional)
 
 Minimum practical setup:
 
@@ -41,14 +48,14 @@ Minimum practical setup:
 
 Without those intents/permissions, `sync`, `tail`, member snapshots, or message content archiving will be partial or fail.
 
-### Bot Token Sources
+### Token Sources
 
 Token resolution:
 
 1. OpenClaw config, if `discord.token_source` is not `env`
 2. `DISCORD_BOT_TOKEN` or the configured `discord.token_env`
 
-`discrawl` accepts either raw token text or a value prefixed with `Bot `. It normalizes that automatically.
+`discrawl` accepts either raw token text or a value prefixed with `Bot `.
 
 Fastest env-only path:
 
@@ -95,7 +102,7 @@ brew install steipete/tap/discrawl
 
 ## Quick Start
 
-Reuse an existing OpenClaw Discord bot config:
+Reuse an existing OpenClaw Discord config:
 
 ```bash
 bin/discrawl init --from-openclaw ~/.openclaw/openclaw.json
@@ -120,8 +127,8 @@ bin/discrawl sync --full
 
 - confirms config can be loaded
 - shows where the token was resolved from
-- verifies bot auth
-- shows how many guilds the bot can access
+- verifies Discord auth
+- shows how many guilds the token can access
 - verifies DB + FTS wiring
 
 ## Commands

--- a/README.md
+++ b/README.md
@@ -30,7 +30,10 @@ Search defaults to all guilds. `sync` and `tail` default to the configured defau
 - a bot token (`Bot <token>` or raw token text)
 - a user token (raw token text)
 
-When a raw token is provided, `discrawl` tries bot auth first, then falls back to user auth if Discord rejects the bot prefix.
+Choose auth mode with `discord.token_kind` in config:
+
+- `bot`: sends `Authorization: Bot <token>`
+- `user`: sends `Authorization: <token>`
 
 ### Discord Bot Setup (optional)
 
@@ -56,6 +59,7 @@ Token resolution:
 2. `DISCORD_BOT_TOKEN` or the configured `discord.token_env`
 
 `discrawl` accepts either raw token text or a value prefixed with `Bot `.
+In `bot` mode, `discrawl` normalizes to `Bot <token>`. In `user` mode, it sends raw token auth.
 
 Fastest env-only path:
 
@@ -285,6 +289,7 @@ token_source = "openclaw"
 openclaw_config = "~/.openclaw/openclaw.json"
 account = "default"
 token_env = "DISCORD_BOT_TOKEN"
+token_kind = "bot"
 
 [sync]
 concurrency = 16
@@ -310,6 +315,7 @@ Config override rules:
 - `--config` beats everything
 - `DISCRAWL_CONFIG` overrides the default config path
 - `discord.token_source = "env"` forces env-only token lookup
+- `discord.token_kind = "bot" | "user"` chooses auth header style
 
 ## Embeddings
 
@@ -339,7 +345,7 @@ Set `sync.attachment_text = false` if you want to keep attachment metadata and f
 
 ## Security
 
-- do not commit bot tokens or API keys
+- do not commit Discord tokens or API keys
 - default config lives in your home directory, not inside the repo
 - CI runs secret scanning with `gitleaks`
 - `doctor` reports token source, not token contents

--- a/SPEC.md
+++ b/SPEC.md
@@ -559,6 +559,7 @@ log_dir = "~/.discrawl/logs"
 token_source = "openclaw"
 openclaw_config = "~/.openclaw/openclaw.json"
 channel_account = "discord"
+token_kind = "bot"
 
 [sync]
 concurrency = 4
@@ -598,6 +599,7 @@ Do not:
 Do:
 
 - load Discord token from OpenClaw config path
+- choose auth style explicitly via `discord.token_kind = "bot" | "user"`
 - load OpenAI key from env
 - redact secrets in debug and doctor output
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -68,7 +68,7 @@ An agent should assume:
 - Go is installed and modern
 - user is Peter
 - user keeps many secrets in `~/.profile`
-- an existing OpenClaw install may already contain usable Discord bot config
+- an existing OpenClaw install may already contain usable Discord token config
 
 ### Key file paths
 
@@ -78,9 +78,9 @@ An agent should assume:
 - `~/.openclaw/openclaw.json`
 - `~/.openclaw/openclaw.json.bak*`
 
-### Existing bot config
+### Existing Discord token config
 
-The current bot token source is expected in:
+The current token source is expected in:
 
 - `~/.openclaw/openclaw.json`
 
@@ -591,13 +591,13 @@ Environment variables:
 
 Do not:
 
-- put bot tokens in git
+- put Discord tokens in git
 - put API keys in git
 - print secrets in normal logs
 
 Do:
 
-- load bot token from OpenClaw config path
+- load Discord token from OpenClaw config path
 - load OpenAI key from env
 - redact secrets in debug and doctor output
 
@@ -607,7 +607,7 @@ Do:
 
 1. load config
 2. resolve token
-3. fetch bot identity
+3. fetch authenticated identity
 4. fetch guild metadata
 5. fetch guild channels
 6. fetch active threads

--- a/internal/cli/admin_commands.go
+++ b/internal/cli/admin_commands.go
@@ -84,6 +84,7 @@ func (r *runtime) runInit(args []string) error {
 		"config_path":       r.configPath,
 		"db_path":           cfg.DBPath,
 		"token_source":      token.Source,
+		"token_kind":        token.Kind,
 		"default_guild_id":  cfg.DefaultGuildID,
 		"discovered_guilds": cfg.GuildIDs,
 	})
@@ -173,6 +174,7 @@ func (r *runtime) runDoctor(args []string) error {
 		report["discord_token"] = err.Error()
 	} else {
 		report["discord_token"] = token.Source
+		report["token_kind"] = token.Kind
 		discordFactory := r.newDiscord
 		if discordFactory == nil {
 			discordFactory = func(cfg config.Config) (discordClient, error) {
@@ -187,7 +189,7 @@ func (r *runtime) runDoctor(args []string) error {
 				report["discord_auth"] = authErr.Error()
 			} else {
 				report["discord_auth"] = "ok"
-				report["bot_user_id"] = self.ID
+				report["discord_user_id"] = self.ID
 			}
 			guilds, guildErr := client.Guilds(r.ctx)
 			if guildErr != nil {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -16,6 +16,7 @@ import (
 const (
 	DefaultConfigEnv = "DISCRAWL_CONFIG"
 	DefaultTokenEnv  = "DISCORD_BOT_TOKEN"
+	DefaultTokenKind = "bot"
 )
 
 type Config struct {
@@ -36,6 +37,7 @@ type DiscordConfig struct {
 	OpenClawConfig string `toml:"openclaw_config"`
 	Account        string `toml:"account"`
 	TokenEnv       string `toml:"token_env"`
+	TokenKind      string `toml:"token_kind"`
 }
 
 type SyncConfig struct {
@@ -62,6 +64,7 @@ type TokenResolution struct {
 	Token  string
 	Source string
 	Path   string
+	Kind   string
 }
 
 type OpenClawDiscord struct {
@@ -101,6 +104,7 @@ func Default() Config {
 			OpenClawConfig: filepath.Join(home, ".openclaw", "openclaw.json"),
 			Account:        "default",
 			TokenEnv:       DefaultTokenEnv,
+			TokenKind:      DefaultTokenKind,
 		},
 		Sync: SyncConfig{
 			Concurrency:    defaultSyncConcurrency(),
@@ -212,6 +216,14 @@ func (c *Config) Normalize() error {
 	if c.Discord.TokenEnv == "" {
 		c.Discord.TokenEnv = DefaultTokenEnv
 	}
+	if c.Discord.TokenKind == "" {
+		c.Discord.TokenKind = DefaultTokenKind
+	}
+	switch c.Discord.TokenKind {
+	case "bot", "user":
+	default:
+		return fmt.Errorf("invalid discord.token_kind %q: expected bot or user", c.Discord.TokenKind)
+	}
 	if c.Sync.Concurrency <= 0 {
 		c.Sync.Concurrency = defaultSyncConcurrency()
 	}
@@ -297,14 +309,17 @@ func ResolveDiscordToken(cfg Config) (TokenResolution, error) {
 	if cfg.Discord.TokenSource != "env" {
 		openClaw, err := LoadOpenClawDiscord(cfg.Discord.OpenClawConfig, cfg.Discord.Account)
 		if err == nil && openClaw.Token != "" {
-			return TokenResolution{Token: openClaw.Token, Source: "openclaw", Path: openClaw.Path}, nil
+			token := formatTokenForKind(openClaw.Token, cfg.Discord.TokenKind)
+			if token != "" {
+				return TokenResolution{Token: token, Source: "openclaw", Path: openClaw.Path, Kind: cfg.Discord.TokenKind}, nil
+			}
 		}
 		if err != nil && !errors.Is(err, os.ErrNotExist) {
 			return TokenResolution{}, err
 		}
 	}
-	if envToken := NormalizeBotToken(os.Getenv(cfg.Discord.TokenEnv)); envToken != "" {
-		return TokenResolution{Token: envToken, Source: "env", Path: cfg.Discord.TokenEnv}, nil
+	if envToken := formatTokenForKind(os.Getenv(cfg.Discord.TokenEnv), cfg.Discord.TokenKind); envToken != "" {
+		return TokenResolution{Token: envToken, Source: "env", Path: cfg.Discord.TokenEnv, Kind: cfg.Discord.TokenKind}, nil
 	}
 	return TokenResolution{}, errors.New("discord token not found in env or openclaw config")
 }
@@ -340,14 +355,14 @@ func loadOpenClawDiscordFile(path, account string) (OpenClawDiscord, error) {
 		return OpenClawDiscord{}, fmt.Errorf("parse openclaw config: %w", err)
 	}
 	discord := payload.Channels.Discord
-	token := NormalizeBotToken(discord.Token)
+	token := normalizeToken(discord.Token)
 	guildIDs := mapKeys(discord.Guilds)
 	if token == "" {
 		acct := discord.Accounts[normalizeAccount(account)]
 		if acct.Token == "" && account != normalizeAccount(account) {
 			acct = discord.Accounts[account]
 		}
-		token = NormalizeBotToken(acct.Token)
+		token = normalizeToken(acct.Token)
 		if len(guildIDs) == 0 {
 			guildIDs = mapKeys(acct.Guilds)
 		}
@@ -374,10 +389,27 @@ func openClawCandidates(path string) ([]string, error) {
 	return uniqueStrings(candidates), nil
 }
 
-func NormalizeBotToken(raw string) string {
+func normalizeToken(raw string) string {
 	raw = strings.TrimSpace(raw)
-	raw = strings.TrimPrefix(raw, "Bot ")
+	lower := strings.ToLower(raw)
+	if strings.HasPrefix(lower, "bot ") {
+		raw = strings.TrimSpace(raw[len("Bot "):])
+	}
+	if strings.HasPrefix(lower, "bearer ") {
+		raw = strings.TrimSpace(raw[len("Bearer "):])
+	}
 	return strings.TrimSpace(raw)
+}
+
+func formatTokenForKind(raw, kind string) string {
+	token := normalizeToken(raw)
+	if token == "" {
+		return ""
+	}
+	if kind == "user" {
+		return token
+	}
+	return "Bot " + token
 }
 
 func normalizeAccount(account string) string {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -17,6 +17,7 @@ func TestNormalizeFillsDefaults(t *testing.T) {
 	require.Equal(t, "openclaw", cfg.Discord.TokenSource)
 	require.Equal(t, "default", cfg.Discord.Account)
 	require.Equal(t, DefaultTokenEnv, cfg.Discord.TokenEnv)
+	require.Equal(t, DefaultTokenKind, cfg.Discord.TokenKind)
 	require.Equal(t, defaultSyncConcurrency(), cfg.Sync.Concurrency)
 	require.GreaterOrEqual(t, cfg.Sync.Concurrency, 8)
 	require.LessOrEqual(t, cfg.Sync.Concurrency, 32)
@@ -43,8 +44,9 @@ func TestResolveDiscordTokenPrefersOpenClaw(t *testing.T) {
 
 	token, err := ResolveDiscordToken(cfg)
 	require.NoError(t, err)
-	require.Equal(t, "config-token", token.Token)
+	require.Equal(t, "Bot config-token", token.Token)
 	require.Equal(t, "openclaw", token.Source)
+	require.Equal(t, "bot", token.Kind)
 }
 
 func TestResolveDiscordTokenFallsBackToEnv(t *testing.T) {
@@ -55,8 +57,21 @@ func TestResolveDiscordTokenFallsBackToEnv(t *testing.T) {
 
 	token, err := ResolveDiscordToken(cfg)
 	require.NoError(t, err)
-	require.Equal(t, "env-token", token.Token)
+	require.Equal(t, "Bot env-token", token.Token)
 	require.Equal(t, "env", token.Source)
+	require.Equal(t, "bot", token.Kind)
+}
+
+func TestResolveDiscordTokenUserKind(t *testing.T) {
+	cfg := Default()
+	cfg.Discord.TokenSource = "env"
+	cfg.Discord.TokenKind = "user"
+	t.Setenv(DefaultTokenEnv, "user-token")
+
+	token, err := ResolveDiscordToken(cfg)
+	require.NoError(t, err)
+	require.Equal(t, "user-token", token.Token)
+	require.Equal(t, "user", token.Kind)
 }
 
 func TestLoadOpenClawDiscordFromAccount(t *testing.T) {
@@ -175,4 +190,10 @@ func TestConfigErrorsAndBackupFallback(t *testing.T) {
 	info, err := LoadOpenClawDiscord(base, "default")
 	require.NoError(t, err)
 	require.Equal(t, "backup-token", info.Token)
+}
+
+func TestNormalizeRejectsInvalidTokenKind(t *testing.T) {
+	cfg := Default()
+	cfg.Discord.TokenKind = "auto"
+	require.ErrorContains(t, cfg.Normalize(), "discord.token_kind")
 }

--- a/internal/discord/client.go
+++ b/internal/discord/client.go
@@ -2,9 +2,12 @@ package discord
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"net/http"
 	"runtime"
 	"slices"
+	"strings"
 	"sync"
 	"time"
 
@@ -22,6 +25,8 @@ type EventHandler interface {
 
 type Client struct {
 	session            *discordgo.Session
+	fallbackToken      string
+	authMu             sync.Mutex
 	requestTimeout     time.Duration
 	tailWorkerCount    int
 	tailQueueSize      int
@@ -29,7 +34,8 @@ type Client struct {
 }
 
 func New(token string) (*Client, error) {
-	session, err := discordgo.New("Bot " + token)
+	authToken, fallbackToken := authTokens(token)
+	session, err := discordgo.New(authToken)
 	if err != nil {
 		return nil, fmt.Errorf("create discord session: %w", err)
 	}
@@ -39,6 +45,7 @@ func New(token string) (*Client, error) {
 		discordgo.IntentsGuildMembers
 	return &Client{
 		session:            session,
+		fallbackToken:      fallbackToken,
 		requestTimeout:     45 * time.Second,
 		tailWorkerCount:    defaultTailWorkerCount(),
 		tailQueueSize:      defaultTailQueueSize(),
@@ -54,18 +61,38 @@ func (c *Client) Close() error {
 }
 
 func (c *Client) Self(ctx context.Context) (*discordgo.User, error) {
-	reqCtx, cancel := c.requestContext(ctx)
-	defer cancel()
-	return c.session.User("@me", discordgo.WithContext(reqCtx))
+	var out *discordgo.User
+	err := c.withAuthFallback(ctx, func(callCtx context.Context) error {
+		reqCtx, cancel := c.requestContext(callCtx)
+		defer cancel()
+		user, err := c.session.User("@me", discordgo.WithContext(reqCtx))
+		if err != nil {
+			return err
+		}
+		out = user
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (c *Client) Guilds(ctx context.Context) ([]*discordgo.UserGuild, error) {
 	var out []*discordgo.UserGuild
 	before := ""
 	for {
-		reqCtx, cancel := c.requestContext(ctx)
-		page, err := c.session.UserGuilds(200, before, "", false, discordgo.WithContext(reqCtx))
-		cancel()
+		var page []*discordgo.UserGuild
+		err := c.withAuthFallback(ctx, func(callCtx context.Context) error {
+			reqCtx, cancel := c.requestContext(callCtx)
+			defer cancel()
+			result, err := c.session.UserGuilds(200, before, "", false, discordgo.WithContext(reqCtx))
+			if err != nil {
+				return err
+			}
+			page = result
+			return nil
+		})
 		if err != nil {
 			return nil, err
 		}
@@ -81,21 +108,53 @@ func (c *Client) Guilds(ctx context.Context) ([]*discordgo.UserGuild, error) {
 }
 
 func (c *Client) Guild(ctx context.Context, guildID string) (*discordgo.Guild, error) {
-	reqCtx, cancel := c.requestContext(ctx)
-	defer cancel()
-	return c.session.Guild(guildID, discordgo.WithContext(reqCtx))
+	var out *discordgo.Guild
+	err := c.withAuthFallback(ctx, func(callCtx context.Context) error {
+		reqCtx, cancel := c.requestContext(callCtx)
+		defer cancel()
+		guild, err := c.session.Guild(guildID, discordgo.WithContext(reqCtx))
+		if err != nil {
+			return err
+		}
+		out = guild
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (c *Client) GuildChannels(ctx context.Context, guildID string) ([]*discordgo.Channel, error) {
-	reqCtx, cancel := c.requestContext(ctx)
-	defer cancel()
-	return c.session.GuildChannels(guildID, discordgo.WithContext(reqCtx))
+	var out []*discordgo.Channel
+	err := c.withAuthFallback(ctx, func(callCtx context.Context) error {
+		reqCtx, cancel := c.requestContext(callCtx)
+		defer cancel()
+		channels, err := c.session.GuildChannels(guildID, discordgo.WithContext(reqCtx))
+		if err != nil {
+			return err
+		}
+		out = channels
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (c *Client) ThreadsActive(ctx context.Context, channelID string) ([]*discordgo.Channel, error) {
-	reqCtx, cancel := c.requestContext(ctx)
-	defer cancel()
-	list, err := c.session.ThreadsActive(channelID, discordgo.WithContext(reqCtx))
+	var list *discordgo.ThreadsList
+	err := c.withAuthFallback(ctx, func(callCtx context.Context) error {
+		reqCtx, cancel := c.requestContext(callCtx)
+		defer cancel()
+		result, err := c.session.ThreadsActive(channelID, discordgo.WithContext(reqCtx))
+		if err != nil {
+			return err
+		}
+		list = result
+		return nil
+	})
 	if err != nil {
 		return nil, err
 	}
@@ -106,15 +165,25 @@ func (c *Client) ThreadsArchived(ctx context.Context, channelID string, private 
 	var out []*discordgo.Channel
 	var before *time.Time
 	for {
-		reqCtx, cancel := c.requestContext(ctx)
 		var list *discordgo.ThreadsList
-		var err error
-		if private {
-			list, err = c.session.ThreadsPrivateArchived(channelID, before, 100, discordgo.WithContext(reqCtx))
-		} else {
-			list, err = c.session.ThreadsArchived(channelID, before, 100, discordgo.WithContext(reqCtx))
-		}
-		cancel()
+		err := c.withAuthFallback(ctx, func(callCtx context.Context) error {
+			reqCtx, cancel := c.requestContext(callCtx)
+			defer cancel()
+			if private {
+				result, err := c.session.ThreadsPrivateArchived(channelID, before, 100, discordgo.WithContext(reqCtx))
+				if err != nil {
+					return err
+				}
+				list = result
+				return nil
+			}
+			result, err := c.session.ThreadsArchived(channelID, before, 100, discordgo.WithContext(reqCtx))
+			if err != nil {
+				return err
+			}
+			list = result
+			return nil
+		})
 		if err != nil {
 			return nil, err
 		}
@@ -138,9 +207,17 @@ func (c *Client) GuildMembers(ctx context.Context, guildID string) ([]*discordgo
 	var out []*discordgo.Member
 	after := ""
 	for {
-		reqCtx, cancel := c.requestContext(ctx)
-		page, err := c.session.GuildMembers(guildID, after, 1000, discordgo.WithContext(reqCtx))
-		cancel()
+		var page []*discordgo.Member
+		err := c.withAuthFallback(ctx, func(callCtx context.Context) error {
+			reqCtx, cancel := c.requestContext(callCtx)
+			defer cancel()
+			result, err := c.session.GuildMembers(guildID, after, 1000, discordgo.WithContext(reqCtx))
+			if err != nil {
+				return err
+			}
+			page = result
+			return nil
+		})
 		if err != nil {
 			return nil, err
 		}
@@ -156,15 +233,39 @@ func (c *Client) GuildMembers(ctx context.Context, guildID string) ([]*discordgo
 }
 
 func (c *Client) ChannelMessages(ctx context.Context, channelID string, limit int, beforeID, afterID string) ([]*discordgo.Message, error) {
-	reqCtx, cancel := c.requestContext(ctx)
-	defer cancel()
-	return c.session.ChannelMessages(channelID, limit, beforeID, afterID, "", discordgo.WithContext(reqCtx))
+	var out []*discordgo.Message
+	err := c.withAuthFallback(ctx, func(callCtx context.Context) error {
+		reqCtx, cancel := c.requestContext(callCtx)
+		defer cancel()
+		messages, err := c.session.ChannelMessages(channelID, limit, beforeID, afterID, "", discordgo.WithContext(reqCtx))
+		if err != nil {
+			return err
+		}
+		out = messages
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (c *Client) ChannelMessage(ctx context.Context, channelID, messageID string) (*discordgo.Message, error) {
-	reqCtx, cancel := c.requestContext(ctx)
-	defer cancel()
-	return c.session.ChannelMessage(channelID, messageID, discordgo.WithContext(reqCtx))
+	var out *discordgo.Message
+	err := c.withAuthFallback(ctx, func(callCtx context.Context) error {
+		reqCtx, cancel := c.requestContext(callCtx)
+		defer cancel()
+		message, err := c.session.ChannelMessage(channelID, messageID, discordgo.WithContext(reqCtx))
+		if err != nil {
+			return err
+		}
+		out = message
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (c *Client) Tail(ctx context.Context, handler EventHandler) error {
@@ -261,7 +362,9 @@ func (c *Client) Tail(ctx context.Context, handler EventHandler) error {
 			return handler.OnMemberDelete(taskCtx, evt.GuildID, evt.User.ID)
 		})
 	})
-	if err := c.session.Open(); err != nil {
+	if err := c.withAuthFallback(tailCtx, func(context.Context) error {
+		return c.session.Open()
+	}); err != nil {
 		return err
 	}
 	defer func() {
@@ -369,4 +472,55 @@ func (c *Client) requestContext(ctx context.Context) (context.Context, context.C
 		return context.WithCancel(ctx)
 	}
 	return context.WithTimeout(ctx, c.requestTimeout)
+}
+
+func authTokens(raw string) (token string, fallback string) {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return "", ""
+	}
+	lower := strings.ToLower(trimmed)
+	if strings.HasPrefix(lower, "bot ") || strings.HasPrefix(lower, "bearer ") {
+		return trimmed, ""
+	}
+	return "Bot " + trimmed, trimmed
+}
+
+func (c *Client) withAuthFallback(ctx context.Context, call func(context.Context) error) error {
+	err := call(ctx)
+	if err == nil || !isUnauthorized(err) {
+		return err
+	}
+	if !c.swapToFallbackToken() {
+		return err
+	}
+	return call(ctx)
+}
+
+func (c *Client) swapToFallbackToken() bool {
+	if c == nil {
+		return false
+	}
+	c.authMu.Lock()
+	defer c.authMu.Unlock()
+	if c.fallbackToken == "" || c.session == nil || c.session.Token == c.fallbackToken {
+		return false
+	}
+	c.session.Token = c.fallbackToken
+	c.fallbackToken = ""
+	return true
+}
+
+func isUnauthorized(err error) bool {
+	var restErr *discordgo.RESTError
+	if errors.As(err, &restErr) && restErr.Response != nil {
+		if restErr.Response.StatusCode == http.StatusUnauthorized {
+			return true
+		}
+	}
+	message := strings.ToLower(err.Error())
+	return strings.Contains(message, "401") ||
+		strings.Contains(message, "4004") ||
+		strings.Contains(message, "unauthorized") ||
+		strings.Contains(message, "authentication failed")
 }

--- a/internal/discord/client.go
+++ b/internal/discord/client.go
@@ -2,9 +2,7 @@ package discord
 
 import (
 	"context"
-	"errors"
 	"fmt"
-	"net/http"
 	"runtime"
 	"slices"
 	"strings"
@@ -25,8 +23,6 @@ type EventHandler interface {
 
 type Client struct {
 	session            *discordgo.Session
-	fallbackToken      string
-	authMu             sync.Mutex
 	requestTimeout     time.Duration
 	tailWorkerCount    int
 	tailQueueSize      int
@@ -34,8 +30,7 @@ type Client struct {
 }
 
 func New(token string) (*Client, error) {
-	authToken, fallbackToken := authTokens(token)
-	session, err := discordgo.New(authToken)
+	session, err := discordgo.New(strings.TrimSpace(token))
 	if err != nil {
 		return nil, fmt.Errorf("create discord session: %w", err)
 	}
@@ -45,7 +40,6 @@ func New(token string) (*Client, error) {
 		discordgo.IntentsGuildMembers
 	return &Client{
 		session:            session,
-		fallbackToken:      fallbackToken,
 		requestTimeout:     45 * time.Second,
 		tailWorkerCount:    defaultTailWorkerCount(),
 		tailQueueSize:      defaultTailQueueSize(),
@@ -61,38 +55,18 @@ func (c *Client) Close() error {
 }
 
 func (c *Client) Self(ctx context.Context) (*discordgo.User, error) {
-	var out *discordgo.User
-	err := c.withAuthFallback(ctx, func(callCtx context.Context) error {
-		reqCtx, cancel := c.requestContext(callCtx)
-		defer cancel()
-		user, err := c.session.User("@me", discordgo.WithContext(reqCtx))
-		if err != nil {
-			return err
-		}
-		out = user
-		return nil
-	})
-	if err != nil {
-		return nil, err
-	}
-	return out, nil
+	reqCtx, cancel := c.requestContext(ctx)
+	defer cancel()
+	return c.session.User("@me", discordgo.WithContext(reqCtx))
 }
 
 func (c *Client) Guilds(ctx context.Context) ([]*discordgo.UserGuild, error) {
 	var out []*discordgo.UserGuild
 	before := ""
 	for {
-		var page []*discordgo.UserGuild
-		err := c.withAuthFallback(ctx, func(callCtx context.Context) error {
-			reqCtx, cancel := c.requestContext(callCtx)
-			defer cancel()
-			result, err := c.session.UserGuilds(200, before, "", false, discordgo.WithContext(reqCtx))
-			if err != nil {
-				return err
-			}
-			page = result
-			return nil
-		})
+		reqCtx, cancel := c.requestContext(ctx)
+		page, err := c.session.UserGuilds(200, before, "", false, discordgo.WithContext(reqCtx))
+		cancel()
 		if err != nil {
 			return nil, err
 		}
@@ -108,53 +82,21 @@ func (c *Client) Guilds(ctx context.Context) ([]*discordgo.UserGuild, error) {
 }
 
 func (c *Client) Guild(ctx context.Context, guildID string) (*discordgo.Guild, error) {
-	var out *discordgo.Guild
-	err := c.withAuthFallback(ctx, func(callCtx context.Context) error {
-		reqCtx, cancel := c.requestContext(callCtx)
-		defer cancel()
-		guild, err := c.session.Guild(guildID, discordgo.WithContext(reqCtx))
-		if err != nil {
-			return err
-		}
-		out = guild
-		return nil
-	})
-	if err != nil {
-		return nil, err
-	}
-	return out, nil
+	reqCtx, cancel := c.requestContext(ctx)
+	defer cancel()
+	return c.session.Guild(guildID, discordgo.WithContext(reqCtx))
 }
 
 func (c *Client) GuildChannels(ctx context.Context, guildID string) ([]*discordgo.Channel, error) {
-	var out []*discordgo.Channel
-	err := c.withAuthFallback(ctx, func(callCtx context.Context) error {
-		reqCtx, cancel := c.requestContext(callCtx)
-		defer cancel()
-		channels, err := c.session.GuildChannels(guildID, discordgo.WithContext(reqCtx))
-		if err != nil {
-			return err
-		}
-		out = channels
-		return nil
-	})
-	if err != nil {
-		return nil, err
-	}
-	return out, nil
+	reqCtx, cancel := c.requestContext(ctx)
+	defer cancel()
+	return c.session.GuildChannels(guildID, discordgo.WithContext(reqCtx))
 }
 
 func (c *Client) ThreadsActive(ctx context.Context, channelID string) ([]*discordgo.Channel, error) {
-	var list *discordgo.ThreadsList
-	err := c.withAuthFallback(ctx, func(callCtx context.Context) error {
-		reqCtx, cancel := c.requestContext(callCtx)
-		defer cancel()
-		result, err := c.session.ThreadsActive(channelID, discordgo.WithContext(reqCtx))
-		if err != nil {
-			return err
-		}
-		list = result
-		return nil
-	})
+	reqCtx, cancel := c.requestContext(ctx)
+	defer cancel()
+	list, err := c.session.ThreadsActive(channelID, discordgo.WithContext(reqCtx))
 	if err != nil {
 		return nil, err
 	}
@@ -165,25 +107,15 @@ func (c *Client) ThreadsArchived(ctx context.Context, channelID string, private 
 	var out []*discordgo.Channel
 	var before *time.Time
 	for {
+		reqCtx, cancel := c.requestContext(ctx)
 		var list *discordgo.ThreadsList
-		err := c.withAuthFallback(ctx, func(callCtx context.Context) error {
-			reqCtx, cancel := c.requestContext(callCtx)
-			defer cancel()
-			if private {
-				result, err := c.session.ThreadsPrivateArchived(channelID, before, 100, discordgo.WithContext(reqCtx))
-				if err != nil {
-					return err
-				}
-				list = result
-				return nil
-			}
-			result, err := c.session.ThreadsArchived(channelID, before, 100, discordgo.WithContext(reqCtx))
-			if err != nil {
-				return err
-			}
-			list = result
-			return nil
-		})
+		var err error
+		if private {
+			list, err = c.session.ThreadsPrivateArchived(channelID, before, 100, discordgo.WithContext(reqCtx))
+		} else {
+			list, err = c.session.ThreadsArchived(channelID, before, 100, discordgo.WithContext(reqCtx))
+		}
+		cancel()
 		if err != nil {
 			return nil, err
 		}
@@ -207,17 +139,9 @@ func (c *Client) GuildMembers(ctx context.Context, guildID string) ([]*discordgo
 	var out []*discordgo.Member
 	after := ""
 	for {
-		var page []*discordgo.Member
-		err := c.withAuthFallback(ctx, func(callCtx context.Context) error {
-			reqCtx, cancel := c.requestContext(callCtx)
-			defer cancel()
-			result, err := c.session.GuildMembers(guildID, after, 1000, discordgo.WithContext(reqCtx))
-			if err != nil {
-				return err
-			}
-			page = result
-			return nil
-		})
+		reqCtx, cancel := c.requestContext(ctx)
+		page, err := c.session.GuildMembers(guildID, after, 1000, discordgo.WithContext(reqCtx))
+		cancel()
 		if err != nil {
 			return nil, err
 		}
@@ -233,39 +157,15 @@ func (c *Client) GuildMembers(ctx context.Context, guildID string) ([]*discordgo
 }
 
 func (c *Client) ChannelMessages(ctx context.Context, channelID string, limit int, beforeID, afterID string) ([]*discordgo.Message, error) {
-	var out []*discordgo.Message
-	err := c.withAuthFallback(ctx, func(callCtx context.Context) error {
-		reqCtx, cancel := c.requestContext(callCtx)
-		defer cancel()
-		messages, err := c.session.ChannelMessages(channelID, limit, beforeID, afterID, "", discordgo.WithContext(reqCtx))
-		if err != nil {
-			return err
-		}
-		out = messages
-		return nil
-	})
-	if err != nil {
-		return nil, err
-	}
-	return out, nil
+	reqCtx, cancel := c.requestContext(ctx)
+	defer cancel()
+	return c.session.ChannelMessages(channelID, limit, beforeID, afterID, "", discordgo.WithContext(reqCtx))
 }
 
 func (c *Client) ChannelMessage(ctx context.Context, channelID, messageID string) (*discordgo.Message, error) {
-	var out *discordgo.Message
-	err := c.withAuthFallback(ctx, func(callCtx context.Context) error {
-		reqCtx, cancel := c.requestContext(callCtx)
-		defer cancel()
-		message, err := c.session.ChannelMessage(channelID, messageID, discordgo.WithContext(reqCtx))
-		if err != nil {
-			return err
-		}
-		out = message
-		return nil
-	})
-	if err != nil {
-		return nil, err
-	}
-	return out, nil
+	reqCtx, cancel := c.requestContext(ctx)
+	defer cancel()
+	return c.session.ChannelMessage(channelID, messageID, discordgo.WithContext(reqCtx))
 }
 
 func (c *Client) Tail(ctx context.Context, handler EventHandler) error {
@@ -362,9 +262,7 @@ func (c *Client) Tail(ctx context.Context, handler EventHandler) error {
 			return handler.OnMemberDelete(taskCtx, evt.GuildID, evt.User.ID)
 		})
 	})
-	if err := c.withAuthFallback(tailCtx, func(context.Context) error {
-		return c.session.Open()
-	}); err != nil {
+	if err := c.session.Open(); err != nil {
 		return err
 	}
 	defer func() {
@@ -472,55 +370,4 @@ func (c *Client) requestContext(ctx context.Context) (context.Context, context.C
 		return context.WithCancel(ctx)
 	}
 	return context.WithTimeout(ctx, c.requestTimeout)
-}
-
-func authTokens(raw string) (token string, fallback string) {
-	trimmed := strings.TrimSpace(raw)
-	if trimmed == "" {
-		return "", ""
-	}
-	lower := strings.ToLower(trimmed)
-	if strings.HasPrefix(lower, "bot ") || strings.HasPrefix(lower, "bearer ") {
-		return trimmed, ""
-	}
-	return "Bot " + trimmed, trimmed
-}
-
-func (c *Client) withAuthFallback(ctx context.Context, call func(context.Context) error) error {
-	err := call(ctx)
-	if err == nil || !isUnauthorized(err) {
-		return err
-	}
-	if !c.swapToFallbackToken() {
-		return err
-	}
-	return call(ctx)
-}
-
-func (c *Client) swapToFallbackToken() bool {
-	if c == nil {
-		return false
-	}
-	c.authMu.Lock()
-	defer c.authMu.Unlock()
-	if c.fallbackToken == "" || c.session == nil || c.session.Token == c.fallbackToken {
-		return false
-	}
-	c.session.Token = c.fallbackToken
-	c.fallbackToken = ""
-	return true
-}
-
-func isUnauthorized(err error) bool {
-	var restErr *discordgo.RESTError
-	if errors.As(err, &restErr) && restErr.Response != nil {
-		if restErr.Response.StatusCode == http.StatusUnauthorized {
-			return true
-		}
-	}
-	message := strings.ToLower(err.Error())
-	return strings.Contains(message, "401") ||
-		strings.Contains(message, "4004") ||
-		strings.Contains(message, "unauthorized") ||
-		strings.Contains(message, "authentication failed")
 }

--- a/internal/discord/client_test.go
+++ b/internal/discord/client_test.go
@@ -158,7 +158,7 @@ func TestTailRequiresHandler(t *testing.T) {
 	require.NoError(t, (&Client{}).Close())
 }
 
-func TestClientSelfFallsBackToUserToken(t *testing.T) {
+func TestClientSelfUsesUserTokenAsProvided(t *testing.T) {
 	var (
 		mu      sync.Mutex
 		headers []string
@@ -190,10 +190,10 @@ func TestClientSelfFallsBackToUserToken(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "user", self.ID)
 	require.Equal(t, "token", client.session.Token)
-	require.Equal(t, []string{"Bot token", "token"}, headers)
+	require.Equal(t, []string{"token"}, headers)
 }
 
-func TestClientSelfKeepsBotTokenWhenBotAuthWorks(t *testing.T) {
+func TestClientSelfUsesBotTokenAsProvided(t *testing.T) {
 	var (
 		mu      sync.Mutex
 		headers []string
@@ -217,7 +217,7 @@ func TestClientSelfKeepsBotTokenWhenBotAuthWorks(t *testing.T) {
 	restore := patchDiscordEndpoints(server.URL + "/api/v10/")
 	defer restore()
 
-	client, err := New("token")
+	client, err := New("Bot token")
 	require.NoError(t, err)
 	defer func() { _ = client.Close() }()
 

--- a/internal/discord/client_test.go
+++ b/internal/discord/client_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -155,6 +156,76 @@ func TestTailRequiresHandler(t *testing.T) {
 	require.NoError(t, err)
 	require.Error(t, client.Tail(context.Background(), nil))
 	require.NoError(t, (&Client{}).Close())
+}
+
+func TestClientSelfFallsBackToUserToken(t *testing.T) {
+	var (
+		mu      sync.Mutex
+		headers []string
+	)
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v10/users/@me", func(w http.ResponseWriter, r *http.Request) {
+		auth := r.Header.Get("Authorization")
+		mu.Lock()
+		headers = append(headers, auth)
+		mu.Unlock()
+		if auth == "token" {
+			_ = json.NewEncoder(w).Encode(map[string]any{"id": "user"})
+			return
+		}
+		w.WriteHeader(http.StatusUnauthorized)
+		_ = json.NewEncoder(w).Encode(map[string]any{"message": "401: Unauthorized", "code": 0})
+	})
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	restore := patchDiscordEndpoints(server.URL + "/api/v10/")
+	defer restore()
+
+	client, err := New("token")
+	require.NoError(t, err)
+	defer func() { _ = client.Close() }()
+
+	self, err := client.Self(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, "user", self.ID)
+	require.Equal(t, "token", client.session.Token)
+	require.Equal(t, []string{"Bot token", "token"}, headers)
+}
+
+func TestClientSelfKeepsBotTokenWhenBotAuthWorks(t *testing.T) {
+	var (
+		mu      sync.Mutex
+		headers []string
+	)
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v10/users/@me", func(w http.ResponseWriter, r *http.Request) {
+		auth := r.Header.Get("Authorization")
+		mu.Lock()
+		headers = append(headers, auth)
+		mu.Unlock()
+		if auth != "Bot token" {
+			w.WriteHeader(http.StatusUnauthorized)
+			_ = json.NewEncoder(w).Encode(map[string]any{"message": "401: Unauthorized", "code": 0})
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"id": "bot"})
+	})
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	restore := patchDiscordEndpoints(server.URL + "/api/v10/")
+	defer restore()
+
+	client, err := New("token")
+	require.NoError(t, err)
+	defer func() { _ = client.Close() }()
+
+	self, err := client.Self(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, "bot", self.ID)
+	require.Equal(t, "Bot token", client.session.Token)
+	require.Equal(t, []string{"Bot token"}, headers)
 }
 
 func TestClientChannelMessagesTimesOut(t *testing.T) {


### PR DESCRIPTION
**Summary**
- Add explicit Discord auth mode selection via `discord.token_kind = \"bot\" | \"user\"`.
- Keep token source resolution (`openclaw` or env) and format the authorization header based on selected mode.
- Remove implicit bot->user fallback behavior so auth mode is an intentional config choice.

**Changes**
- `internal/config/config.go`: add `token_kind` (default `bot`), validation, token formatting, and expose resolved token kind.
- `internal/discord/client.go`: use provided token as-is (no fallback retry logic).
- `internal/cli/admin_commands.go`: include `token_kind` in `init`/`doctor` output and rename `bot_user_id` to `discord_user_id`.
- `README.md` and `SPEC.md`: document explicit mode selection and updated behavior.
- Tests added/updated in `internal/config/config_test.go` and `internal/discord/client_test.go`.

**Validation**
- `go test ./...`
- Live check with the token from `discord-py-self`:
  - `token_kind=user`: `doctor` auth ok and `sync` scraped real data (`channels=109`, `messages=51935`).
  - `token_kind=bot` with same token: expected `401 Unauthorized`.