### PR TITLE
test(syncer): cover ThreadsArchived 403 tolerance

### DIFF
--- a/internal/syncer/channel_catalog_test.go
+++ b/internal/syncer/channel_catalog_test.go
@@ -123,6 +123,52 @@ func TestSyncChannelSubsetExpandsRequestedForumThreads(t *testing.T) {
 	require.Equal(t, "t1", results[0].ChannelID)
 }
 
+func TestSyncToleratesPrivateThreadArchive403(t *testing.T) {
+	t.Parallel()
+
+	// Discord blocks private archived thread listing on community Rules Screening
+	// channels even for bots with Administrator permission. A 403 from
+	// ThreadsArchived should be logged and skipped, not abort the entire sync.
+	ctx := context.Background()
+	s, err := store.Open(ctx, filepath.Join(t.TempDir(), "discrawl.db"))
+	require.NoError(t, err)
+	defer func() { _ = s.Close() }()
+
+	require.NoError(t, s.UpsertGuild(ctx, store.GuildRecord{ID: "g1", Name: "Guild", RawJSON: `{}`}))
+
+	client := &fakeClient{
+		guilds: []*discordgo.UserGuild{{ID: "g1", Name: "Guild"}},
+		guildByID: map[string]*discordgo.Guild{
+			"g1": {ID: "g1", Name: "Guild"},
+		},
+		channels: map[string][]*discordgo.Channel{
+			"g1": {
+				{ID: "c1", GuildID: "g1", Name: "general", Type: discordgo.ChannelTypeGuildText},
+				{ID: "rules", GuildID: "g1", Name: "rules-and-info", Type: discordgo.ChannelTypeGuildText},
+			},
+		},
+		archivedErrors: map[string]error{
+			"rules": errMissingAccess(),
+		},
+		messages: map[string][]*discordgo.Message{
+			"c1": {{
+				ID:        "10",
+				GuildID:   "g1",
+				ChannelID: "c1",
+				Content:   "hello",
+				Timestamp: time.Now().UTC(),
+				Author:    &discordgo.User{ID: "u1", Username: "user"},
+			}},
+		},
+	}
+
+	svc := New(client, s, nil)
+	stats, err := svc.Sync(ctx, SyncOptions{Full: true, GuildIDs: []string{"g1"}})
+	require.NoError(t, err)
+	require.Equal(t, 1, stats.Messages)
+	require.Equal(t, 1, client.messageCalls["c1"])
+}
+
 func TestSyncSkipsInaccessibleForumThreadCatalog(t *testing.T) {
 	t.Parallel()
 

--- a/internal/syncer/syncer_test.go
+++ b/internal/syncer/syncer_test.go
@@ -25,6 +25,7 @@ type fakeClient struct {
 	guildThreadErrs  map[string]error
 	publicArchived   map[string][]*discordgo.Channel
 	privateArchive   map[string][]*discordgo.Channel
+	archivedErrors   map[string]error
 	members          map[string][]*discordgo.Member
 	messages         map[string][]*discordgo.Message
 	messageErrors    map[string]error
@@ -84,6 +85,9 @@ func (f *fakeClient) GuildThreadsActive(_ context.Context, guildID string) ([]*d
 
 func (f *fakeClient) ThreadsArchived(_ context.Context, channelID string, private bool) ([]*discordgo.Channel, error) {
 	f.threadCalls++
+	if err := f.archivedErrors[channelID]; err != nil {
+		return nil, err
+	}
 	if private {
 		return f.privateArchive[channelID], nil
 	}


### PR DESCRIPTION
## Summary

The fix for issue #30 (sync crashing on 403 from the Rules Screening channel) landed in v0.3.0 via `b8d4b1d`, but the `ThreadsArchived` error path in `appendThreadCatalog` never gained test coverage. The `appendActiveThreads` and `appendActiveThreadCatalog` fixes added tests, but `ThreadsArchived` returning a 403 was left uncovered because `fakeClient.ThreadsArchived` had no error injection support.

This PR closes that gap:

- Adds `archivedErrors map[string]error` to `fakeClient` so tests can inject errors from `ThreadsArchived`
- Wires it into `fakeClient.ThreadsArchived` before the public/private branch
- Adds `TestSyncToleratesPrivateThreadArchive403` - a regression guard for the exact scenario in #30 (a text channel returning 403 on all archived thread listing, sync continues and syncs other channels)

Closes #30 (the bug is fixed; this is the missing regression test).

## Test plan

- [ ] `go test ./internal/syncer/` passes with the new test green
- [ ] Existing tests unaffected