### PR TITLE
feat(ci): post daily field notes to Discord

### DIFF
--- a/.github/workflows/discord-backup-report.yml
+++ b/.github/workflows/discord-backup-report.yml
@@ -58,6 +58,7 @@ jobs:
           DB: ${{ github.workspace }}/.discrawl-ci/discrawl.db
           BACKUP_REPO: ${{ runner.temp }}/discord-backup
           OPENCLAW_STATE_DIR: ${{ runner.temp }}/openclaw
+          FIELD_NOTES_OUT: ${{ runner.temp }}/field-notes.md
           DISCORD_FIELD_NOTES_GITHUB_REPO: openclaw/openclaw
         run: |
           if [ -z "${DISCORD_BACKUP_TOKEN:-}" ]; then
@@ -87,7 +88,7 @@ jobs:
             jq '.agents.defaults.model = "openai/gpt-5.2" | .agents.defaults.timeoutSeconds = 300 | .agents.defaults.llm.idleTimeoutSeconds = 240' \
               "$OPENCLAW_STATE_DIR/openclaw.json" > "$tmp_config"
             mv "$tmp_config" "$OPENCLAW_STATE_DIR/openclaw.json"
-            scripts/discord-backup-field-notes.sh "$CONFIG" "$BACKUP_REPO"
+            scripts/discord-backup-field-notes.sh "$CONFIG" "$BACKUP_REPO" "$FIELD_NOTES_OUT"
           else
             echo "OPENAI_API_KEY not configured; skipping OpenClaw field notes"
           fi
@@ -99,6 +100,31 @@ jobs:
           git -C "$BACKUP_REPO" commit -m "docs: update discord activity report"
           git -C "$BACKUP_REPO" pull --rebase --autostash origin main
           git -C "$BACKUP_REPO" push
+
+      - name: Post field notes to Discord
+        env:
+          DISCORD_BOT_TOKEN: ${{ secrets.DISCORD_BOT_TOKEN }}
+          DISCORD_FIELD_NOTES_CHANNEL_ID: ${{ vars.DISCORD_FIELD_NOTES_CHANNEL_ID }}
+          FIELD_NOTES_OUT: ${{ runner.temp }}/field-notes.md
+        run: |
+          if [ -z "${DISCORD_FIELD_NOTES_CHANNEL_ID:-}" ]; then
+            echo "DISCORD_FIELD_NOTES_CHANNEL_ID not configured; skipping Discord post"
+            exit 0
+          fi
+          if [ ! -s "$FIELD_NOTES_OUT" ]; then
+            echo "no field notes written at $FIELD_NOTES_OUT; skipping Discord post"
+            exit 0
+          fi
+          notes=$(cat "$FIELD_NOTES_OUT")
+          if [ "${#notes}" -gt 4096 ]; then
+            notes="${notes:0:4000}…(full notes in backup repo README)"
+          fi
+          jq -n --arg desc "$notes" '{embeds: [{description: $desc}]}' \
+            | curl -fsS -X POST \
+                -H "Authorization: Bot $DISCORD_BOT_TOKEN" \
+                -H "Content-Type: application/json" \
+                --data @- \
+                "https://discord.com/api/v10/channels/$DISCORD_FIELD_NOTES_CHANNEL_ID/messages"
 
       - name: Save Discord DB cache
         uses: actions/cache/save@v5.0.5

--- a/scripts/discord-backup-field-notes.sh
+++ b/scripts/discord-backup-field-notes.sh
@@ -1,13 +1,14 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-if [ "$#" -ne 2 ]; then
-  echo "usage: $0 <discrawl-config> <backup-repo>" >&2
+if [ "$#" -ne 3 ]; then
+  echo "usage: $0 <discrawl-config> <backup-repo> <output-file>" >&2
   exit 2
 fi
 
 CONFIG=$1
 BACKUP_REPO=$2
+OUTPUT_FILE=$3
 OPENCLAW_BIN=${OPENCLAW_BIN:-openclaw}
 OPENCLAW_TIMEOUT=${OPENCLAW_TIMEOUT:-300}
 OPENCLAW_THINKING=${OPENCLAW_THINKING:-low}
@@ -371,6 +372,8 @@ if [ ! -s "$TMP_DIR/field-notes.md" ]; then
   echo "openclaw did not return field notes text; using deterministic fallback" >&2
   write_fallback_notes >"$TMP_DIR/field-notes.md"
 fi
+
+cp "$TMP_DIR/field-notes.md" "$OUTPUT_FILE"
 
 awk -v start="$START_MARKER" -v end="$END_MARKER" -v notes="$TMP_DIR/field-notes.md" '
   BEGIN {


### PR DESCRIPTION
## Summary
- New workflow step in `discord-backup-report.yml` that posts the generated field notes to a Discord channel as an embed, using the existing `DISCORD_BOT_TOKEN` secret.
- Gated on a new `DISCORD_FIELD_NOTES_CHANNEL_ID` repo variable — the step logs and exits 0 when unset, so this is safe to merge before the channel is configured.
- `scripts/discord-backup-field-notes.sh` now takes a third positional arg `<output-file>` and copies `field-notes.md` there before `$TMP_DIR` is cleaned up. This gives the workflow a stable handle on the exact markdown that lands in the backup repo README.

## How posting works
- After the existing step updates `openclaw/discord-backup/README.md` and pushes, the new step reads `$FIELD_NOTES_OUT`, truncates at 4000 chars if needed (Discord embed description cap is 4096), and POSTs to `/api/v10/channels/{id}/messages` with `Authorization: Bot $DISCORD_BOT_TOKEN`.
- No new secrets — reuses the bot token already in the workflow env.

## To activate after merge
1. In Discord, right-click the target channel → Copy Channel ID.
2. Repo → Settings → Secrets and variables → Actions → Variables → New repository variable: `DISCORD_FIELD_NOTES_CHANNEL_ID` = that snowflake.
3. Confirm the bot has `Send Messages` on that channel.

## Test plan
- [ ] Create a dummy guild + channel; invite the bot with Send Messages.
- [ ] Local smoke test: run the new curl/jq block against a sample `field-notes.md` pointed at the dummy channel — confirm the embed renders cleanly, headers survive, length cap trims correctly.
- [ ] Branch `workflow_dispatch` run with `DISCORD_FIELD_NOTES_CHANNEL_ID` set to the dummy channel — confirm the existing README update still works AND the dummy channel receives the post.
- [ ] Flip the variable to the production channel; verify the next 07:17 UTC scheduled run posts successfully.
- [ ] Verify the no-op path: unset the variable, rerun, confirm the step logs "not configured; skipping" and the rest of the workflow is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)