### PR TITLE
Use platform-native data paths by default

### DIFF
--- a/.agents/skills/discrawl/SKILL.md
+++ b/.agents/skills/discrawl/SKILL.md
@@ -11,14 +11,18 @@ for current external context.
 
 ## Sources
 
-- DB: `~/.discrawl/discrawl.db`
-- Config: `~/.discrawl/config.toml`
-- Cache: `~/.discrawl/cache`
-- Logs: `~/.discrawl/logs`
-- Git share repo: `~/.discrawl/share`
+- DB: platform-native XDG data dir, usually
+  `${XDG_DATA_HOME:-~/.local/share}/discrawl/discrawl.db` on Linux or
+  `~/Library/Application Support/discrawl/discrawl.db` on macOS
+- Config: platform-native XDG config dir, with legacy fallback to
+  `~/.discrawl/config.toml`
+- Cache: platform-native XDG cache dir
+- Logs: platform-native XDG state dir
+- Git share repo: platform-native XDG data dir
 - Repo: `openclaw/discrawl`; use `~/GIT/_Perso/discrawl` only after verifying
   its remote targets `openclaw/discrawl`, otherwise use a fresh checkout
-- Preferred CLI: `discrawl`; fallback to `go run ./cmd/discrawl` from the repo if the installed binary is stale
+- Preferred CLI: `discrawl`; fallback to `go run ./cmd/discrawl` from the repo
+  if the installed binary is stale
 
 ## Freshness
 
@@ -31,7 +35,16 @@ discrawl status --json
 For precise freshness from the default database:
 
 ```bash
-sqlite3 ~/.discrawl/discrawl.db \
+# Discrawl uses macOS ~/Library defaults unless XDG_DATA_HOME is explicitly set.
+case "$(uname -s)" in
+  Darwin)
+    db="$HOME/Library/Application Support/discrawl/discrawl.db"
+    ;;
+  *)
+    db="${XDG_DATA_HOME:-$HOME/.local/share}/discrawl/discrawl.db"
+    ;;
+esac
+sqlite3 "$db" \
   "select coalesce(max(updated_at),'') from sync_state where scope like 'channel:%';"
 ```
 

--- a/README.md
+++ b/README.md
@@ -98,12 +98,21 @@ cmdkey /generic:discrawl:discord_bot_token /user:discord_bot_token /pass:%DISCOR
 
 Set `discord.token_source = "keyring"` if you want to require keyring lookup instead of env-first fallback.
 
-Default runtime paths:
+Default runtime paths follow the OS convention instead of writing a new top-level directory in
+your home folder. Linux uses the XDG Base Directory variables. macOS uses `~/Library` folders,
+unless you set XDG variables yourself.
 
-- config: `~/.discrawl/config.toml`
-- database: `~/.discrawl/discrawl.db`
-- cache: `~/.discrawl/cache/`
-- logs: `~/.discrawl/logs/`
+- Linux config: `${XDG_CONFIG_HOME:-~/.config}/discrawl/config.toml`
+- Linux database/share: `${XDG_DATA_HOME:-~/.local/share}/discrawl/`
+- Linux cache: `${XDG_CACHE_HOME:-~/.cache}/discrawl/`
+- Linux logs: `${XDG_STATE_HOME:-~/.local/state}/discrawl/logs/`
+- macOS config/database/share/logs: `~/Library/Application Support/discrawl/`
+- macOS cache: `~/Library/Caches/discrawl/`
+
+Existing installs that already have `~/.discrawl/config.toml` continue to load that config when
+the new default config file does not exist. This is true even if XDG variables are set globally by
+your desktop. To migrate deliberately, copy or create the new config file first, or point Discrawl
+at it with `--config` / `DISCRAWL_CONFIG`.
 
 ## Install
 
@@ -149,8 +158,10 @@ discrawl search "launch checklist"
 discrawl messages --channel general --hours 24
 ```
 
-`init` discovers accessible guilds and writes `~/.discrawl/config.toml`. If exactly one guild is available, that guild becomes the default automatically.
-`subscribe` writes a token-free config, imports the private Git snapshot, and read commands auto-refresh when the local snapshot is older than `15m`.
+`init` discovers accessible guilds and writes the default XDG config file. If
+exactly one guild is available, that guild becomes the default automatically.
+`subscribe` writes a token-free config, imports the private Git snapshot, and
+read commands auto-refresh when the local snapshot is older than `15m`.
 
 `doctor` is the fastest sanity check:
 
@@ -578,9 +589,9 @@ Typical config shape:
 version = 1
 default_guild_id = ""
 guild_ids = []
-db_path = "~/.discrawl/discrawl.db"
-cache_dir = "~/.discrawl/cache"
-log_dir = "~/.discrawl/logs"
+db_path = "~/.local/share/discrawl/discrawl.db" # macOS: "~/Library/Application Support/discrawl/discrawl.db"
+cache_dir = "~/.cache/discrawl" # macOS: "~/Library/Caches/discrawl"
+log_dir = "~/.local/state/discrawl/logs" # macOS: "~/Library/Application Support/discrawl/logs"
 
 [discord]
 token_source = "env" # use "none" for Git-only read access
@@ -612,7 +623,7 @@ batch_size = 64
 
 [share]
 remote = ""
-repo_path = "~/.discrawl/share"
+repo_path = "~/.local/share/discrawl/share" # macOS: "~/Library/Application Support/discrawl/share"
 branch = "main"
 auto_update = true
 stale_after = "15m"

--- a/SPEC.md
+++ b/SPEC.md
@@ -47,10 +47,15 @@ Out of scope for V1:
 These are settled unless the user explicitly changes them:
 
 - config format: `TOML`
-- config location: `~/.discrawl/config.toml`
-- DB location: `~/.discrawl/discrawl.db`
-- cache dir: `~/.discrawl/cache/`
-- log dir: `~/.discrawl/logs/`
+- config location: platform-native XDG config dir, e.g.
+  `${XDG_CONFIG_HOME:-~/.config}/discrawl/config.toml` on Linux
+- DB location: platform-native XDG data dir, e.g.
+  `${XDG_DATA_HOME:-~/.local/share}/discrawl/discrawl.db` on Linux
+- cache dir: platform-native XDG cache dir, e.g. `${XDG_CACHE_HOME:-~/.cache}/discrawl/`
+- log dir: platform-native XDG state dir, e.g.
+  `${XDG_STATE_HOME:-~/.local/state}/discrawl/logs/`
+- legacy installs with `~/.discrawl/config.toml` continue to load that config when the new default
+  config file does not exist, even if XDG env vars are present
 - token source: `DISCORD_BOT_TOKEN` or configured env var, then optional OS keyring fallback
 - guild model: one guild in CLI UX, multi-guild-ready schema
 - search: hybrid, with FTS first and embeddings optional
@@ -74,8 +79,8 @@ An agent should assume:
 
 ### Key file paths
 
-- `~/.discrawl/config.toml`
-- `~/.discrawl/discrawl.db`
+- platform-native Discrawl config file
+- platform-native Discrawl SQLite database
 - `~/.profile`
 
 ### OpenAI embeddings key
@@ -406,7 +411,7 @@ discrawl [global flags] <command> [args]
 
 Purpose:
 
-- create `~/.discrawl/config.toml`
+- create the platform-native Discrawl config file
 - discover accessible Discord guilds
 - persist guild id and DB path
 
@@ -551,16 +556,16 @@ Format:
 
 Location:
 
-- `~/.discrawl/config.toml`
+- platform-native Discrawl config file
 
 Suggested shape:
 
 ```toml
 version = 1
 guild_id = "1456350064065904867"
-db_path = "~/.discrawl/discrawl.db"
-cache_dir = "~/.discrawl/cache"
-log_dir = "~/.discrawl/logs"
+db_path = "~/.local/share/discrawl/discrawl.db"
+cache_dir = "~/.cache/discrawl"
+log_dir = "~/.local/state/discrawl/logs"
 
 [discord]
 token_source = "env"

--- a/docs/commands/init.md
+++ b/docs/commands/init.md
@@ -13,7 +13,8 @@ discrawl init --with-embeddings
 
 ## What it does
 
-- writes `~/.discrawl/config.toml` (or whatever `--config` / `DISCRAWL_CONFIG` points to)
+- writes the default XDG config file, or whatever `--config` /
+  `DISCRAWL_CONFIG` points to
 - discovers guilds the configured bot can access
 - if exactly one guild is available, sets it as `default_guild_id` automatically
 - creates the SQLite database at `db_path`

--- a/docs/commands/search.md
+++ b/docs/commands/search.md
@@ -38,7 +38,7 @@ User query terms are parameterized and quoted before `MATCH`, so tokens like `AN
 
 ## Semantic prerequisites
 
-- `[search.embeddings]` configured in `~/.discrawl/config.toml`
+- `[search.embeddings]` configured in the Discrawl config file
 - local `message_embeddings` rows for the configured provider, model, and input version
 - input version is currently `message_normalized_v1`
 

--- a/docs/commands/subscribe.md
+++ b/docs/commands/subscribe.md
@@ -1,12 +1,15 @@
 # `subscribe`
 
-Subscribes to a Git-backed snapshot repo. The Git-only setup path - no Discord bot token required.
+Subscribes to a Git-backed snapshot repo. The Git-only setup path needs no
+Discord bot token.
 
 ## Usage
 
 ```bash
 discrawl subscribe https://github.com/example/discord-archive.git
-discrawl subscribe --repo ~/.discrawl/share https://github.com/example/discord-archive.git
+discrawl subscribe \
+  --repo ~/.local/share/discrawl/share \
+  https://github.com/example/discord-archive.git
 discrawl subscribe --branch main https://github.com/example/discord-archive.git
 discrawl subscribe --stale-after 15m https://github.com/example/discord-archive.git
 discrawl subscribe --no-auto-update https://github.com/example/discord-archive.git

--- a/docs/commands/update.md
+++ b/docs/commands/update.md
@@ -8,7 +8,9 @@ Routine imports are delta-planned from crawlkit shard fingerprints, with a Git-o
 
 ```bash
 discrawl update
-discrawl update --repo ~/.discrawl/share --remote https://github.com/example/discord-archive.git
+discrawl update \
+  --repo ~/.local/share/discrawl/share \
+  --remote https://github.com/example/discord-archive.git
 discrawl update --with-embeddings
 ```
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,6 +1,41 @@
 # Configuration
 
-`discrawl init` writes a complete config so most users do not hand-edit anything initially. This page documents the full shape and override rules for when you do.
+`discrawl init` writes a complete config so most users do not hand-edit anything initially. This
+page documents the full shape and override rules for when you do.
+
+## Default paths
+
+Discrawl follows the normal per-OS storage convention instead of writing a new top-level directory
+in your home folder.
+
+On Linux and other Unix desktops, Discrawl uses XDG Base Directory paths. In practice, that means:
+
+- config: `${XDG_CONFIG_HOME:-~/.config}/discrawl/config.toml`
+- database: `${XDG_DATA_HOME:-~/.local/share}/discrawl/discrawl.db`
+- Git share repo: `${XDG_DATA_HOME:-~/.local/share}/discrawl/share`
+- cache: `${XDG_CACHE_HOME:-~/.cache}/discrawl/`
+- logs: `${XDG_STATE_HOME:-~/.local/state}/discrawl/logs/`
+
+On macOS, Discrawl uses the platform's `~/Library` locations:
+
+- config: `~/Library/Application Support/discrawl/config.toml`
+- database: `~/Library/Application Support/discrawl/discrawl.db`
+- Git share repo: `~/Library/Application Support/discrawl/share`
+- cache: `~/Library/Caches/discrawl/`
+- logs: `~/Library/Application Support/discrawl/logs/`
+
+If you set `XDG_CONFIG_HOME`, `XDG_DATA_HOME`, `XDG_CACHE_HOME`, or `XDG_STATE_HOME`, those
+variables choose the new default locations on any OS.
+
+Existing installs are preserved before those new locations take over. If `~/.discrawl/config.toml`
+exists and the new default config file does not, Discrawl keeps loading the legacy config. Missing
+runtime fields also keep using existing legacy files or directories under `~/.discrawl` when the
+new location does not exist yet. This avoids breaking users whose desktop already sets XDG
+variables globally.
+
+To migrate deliberately, copy or create the new config file first, or point Discrawl at it with
+`--config` / `DISCRAWL_CONFIG`. Runtime paths switch one-by-one: once the new database, cache,
+logs, or share path exists, that path wins over the legacy `~/.discrawl` counterpart.
 
 ## File layout
 
@@ -8,9 +43,9 @@
 version = 1
 default_guild_id = ""
 guild_ids = []
-db_path = "~/.discrawl/discrawl.db"
-cache_dir = "~/.discrawl/cache"
-log_dir = "~/.discrawl/logs"
+db_path = "~/.local/share/discrawl/discrawl.db" # macOS: "~/Library/Application Support/discrawl/discrawl.db"
+cache_dir = "~/.cache/discrawl" # macOS: "~/Library/Caches/discrawl"
+log_dir = "~/.local/state/discrawl/logs" # macOS: "~/Library/Application Support/discrawl/logs"
 
 [discord]
 token_source = "env" # use "none" for Git-only read access
@@ -42,7 +77,7 @@ batch_size = 64
 
 [share]
 remote = ""
-repo_path = "~/.discrawl/share"
+repo_path = "~/.local/share/discrawl/share" # macOS: "~/Library/Application Support/discrawl/share"
 branch = "main"
 auto_update = true
 stale_after = "15m"

--- a/docs/guides/data-storage.md
+++ b/docs/guides/data-storage.md
@@ -1,6 +1,12 @@
 # Data layout
 
-Everything lives in one local SQLite file. Default path: `~/.discrawl/discrawl.db`.
+Everything lives in one local SQLite file. By default, Discrawl stores it at
+`${XDG_DATA_HOME:-~/.local/share}/discrawl/discrawl.db` on Linux and
+`~/Library/Application Support/discrawl/discrawl.db` on macOS. Setting `XDG_DATA_HOME` overrides
+the new default base directory on any OS.
+
+Existing `~/.discrawl/discrawl.db` installs continue to use that database until the new default
+database file exists. This keeps old installs working on systems that already set XDG variables.
 
 ## What is stored
 

--- a/docs/guides/search-modes.md
+++ b/docs/guides/search-modes.md
@@ -17,7 +17,7 @@
 
 ## Semantic and hybrid prerequisites
 
-- `[search.embeddings]` configured in `~/.discrawl/config.toml`
+- `[search.embeddings]` configured in the Discrawl config file
 - local `message_embeddings` rows for the configured provider, model, and input version
 - input version is currently `message_normalized_v1`, so vectors are tied to normalized message text rather than raw Discord payloads
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -36,9 +36,11 @@ discrawl search "panic: nil pointer"
 discrawl tail
 ```
 
-`init` discovers accessible guilds and writes `~/.discrawl/config.toml`. If exactly one guild is available, it becomes the default automatically.
+`init` discovers accessible guilds and writes the default XDG config file. If
+exactly one guild is available, it becomes the default automatically.
 
-`doctor` verifies the config loads, the token resolves, the bot can reach the Gateway, and the local DB and FTS index are wired up.
+`doctor` verifies the config loads, the token resolves, the bot can reach the
+Gateway, and the local DB and FTS index are wired up.
 
 ## Quick start (Git-only reader)
 
@@ -50,14 +52,26 @@ discrawl search "launch checklist"
 discrawl messages --channel general --hours 24
 ```
 
-`subscribe` writes a token-free config (`discord.token_source = "none"`) and imports the snapshot. Read commands auto-refresh when the local snapshot is older than `15m`.
+`subscribe` writes a token-free config (`discord.token_source = "none"`) and
+imports the snapshot. Read commands auto-refresh when the local snapshot is
+older than `15m`.
 
 ## Default runtime paths
 
-- config: `~/.discrawl/config.toml`
-- database: `~/.discrawl/discrawl.db`
-- cache: `~/.discrawl/cache/`
-- logs: `~/.discrawl/logs/`
+Discrawl follows the OS storage convention instead of writing a new top-level directory in your
+home folder. Linux uses XDG Base Directory paths. macOS uses `~/Library` folders unless you set XDG
+variables yourself.
+
+- Linux config: `${XDG_CONFIG_HOME:-~/.config}/discrawl/config.toml`
+- Linux database/share: `${XDG_DATA_HOME:-~/.local/share}/discrawl/`
+- Linux cache: `${XDG_CACHE_HOME:-~/.cache}/discrawl/`
+- Linux logs: `${XDG_STATE_HOME:-~/.local/state}/discrawl/logs/`
+- macOS config/database/logs/share: `~/Library/Application Support/discrawl/`
+- macOS cache: `~/Library/Caches/discrawl/`
+
+Existing `~/.discrawl/config.toml` installs continue to load when the new default config file does
+not exist, even if XDG variables are set globally by your desktop. To migrate deliberately, copy or
+create the new config file first, or point Discrawl at it with `--config` / `DISCRAWL_CONFIG`.
 
 ## Next steps
 

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/openclaw/discrawl
 go 1.26.3
 
 require (
+	github.com/adrg/xdg v0.5.3
 	github.com/alecthomas/kong v1.15.0
 	github.com/bwmarrin/discordgo v0.29.0
 	github.com/gorilla/websocket v1.5.3

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/adrg/xdg v0.5.3 h1:xRnxJXne7+oWDatRhR1JLnvuccuIeCoBu2rtuLqQB78=
+github.com/adrg/xdg v0.5.3/go.mod h1:nlTsY+NNiCBGCK2tpm09vRqfVzrc2fLmXGpBLF0zlTQ=
 github.com/alecthomas/assert/v2 v2.11.0 h1:2Q9r3ki8+JYXvGsDyBXwH3LcJ+WK5D0gc5E8vS6K3D0=
 github.com/alecthomas/assert/v2 v2.11.0/go.mod h1:Bze95FyfUr7x34QZrjL+XP+0qgp/zg8yS+TtBj1WA3k=
 github.com/alecthomas/kong v1.15.0 h1:BVJstKbpO73zKpmIu+m/aLRrNmWwxXPIGTNin9VmLVI=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -7,8 +7,10 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"sync"
 	"time"
 
+	"github.com/adrg/xdg"
 	crawlconfig "github.com/openclaw/crawlkit/config"
 )
 
@@ -18,6 +20,8 @@ const (
 	DefaultTokenKeyringService = "discrawl"
 	DefaultTokenKeyringAccount = "discord_bot_token"
 )
+
+var xdgMu sync.Mutex
 
 type Config struct {
 	Version        int           `toml:"version"`
@@ -85,20 +89,9 @@ type TokenResolution struct {
 	Path   string
 }
 
-var appConfig = crawlconfig.App{Name: "discrawl", ConfigEnv: DefaultConfigEnv, BaseDir: "~/.discrawl", LegacyBaseDir: "~/.discrawl"}
-
 func Default() Config {
 	home, _ := os.UserHomeDir()
-	paths, err := appConfig.DefaultPaths()
-	if err != nil {
-		base := filepath.Join(home, ".discrawl")
-		paths = crawlconfig.Paths{
-			DBPath:   filepath.Join(base, "discrawl.db"),
-			CacheDir: filepath.Join(base, "cache"),
-			LogDir:   filepath.Join(base, "logs"),
-			ShareDir: filepath.Join(base, "share"),
-		}
-	}
+	paths := defaultPaths(home)
 	return Config{
 		Version:        1,
 		DBPath:         paths.DBPath,
@@ -156,12 +149,22 @@ func defaultSyncConcurrency() int {
 }
 
 func ResolvePath(flagPath string) string {
-	path, err := appConfig.ResolveConfigPath(flagPath)
-	if err != nil {
-		home, _ := os.UserHomeDir()
-		return filepath.Join(home, ".discrawl", "config.toml")
+	if strings.TrimSpace(flagPath) != "" {
+		return crawlconfig.ExpandHome(flagPath)
 	}
-	return path
+	if envPath := strings.TrimSpace(os.Getenv(DefaultConfigEnv)); envPath != "" {
+		return crawlconfig.ExpandHome(envPath)
+	}
+	home, _ := os.UserHomeDir()
+	paths := xdgPaths()
+	legacy := legacyPaths(home)
+	// Preserve early ~/.discrawl installs even when XDG env vars are present:
+	// many desktops set them globally, and that should not silently strand an
+	// existing config. DISCRAWL_CONFIG/--config remain the explicit opt-out.
+	if pathExists(legacy.ConfigPath) && !pathExists(paths.ConfigPath) {
+		return legacy.ConfigPath
+	}
+	return paths.ConfigPath
 }
 
 func Load(path string) (Config, error) {
@@ -316,6 +319,62 @@ func defaultDiscordDesktopPath(home string) string {
 func homeDir() string {
 	home, _ := os.UserHomeDir()
 	return home
+}
+
+func defaultPaths(home string) crawlconfig.Paths {
+	// New installs use platform-native locations from adrg/xdg. Early Discrawl
+	// installs wrote every runtime file under ~/.discrawl, so each runtime path
+	// falls back to its legacy counterpart only when that legacy file or
+	// directory already exists and the new location does not. This intentionally
+	// applies even when XDG env vars are set, because those env vars are often
+	// part of the ambient desktop environment rather than a migration request.
+	paths := xdgPaths()
+	legacy := legacyPaths(home)
+	if pathExists(legacy.DBPath) && !pathExists(paths.DBPath) {
+		paths.DBPath = legacy.DBPath
+	}
+	if pathExists(legacy.CacheDir) && !pathExists(paths.CacheDir) {
+		paths.CacheDir = legacy.CacheDir
+	}
+	if pathExists(legacy.LogDir) && !pathExists(paths.LogDir) {
+		paths.LogDir = legacy.LogDir
+	}
+	if pathExists(legacy.ShareDir) && !pathExists(paths.ShareDir) {
+		paths.ShareDir = legacy.ShareDir
+	}
+	return paths
+}
+
+func xdgPaths() crawlconfig.Paths {
+	xdgMu.Lock()
+	defer xdgMu.Unlock()
+
+	xdg.Reload()
+	return crawlconfig.Paths{
+		BaseDir:    filepath.Join(xdg.DataHome, "discrawl"),
+		ConfigPath: filepath.Join(xdg.ConfigHome, "discrawl", "config.toml"),
+		DBPath:     filepath.Join(xdg.DataHome, "discrawl", "discrawl.db"),
+		CacheDir:   filepath.Join(xdg.CacheHome, "discrawl"),
+		LogDir:     filepath.Join(xdg.StateHome, "discrawl", "logs"),
+		ShareDir:   filepath.Join(xdg.DataHome, "discrawl", "share"),
+	}
+}
+
+func legacyPaths(home string) crawlconfig.Paths {
+	base := filepath.Join(home, ".discrawl")
+	return crawlconfig.Paths{
+		BaseDir:    base,
+		ConfigPath: filepath.Join(base, "config.toml"),
+		DBPath:     filepath.Join(base, "discrawl.db"),
+		CacheDir:   filepath.Join(base, "cache"),
+		LogDir:     filepath.Join(base, "logs"),
+		ShareDir:   filepath.Join(base, "share"),
+	}
+}
+
+func pathExists(path string) bool {
+	_, err := os.Stat(path)
+	return err == nil
 }
 
 func (c Config) EffectiveDefaultGuildID() string {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -41,6 +41,176 @@ func TestNormalizeFillsDefaults(t *testing.T) {
 	require.Equal(t, "2m", cfg.Search.Embeddings.RequestTimeout)
 }
 
+func TestDefaultPathsUseXDGDirs(t *testing.T) {
+	// Explicit XDG env vars define the candidate new-install paths on every
+	// platform, including macOS.
+	home := t.TempDir()
+	configHome := filepath.Join(home, "xdg-config")
+	dataHome := filepath.Join(home, "xdg-data")
+	cacheHome := filepath.Join(home, "xdg-cache")
+	stateHome := filepath.Join(home, "xdg-state")
+	setTestHome(t, home)
+	t.Setenv("XDG_CONFIG_HOME", configHome)
+	t.Setenv("XDG_DATA_HOME", dataHome)
+	t.Setenv("XDG_CACHE_HOME", cacheHome)
+	t.Setenv("XDG_STATE_HOME", stateHome)
+
+	cfg := Default()
+	require.Equal(t, filepath.Join(dataHome, "discrawl", "discrawl.db"), cfg.DBPath)
+	require.Equal(t, filepath.Join(cacheHome, "discrawl"), cfg.CacheDir)
+	require.Equal(t, filepath.Join(stateHome, "discrawl", "logs"), cfg.LogDir)
+	require.Equal(t, filepath.Join(dataHome, "discrawl", "share"), cfg.Share.RepoPath)
+	require.Equal(t, filepath.Join(configHome, "discrawl", "config.toml"), ResolvePath(""))
+}
+
+func TestDefaultPathsUseXDGFallbacks(t *testing.T) {
+	// With no XDG env vars, use the adrg/xdg platform defaults.
+	home := t.TempDir()
+	configHome, dataHome, cacheHome, stateHome := defaultXDGTestDirs(home)
+	setTestHome(t, home)
+	clearXDGEnv(t)
+
+	cfg := Default()
+	require.Equal(t, filepath.Join(dataHome, "discrawl", "discrawl.db"), cfg.DBPath)
+	require.Equal(t, filepath.Join(cacheHome, "discrawl"), cfg.CacheDir)
+	require.Equal(t, filepath.Join(stateHome, "discrawl", "logs"), cfg.LogDir)
+	require.Equal(t, filepath.Join(dataHome, "discrawl", "share"), cfg.Share.RepoPath)
+	require.Equal(t, filepath.Join(configHome, "discrawl", "config.toml"), ResolvePath(""))
+}
+
+func TestDefaultPathsIgnoreRelativeXDGDirs(t *testing.T) {
+	// Relative XDG env values are invalid per the spec and should fall back.
+	home := t.TempDir()
+	configHome, dataHome, cacheHome, stateHome := defaultXDGTestDirs(home)
+	setTestHome(t, home)
+	t.Setenv("XDG_CONFIG_HOME", "relative-config")
+	t.Setenv("XDG_DATA_HOME", "relative-data")
+	t.Setenv("XDG_CACHE_HOME", "relative-cache")
+	t.Setenv("XDG_STATE_HOME", "relative-state")
+
+	cfg := Default()
+	require.Equal(t, filepath.Join(dataHome, "discrawl", "discrawl.db"), cfg.DBPath)
+	require.Equal(t, filepath.Join(cacheHome, "discrawl"), cfg.CacheDir)
+	require.Equal(t, filepath.Join(stateHome, "discrawl", "logs"), cfg.LogDir)
+	require.Equal(t, filepath.Join(configHome, "discrawl", "config.toml"), ResolvePath(""))
+}
+
+func TestDefaultPathsPreferExistingLegacyInstallPaths(t *testing.T) {
+	// Existing ~/.discrawl installs should continue to run without migration.
+	home := t.TempDir()
+	legacy := filepath.Join(home, ".discrawl")
+	require.NoError(t, os.MkdirAll(filepath.Join(legacy, "cache"), 0o755))
+	require.NoError(t, os.MkdirAll(filepath.Join(legacy, "logs"), 0o755))
+	require.NoError(t, os.MkdirAll(filepath.Join(legacy, "share"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(legacy, "discrawl.db"), nil, 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(legacy, "config.toml"), nil, 0o600))
+	setTestHome(t, home)
+	clearXDGEnv(t)
+
+	cfg := Default()
+	require.Equal(t, filepath.Join(legacy, "discrawl.db"), cfg.DBPath)
+	require.Equal(t, filepath.Join(legacy, "cache"), cfg.CacheDir)
+	require.Equal(t, filepath.Join(legacy, "logs"), cfg.LogDir)
+	require.Equal(t, filepath.Join(legacy, "share"), cfg.Share.RepoPath)
+	require.Equal(t, filepath.Join(legacy, "config.toml"), ResolvePath(""))
+}
+
+func TestDefaultPathsKeepLegacyInstallWithXDGEnv(t *testing.T) {
+	// XDG env vars are often ambient desktop state. They should not force an
+	// existing ~/.discrawl install to migrate before the new paths exist.
+	home := t.TempDir()
+	legacy := filepath.Join(home, ".discrawl")
+	configHome := filepath.Join(home, "xdg-config")
+	dataHome := filepath.Join(home, "xdg-data")
+	cacheHome := filepath.Join(home, "xdg-cache")
+	stateHome := filepath.Join(home, "xdg-state")
+	require.NoError(t, os.MkdirAll(filepath.Join(legacy, "cache"), 0o755))
+	require.NoError(t, os.MkdirAll(filepath.Join(legacy, "logs"), 0o755))
+	require.NoError(t, os.MkdirAll(filepath.Join(legacy, "share"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(legacy, "discrawl.db"), nil, 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(legacy, "config.toml"), nil, 0o600))
+	setTestHome(t, home)
+	t.Setenv("XDG_CONFIG_HOME", configHome)
+	t.Setenv("XDG_DATA_HOME", dataHome)
+	t.Setenv("XDG_CACHE_HOME", cacheHome)
+	t.Setenv("XDG_STATE_HOME", stateHome)
+
+	cfg := Default()
+	require.Equal(t, filepath.Join(legacy, "discrawl.db"), cfg.DBPath)
+	require.Equal(t, filepath.Join(legacy, "cache"), cfg.CacheDir)
+	require.Equal(t, filepath.Join(legacy, "logs"), cfg.LogDir)
+	require.Equal(t, filepath.Join(legacy, "share"), cfg.Share.RepoPath)
+	require.Equal(t, filepath.Join(legacy, "config.toml"), ResolvePath(""))
+}
+
+func TestDefaultPathsMixLegacyAndNewLocations(t *testing.T) {
+	// Fallback is path-by-path so partial migration does not hide newer data.
+	home := t.TempDir()
+	_, dataHome, _, stateHome := defaultXDGTestDirs(home)
+	legacy := filepath.Join(home, ".discrawl")
+	newDBPath := filepath.Join(dataHome, "discrawl", "discrawl.db")
+	require.NoError(t, os.MkdirAll(filepath.Dir(newDBPath), 0o755))
+	require.NoError(t, os.WriteFile(newDBPath, nil, 0o600))
+	require.NoError(t, os.MkdirAll(filepath.Join(legacy, "cache"), 0o755))
+	require.NoError(t, os.MkdirAll(filepath.Join(legacy, "share"), 0o755))
+	setTestHome(t, home)
+	clearXDGEnv(t)
+
+	cfg := Default()
+	require.Equal(t, newDBPath, cfg.DBPath)
+	require.Equal(t, filepath.Join(legacy, "cache"), cfg.CacheDir)
+	require.Equal(t, filepath.Join(stateHome, "discrawl", "logs"), cfg.LogDir)
+	require.Equal(t, filepath.Join(legacy, "share"), cfg.Share.RepoPath)
+}
+
+func TestDefaultPathsPreferNewConfigOverLegacy(t *testing.T) {
+	// Once the new config exists, it becomes the default source of truth.
+	home := t.TempDir()
+	configHome, _, _, _ := defaultXDGTestDirs(home)
+	legacyConfig := filepath.Join(home, ".discrawl", "config.toml")
+	newConfig := filepath.Join(configHome, "discrawl", "config.toml")
+	require.NoError(t, os.MkdirAll(filepath.Dir(legacyConfig), 0o755))
+	require.NoError(t, os.MkdirAll(filepath.Dir(newConfig), 0o755))
+	require.NoError(t, os.WriteFile(legacyConfig, nil, 0o600))
+	require.NoError(t, os.WriteFile(newConfig, nil, 0o600))
+	setTestHome(t, home)
+	t.Setenv("XDG_CONFIG_HOME", "")
+
+	require.Equal(t, newConfig, ResolvePath(""))
+}
+
+func setTestHome(t *testing.T, home string) {
+	t.Helper()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("LOCALAPPDATA", filepath.Join(home, "AppData", "Local"))
+	t.Setenv("APPDATA", filepath.Join(home, "AppData", "Roaming"))
+}
+
+func clearXDGEnv(t *testing.T) {
+	t.Helper()
+	t.Setenv("XDG_CONFIG_HOME", "")
+	t.Setenv("XDG_DATA_HOME", "")
+	t.Setenv("XDG_CACHE_HOME", "")
+	t.Setenv("XDG_STATE_HOME", "")
+}
+
+func defaultXDGTestDirs(home string) (configHome, dataHome, cacheHome, stateHome string) {
+	switch runtime.GOOS {
+	case "darwin":
+		appSupport := filepath.Join(home, "Library", "Application Support")
+		return appSupport, appSupport, filepath.Join(home, "Library", "Caches"), appSupport
+	case "windows":
+		localAppData := filepath.Join(home, "AppData", "Local")
+		return localAppData, localAppData, filepath.Join(localAppData, "cache"), localAppData
+	default:
+		return filepath.Join(home, ".config"),
+			filepath.Join(home, ".local", "share"),
+			filepath.Join(home, ".cache"),
+			filepath.Join(home, ".local", "state")
+	}
+}
+
 func TestDefaultSyncConcurrencyBounds(t *testing.T) {
 	old := runtime.GOMAXPROCS(0)
 	t.Cleanup(func() { runtime.GOMAXPROCS(old) })
@@ -262,11 +432,17 @@ func TestExpandPath(t *testing.T) {
 func TestResolvePath(t *testing.T) {
 	dir := t.TempDir()
 	envPath := filepath.Join(dir, "env.toml")
+	// ResolvePath reads process-wide home/XDG state through adrg/xdg; isolate
+	// the test so host XDG variables or Windows known-folder env vars do not
+	// leak into the fallback assertion below.
+	setTestHome(t, dir)
 	t.Setenv(DefaultConfigEnv, envPath)
 	require.Equal(t, "flag.toml", ResolvePath("flag.toml"))
 	require.Equal(t, envPath, ResolvePath(""))
 	t.Setenv(DefaultConfigEnv, "")
-	require.Contains(t, ResolvePath(""), filepath.Join(".discrawl", "config.toml"))
+	clearXDGEnv(t)
+	configHome, _, _, _ := defaultXDGTestDirs(dir)
+	require.Equal(t, filepath.Join(configHome, "discrawl", "config.toml"), ResolvePath(""))
 	_, err := ExpandPath("")
 	require.ErrorContains(t, err, "empty path")
 }


### PR DESCRIPTION
## Summary
- use github.com/adrg/xdg for platform-native config/data/cache/state defaults
- preserve existing ~/.discrawl installs until corresponding new paths exist
- document Linux, macOS, XDG override, and legacy migration behavior

## Verification
- GOWORK=off go test ./internal/config
- GOWORK=off go test ./...
- git -c core.fsmonitor=false diff --check