### PR TITLE
fix(share): keep embedding jobs local to each archive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to `discrawl` will be documented in this file.
 - normalized message text is now sanitized before it reaches SQLite and FTS5, repairing malformed UTF-8 and stripping invisible/control-character noise that can poison search content
 - local embedding providers now support OpenAI-compatible endpoints, Ollama, and llama.cpp, and `doctor` can probe the configured provider before you queue vectors
 - `embed` now drains the queued embedding backlog in bounded batches, requeues safely on provider throttling, and drops stale stored vectors when messages no longer have embeddable content
+- Git-backed snapshots now keep embedding queue state and generated vectors local to each archive, so subscribers no longer inherit misleading embedding backlog metadata. (#38) Thanks @GaosCode.
 
 ## 0.3.0 - 2026-04-21
 

--- a/README.md
+++ b/README.md
@@ -365,6 +365,8 @@ Once `share.remote` is configured, read commands auto-fetch and import when the 
 
 Hybrid mode is supported too: keep normal Discord credentials configured and set `share.remote`. `discrawl sync` and `discrawl messages --sync` import the Git snapshot first, then use live Discord only to fill anything newer or missing. This keeps day-to-day sync fast while preserving live repair behavior.
 
+Git snapshots publish archive tables only. Embedding queue state and generated vectors stay local to each machine.
+
 The Docker smoke test installs `discrawl` in a clean Go container, subscribes to a Git snapshot repo, then checks `search`, `messages`, `sql`, and `report`:
 
 ```bash
@@ -474,7 +476,7 @@ discrawl sync --with-embeddings
 - canonical message rows
 - append-only message event records
 - FTS index rows
-- optional embedding backlog metadata
+- optional local embedding queue metadata and vectors
 
 SQLite schema migrations are versioned with `PRAGMA user_version`. Startup now fails fast when a local DB schema is newer than the supported binary.
 

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/bwmarrin/discordgo"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/steipete/discrawl/internal/config"
@@ -497,12 +498,12 @@ func TestEmbedCommandDrainsBoundedBacklog(t *testing.T) {
 	dbPath := filepath.Join(dir, "discrawl.db")
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		require.Equal(t, "/embeddings", r.URL.Path)
+		assert.Equal(t, "/embeddings", r.URL.Path)
 		var req struct {
 			Input []string `json:"input"`
 		}
-		require.NoError(t, json.NewDecoder(r.Body).Decode(&req))
-		require.Len(t, req.Input, 1)
+		assert.NoError(t, json.NewDecoder(r.Body).Decode(&req))
+		assert.Len(t, req.Input, 1)
 		_, _ = w.Write([]byte(`{"data":[{"index":0,"embedding":[1,2]}]}`))
 	}))
 	defer server.Close()
@@ -745,7 +746,7 @@ func TestDoctorChecksEnabledLocalEmbeddingProvider(t *testing.T) {
 	dbPath := filepath.Join(dir, "discrawl.db")
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		require.Equal(t, "/api/embed", r.URL.Path)
+		assert.Equal(t, "/api/embed", r.URL.Path)
 		_, _ = w.Write([]byte(`{"model":"nomic-embed-text","embeddings":[[1,2,3]]}`))
 	}))
 	defer server.Close()

--- a/internal/embed/provider_test.go
+++ b/internal/embed/provider_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/steipete/discrawl/internal/config"
@@ -16,12 +17,12 @@ func TestOllamaProviderEmbeds(t *testing.T) {
 	t.Parallel()
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		require.Equal(t, "/api/embed", r.URL.Path)
-		require.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "/api/embed", r.URL.Path)
+		assert.Equal(t, http.MethodPost, r.Method)
 		var req ollamaEmbedRequest
-		require.NoError(t, json.NewDecoder(r.Body).Decode(&req))
-		require.Equal(t, "nomic-embed-text", req.Model)
-		require.Equal(t, []string{"abcd", "xy"}, req.Input)
+		assert.NoError(t, json.NewDecoder(r.Body).Decode(&req))
+		assert.Equal(t, "nomic-embed-text", req.Model)
+		assert.Equal(t, []string{"abcd", "xy"}, req.Input)
 		_, _ = w.Write([]byte(`{"model":"nomic-embed-text","embeddings":[[1,2,3],[4,5,6]]}`))
 	}))
 	defer server.Close()
@@ -44,12 +45,12 @@ func TestOllamaProviderEmbeds(t *testing.T) {
 
 func TestOpenAICompatibleProviderEmbedsAndUsesAuth(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		require.Equal(t, "/embeddings", r.URL.Path)
-		require.Equal(t, "Bearer secret", r.Header.Get("Authorization"))
+		assert.Equal(t, "/embeddings", r.URL.Path)
+		assert.Equal(t, "Bearer secret", r.Header.Get("Authorization"))
 		var req openAIEmbeddingRequest
-		require.NoError(t, json.NewDecoder(r.Body).Decode(&req))
-		require.Equal(t, "local-model", req.Model)
-		require.Equal(t, []string{"one", "two"}, req.Input)
+		assert.NoError(t, json.NewDecoder(r.Body).Decode(&req))
+		assert.Equal(t, "local-model", req.Model)
+		assert.Equal(t, []string{"one", "two"}, req.Input)
 		_, _ = w.Write([]byte(`{
 			"model":"local-model",
 			"data":[
@@ -136,7 +137,7 @@ func TestCheckProviderProbesLocalProvider(t *testing.T) {
 	t.Parallel()
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		require.Equal(t, "/api/embed", r.URL.Path)
+		assert.Equal(t, "/api/embed", r.URL.Path)
 		_, _ = w.Write([]byte(`{"model":"nomic-embed-text","embeddings":[[1,2]]}`))
 	}))
 	defer server.Close()

--- a/internal/share/share.go
+++ b/internal/share/share.go
@@ -39,7 +39,6 @@ var SnapshotTables = []string{
 	"message_attachments",
 	"mention_events",
 	"sync_state",
-	"embedding_jobs",
 }
 
 type Options struct {

--- a/internal/share/share_test.go
+++ b/internal/share/share_test.go
@@ -53,6 +53,47 @@ func TestExportImportRoundTrip(t *testing.T) {
 	require.False(t, NeedsImport(ctx, dst, 15*time.Minute))
 }
 
+func TestSnapshotExcludesLocalEmbeddingState(t *testing.T) {
+	ctx := context.Background()
+	src := seedStore(t, filepath.Join(t.TempDir(), "src.db"))
+	defer func() { _ = src.Close() }()
+
+	_, err := src.DB().ExecContext(ctx, `
+		insert into embedding_jobs(message_id, state, attempts, provider, model, input_version, updated_at)
+		values ('m1', 'done', 0, 'ollama', 'nomic-embed-text', ?, ?)
+	`, store.EmbeddingInputVersion, time.Now().UTC().Format(time.RFC3339Nano))
+	require.NoError(t, err)
+	_, err = src.DB().ExecContext(ctx, `
+		insert into message_embeddings(
+			message_id, provider, model, input_version, dimensions, embedding_blob, embedded_at
+		) values ('m1', 'ollama', 'nomic-embed-text', ?, 2, ?, ?)
+	`, store.EmbeddingInputVersion, []byte{0, 0, 0, 0, 0, 0, 0, 0}, time.Now().UTC().Format(time.RFC3339Nano))
+	require.NoError(t, err)
+
+	repo := filepath.Join(t.TempDir(), "share")
+	manifest, err := Export(ctx, src, Options{RepoPath: repo, Branch: "main"})
+	require.NoError(t, err)
+	require.NotContains(t, tableNames(manifest), "embedding_jobs")
+	require.NotContains(t, tableNames(manifest), "message_embeddings")
+
+	dst, err := store.Open(ctx, filepath.Join(t.TempDir(), "dst.db"))
+	require.NoError(t, err)
+	defer func() { _ = dst.Close() }()
+	_, err = dst.DB().ExecContext(ctx, `
+		insert into embedding_jobs(message_id, state, attempts, provider, model, input_version, updated_at)
+		values ('m1', 'pending', 0, 'ollama', 'nomic-embed-text', ?, ?)
+	`, store.EmbeddingInputVersion, time.Now().UTC().Format(time.RFC3339Nano))
+	require.NoError(t, err)
+
+	_, err = Import(ctx, dst, Options{RepoPath: repo, Branch: "main"})
+	require.NoError(t, err)
+	var state string
+	require.NoError(t, dst.DB().QueryRowContext(ctx, `
+		select state from embedding_jobs where message_id = 'm1'
+	`).Scan(&state))
+	require.Equal(t, "pending", state)
+}
+
 func TestImportIfChangedSkipsSameManifest(t *testing.T) {
 	ctx := context.Background()
 	src := seedStore(t, filepath.Join(t.TempDir(), "src.db"))
@@ -305,4 +346,12 @@ func tableEntry(t *testing.T, manifest Manifest, name string) TableManifest {
 	}
 	t.Fatalf("table %s not found", name)
 	return TableManifest{}
+}
+
+func tableNames(manifest Manifest) []string {
+	names := make([]string, 0, len(manifest.Tables))
+	for _, table := range manifest.Tables {
+		names = append(names, table.Name)
+	}
+	return names
 }

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -211,7 +211,6 @@ func (s *Store) migrate(ctx context.Context) error {
 		if err := s.setSchemaVersion(ctx, storeSchemaVersion); err != nil {
 			return err
 		}
-		currentVersion = storeSchemaVersion
 	}
 	if version, err := s.schemaVersion(ctx); err != nil {
 		return err
@@ -501,6 +500,7 @@ func columnExists(ctx context.Context, tx *sql.Tx, table, column string) (bool, 
 	}
 	return false, rows.Err()
 }
+
 func (s *Store) ensureFTSRowIDs(ctx context.Context) error {
 	var version sql.NullString
 	err := s.db.QueryRowContext(ctx, `


### PR DESCRIPTION
## Summary

Keep embedding queue state out of Git-backed archive snapshots.

`embedding_jobs` describes local embedding work for one machine/provider/model setup. Since generated vectors are already local-only and are not exported, exporting job state can make subscribers inherit misleading queue metadata without having the corresponding local vectors.

## Changes

- Removes `embedding_jobs` from Git snapshot export/import tables.
- Keeps both embedding queue state and generated vectors local to each machine.
- Adds a share test covering that snapshots exclude `embedding_jobs` and `message_embeddings`.
- Adds coverage that importing a snapshot does not overwrite an existing local embedding job state.
- Updates README wording around Git-backed sharing and local embedding state.

## Testing

- `git diff --check`
- `go test ./internal/share`
- `go test ./...`

## Risks / Notes

This changes snapshot contents by no longer exporting `embedding_jobs`. Subscribers that want semantic or hybrid search with semantic recall should generate local vectors with their own configured embedding provider.
