### PR TITLE
test(syncer): cover ThreadsArchived 403 tolerance

### DIFF
--- a/internal/syncer/channel_catalog_test.go
+++ b/internal/syncer/channel_catalog_test.go
@@ -168,11 +168,15 @@ func TestSyncToleratesArchivedThread403(t *testing.T) {
 	svc := New(client, s, nil)
 	stats, err := svc.Sync(ctx, SyncOptions{Full: true, GuildIDs: []string{"g1"}})
 	require.NoError(t, err)
-	// ThreadsArchived was invoked for "rules" (public + private = 2 calls minimum),
+	// ThreadsArchived was invoked for "rules" (public + private),
 	// confirming the error path was reached and tolerated, not bypassed.
-	require.GreaterOrEqual(t, client.threadCalls, 2)
+	require.Equal(t, 2, client.archivedCalls["rules"])
 	require.Equal(t, 1, stats.Messages)
 	require.Equal(t, 1, client.messageCalls["c1"])
+
+	cursor, err := s.GetSyncState(ctx, "channel:rules:unavailable")
+	require.NoError(t, err)
+	require.Empty(t, cursor)
 }
 
 func TestSyncSkipsInaccessibleForumThreadCatalog(t *testing.T) {

--- a/internal/syncer/channel_catalog_test.go
+++ b/internal/syncer/channel_catalog_test.go
@@ -123,6 +123,58 @@ func TestSyncChannelSubsetExpandsRequestedForumThreads(t *testing.T) {
 	require.Equal(t, "t1", results[0].ChannelID)
 }
 
+func TestSyncToleratesArchivedThread403(t *testing.T) {
+	t.Parallel()
+
+	// Discord blocks archived thread listing on community Rules Screening channels
+	// even for bots with Administrator permission. A 403 from ThreadsArchived
+	// (for either public or private) should be logged and skipped, not abort the
+	// entire sync. The archived loop uses continue, so no unavailable marker is
+	// written for the channel — only active-thread 403s go through
+	// skipUnavailableChannelByID.
+	ctx := context.Background()
+	s, err := store.Open(ctx, filepath.Join(t.TempDir(), "discrawl.db"))
+	require.NoError(t, err)
+	defer func() { _ = s.Close() }()
+
+	require.NoError(t, s.UpsertGuild(ctx, store.GuildRecord{ID: "g1", Name: "Guild", RawJSON: `{}`}))
+
+	client := &fakeClient{
+		guilds: []*discordgo.UserGuild{{ID: "g1", Name: "Guild"}},
+		guildByID: map[string]*discordgo.Guild{
+			"g1": {ID: "g1", Name: "Guild"},
+		},
+		channels: map[string][]*discordgo.Channel{
+			"g1": {
+				{ID: "c1", GuildID: "g1", Name: "general", Type: discordgo.ChannelTypeGuildText},
+				{ID: "rules", GuildID: "g1", Name: "rules-and-info", Type: discordgo.ChannelTypeGuildText},
+			},
+		},
+		archivedErrors: map[string]error{
+			"rules": errMissingAccess(),
+		},
+		messages: map[string][]*discordgo.Message{
+			"c1": {{
+				ID:        "10",
+				GuildID:   "g1",
+				ChannelID: "c1",
+				Content:   "hello",
+				Timestamp: time.Now().UTC(),
+				Author:    &discordgo.User{ID: "u1", Username: "user"},
+			}},
+		},
+	}
+
+	svc := New(client, s, nil)
+	stats, err := svc.Sync(ctx, SyncOptions{Full: true, GuildIDs: []string{"g1"}})
+	require.NoError(t, err)
+	// ThreadsArchived was invoked for "rules" (public + private = 2 calls minimum),
+	// confirming the error path was reached and tolerated, not bypassed.
+	require.GreaterOrEqual(t, client.threadCalls, 2)
+	require.Equal(t, 1, stats.Messages)
+	require.Equal(t, 1, client.messageCalls["c1"])
+}
+
 func TestSyncSkipsInaccessibleForumThreadCatalog(t *testing.T) {
 	t.Parallel()
 

--- a/internal/syncer/syncer_test.go
+++ b/internal/syncer/syncer_test.go
@@ -25,6 +25,7 @@ type fakeClient struct {
 	guildThreadErrs  map[string]error
 	publicArchived   map[string][]*discordgo.Channel
 	privateArchive   map[string][]*discordgo.Channel
+	archivedErrors   map[string]error
 	members          map[string][]*discordgo.Member
 	messages         map[string][]*discordgo.Message
 	messageErrors    map[string]error
@@ -84,6 +85,9 @@ func (f *fakeClient) GuildThreadsActive(_ context.Context, guildID string) ([]*d
 
 func (f *fakeClient) ThreadsArchived(_ context.Context, channelID string, private bool) ([]*discordgo.Channel, error) {
 	f.threadCalls++
+	if err := f.archivedErrors[channelID]; err != nil {
+		return nil, err
+	}
 	if private {
 		return f.privateArchive[channelID], nil
 	}

--- a/internal/syncer/syncer_test.go
+++ b/internal/syncer/syncer_test.go
@@ -26,6 +26,7 @@ type fakeClient struct {
 	publicArchived   map[string][]*discordgo.Channel
 	privateArchive   map[string][]*discordgo.Channel
 	archivedErrors   map[string]error
+	archivedCalls    map[string]int
 	members          map[string][]*discordgo.Member
 	messages         map[string][]*discordgo.Message
 	messageErrors    map[string]error
@@ -85,6 +86,10 @@ func (f *fakeClient) GuildThreadsActive(_ context.Context, guildID string) ([]*d
 
 func (f *fakeClient) ThreadsArchived(_ context.Context, channelID string, private bool) ([]*discordgo.Channel, error) {
 	f.threadCalls++
+	if f.archivedCalls == nil {
+		f.archivedCalls = make(map[string]int)
+	}
+	f.archivedCalls[channelID]++
 	if err := f.archivedErrors[channelID]; err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Summary

The fix for issue #30 landed in v0.3.0 (b8d4b1d), but the ThreadsArchived
error path in appendThreadCatalog had no test coverage. The appendActiveThreads
and appendActiveThreadCatalog fixes both got tests, but fakeClient.ThreadsArchived
could never return an error, so the `continue` that keeps the sync alive was
untested.

- Adds `archivedErrors map[string]error` to fakeClient so tests can inject
  errors from ThreadsArchived
- Wires it in before the public/private branch so a single entry blocks both
  calls (matching how Discord actually behaves on Rules Screening channels)
- Adds TestSyncToleratesArchivedThread403: a regression guard for the exact
  scenario in #30. Asserts the sync returns no error, that ThreadsArchived
  was actually invoked for the failing channel (threadCalls >= 2, confirming
  the error path was reached and tolerated rather than bypassed), and that the
  accessible channel's message was synced.

Closes #30 (the bug is fixed; this adds the missing regression test).

## Test plan

- [x] `go test ./internal/syncer/ -run TestSyncToleratesArchivedThread403` passes
- [x] Full `go test ./internal/syncer/` passes, no regressions