### PR TITLE
fix(update): avoid OOM during large SQLite snapshot imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ### Changes
 
+### Fixes
+
+- Kept large Git snapshot imports and FTS rebuilds from exhausting memory on small hosts by using file-backed SQLite temp storage and a bounded import cache. (#65) Thanks @hxy91819.
+
 ## 0.7.2 - 2026-05-11
 
 ### Changes

--- a/internal/share/import_memory_test.go
+++ b/internal/share/import_memory_test.go
@@ -1,0 +1,220 @@
+package share
+
+import (
+	"compress/gzip"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/openclaw/discrawl/internal/store"
+)
+
+func TestImportRealSnapshot(t *testing.T) {
+	repo := strings.TrimSpace(os.Getenv("DISCRAWL_REAL_REPO"))
+	if repo == "" {
+		t.Skip("set DISCRAWL_REAL_REPO to run real snapshot import validation")
+	}
+
+	ctx := context.Background()
+	dst, err := store.Open(ctx, filepath.Join(t.TempDir(), "dst.db"))
+	require.NoError(t, err)
+	defer func() { _ = dst.Close() }()
+
+	_, changed, err := ImportIfChanged(ctx, dst, Options{
+		RepoPath: repo,
+		Branch:   "main",
+		Progress: func(p ImportProgress) {
+			if p.Phase == "start" || p.Phase == "rebuild_fts" || p.Phase == "done" {
+				t.Logf("import progress phase=%s total_rows=%d", p.Phase, p.TotalRows)
+			}
+		},
+	})
+	require.NoError(t, err)
+	require.True(t, changed)
+
+	var messageCount int
+	require.NoError(t, dst.DB().QueryRowContext(ctx, `select count(*) from messages`).Scan(&messageCount))
+	require.Positive(t, messageCount)
+	var ftsCount int
+	require.NoError(t, dst.DB().QueryRowContext(ctx, `select count(*) from message_fts`).Scan(&ftsCount))
+	require.Equal(t, messageCount, ftsCount)
+}
+
+func TestImportMemoryBounded(t *testing.T) {
+	if os.Getenv("DISCRAWL_OOM_REGRESSION") != "1" {
+		t.Skip("set DISCRAWL_OOM_REGRESSION=1 to run the memory-bounded import regression")
+	}
+
+	ctx := context.Background()
+	repo := t.TempDir()
+	messageRows := envInt(t, "DISCRAWL_OOM_ROWS", 80000)
+	textBytes := envInt(t, "DISCRAWL_OOM_TEXT_BYTES", 2048)
+	t.Logf("building synthetic snapshot rows=%d text_bytes=%d", messageRows, textBytes)
+	writeSyntheticMemorySnapshot(t, repo, messageRows, textBytes)
+	t.Log("synthetic snapshot built; starting import")
+
+	dst, err := store.Open(ctx, filepath.Join(t.TempDir(), "dst.db"))
+	require.NoError(t, err)
+	defer func() { _ = dst.Close() }()
+
+	var progress []ImportProgress
+	_, changed, err := ImportIfChanged(ctx, dst, Options{
+		RepoPath: repo,
+		Branch:   "main",
+		Progress: func(p ImportProgress) { progress = append(progress, p) },
+	})
+	require.NoError(t, err)
+	require.True(t, changed)
+	require.Contains(t, progressPhases(progress), "rebuild_fts")
+
+	needle := "oomunique000042"
+	results, err := dst.SearchMessages(ctx, store.SearchOptions{Query: needle, Limit: 10})
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	require.Contains(t, results[0].Content, needle)
+}
+
+func writeSyntheticMemorySnapshot(t *testing.T, repo string, messageRows, textBytes int) {
+	t.Helper()
+	generatedAt := time.Now().UTC()
+	updatedAt := generatedAt.Format(time.RFC3339Nano)
+	guildFile := "tables/guilds/000000.jsonl.gz"
+	channelFile := "tables/channels/000000.jsonl.gz"
+	memberFile := "tables/members/000000.jsonl.gz"
+	messageFile := "tables/messages/000000.jsonl.gz"
+
+	writeJSONLGzip(t, repo, guildFile, func(enc *json.Encoder) int {
+		require.NoError(t, enc.Encode(map[string]any{
+			"id":         "g1",
+			"name":       "Guild",
+			"icon":       "",
+			"raw_json":   `{}`,
+			"updated_at": updatedAt,
+		}))
+		return 1
+	})
+	writeJSONLGzip(t, repo, channelFile, func(enc *json.Encoder) int {
+		require.NoError(t, enc.Encode(map[string]any{
+			"id":                "c1",
+			"guild_id":          "g1",
+			"parent_id":         "",
+			"kind":              "text",
+			"name":              "general",
+			"topic":             "",
+			"position":          0,
+			"is_nsfw":           false,
+			"is_archived":       false,
+			"is_locked":         false,
+			"is_private_thread": false,
+			"thread_parent_id":  "",
+			"archive_timestamp": "",
+			"raw_json":          `{}`,
+			"updated_at":        updatedAt,
+		}))
+		return 1
+	})
+	writeJSONLGzip(t, repo, memberFile, func(enc *json.Encoder) int {
+		require.NoError(t, enc.Encode(map[string]any{
+			"guild_id":      "g1",
+			"user_id":       "u1",
+			"username":      "peter",
+			"global_name":   "",
+			"display_name":  "Peter",
+			"nick":          "",
+			"discriminator": "",
+			"avatar":        "",
+			"bot":           false,
+			"joined_at":     "",
+			"role_ids_json": `[]`,
+			"raw_json":      `{"bio":"memory regression profile"}`,
+			"updated_at":    updatedAt,
+		}))
+		return 1
+	})
+	writeJSONLGzip(t, repo, messageFile, func(enc *json.Encoder) int {
+		for i := range messageRows {
+			messageID := strconv.FormatInt(1456744319972282449+int64(i), 10)
+			unique := fmt.Sprintf("oomunique%06d", i)
+			content := syntheticMemoryContent(unique, textBytes)
+			require.NoError(t, enc.Encode(map[string]any{
+				"id":                  messageID,
+				"guild_id":            "g1",
+				"channel_id":          "c1",
+				"author_id":           "u1",
+				"message_type":        0,
+				"created_at":          updatedAt,
+				"edited_at":           "",
+				"deleted_at":          "",
+				"content":             content,
+				"normalized_content":  content,
+				"reply_to_message_id": "",
+				"pinned":              false,
+				"has_attachments":     false,
+				"raw_json":            `{"author":{"username":"Peter"}}`,
+				"updated_at":          updatedAt,
+			}))
+		}
+		return messageRows
+	})
+
+	manifest := Manifest{
+		Version:     1,
+		GeneratedAt: generatedAt,
+		Tables: []TableManifest{
+			{Name: "guilds", Files: []string{guildFile}, Columns: []string{"id", "name", "icon", "raw_json", "updated_at"}, Rows: 1},
+			{Name: "channels", Files: []string{channelFile}, Columns: []string{"id", "guild_id", "parent_id", "kind", "name", "topic", "position", "is_nsfw", "is_archived", "is_locked", "is_private_thread", "thread_parent_id", "archive_timestamp", "raw_json", "updated_at"}, Rows: 1},
+			{Name: "members", Files: []string{memberFile}, Columns: []string{"guild_id", "user_id", "username", "global_name", "display_name", "nick", "discriminator", "avatar", "bot", "joined_at", "role_ids_json", "raw_json", "updated_at"}, Rows: 1},
+			{Name: "messages", Files: []string{messageFile}, Columns: []string{"id", "guild_id", "channel_id", "author_id", "message_type", "created_at", "edited_at", "deleted_at", "content", "normalized_content", "reply_to_message_id", "pinned", "has_attachments", "raw_json", "updated_at"}, Rows: messageRows},
+		},
+	}
+	body, err := json.MarshalIndent(manifest, "", "  ")
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(repo, ManifestName), append(body, '\n'), 0o600))
+}
+
+func writeJSONLGzip(t *testing.T, repo, rel string, writeRows func(*json.Encoder) int) {
+	t.Helper()
+	path := filepath.Join(repo, filepath.FromSlash(rel))
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+	file, err := os.Create(path)
+	require.NoError(t, err)
+	gz := gzip.NewWriter(file)
+	enc := json.NewEncoder(gz)
+	rows := writeRows(enc)
+	require.Positive(t, rows)
+	require.NoError(t, gz.Close())
+	require.NoError(t, file.Close())
+}
+
+func syntheticMemoryContent(unique string, size int) string {
+	if size <= len(unique) {
+		return unique
+	}
+	var b strings.Builder
+	b.Grow(size)
+	b.WriteString(unique)
+	for i := 0; b.Len() < size; i++ {
+		_, _ = fmt.Fprintf(&b, " token_%s_%04d", unique, i)
+	}
+	return b.String()[:size]
+}
+
+func envInt(t *testing.T, name string, fallback int) int {
+	t.Helper()
+	raw := strings.TrimSpace(os.Getenv(name))
+	if raw == "" {
+		return fallback
+	}
+	value, err := strconv.Atoi(raw)
+	require.NoError(t, err)
+	require.Positive(t, value)
+	return value
+}

--- a/internal/share/share.go
+++ b/internal/share/share.go
@@ -252,10 +252,11 @@ func Import(ctx context.Context, s *store.Store, opts Options) (Manifest, error)
 func applyImportPragmas(ctx context.Context, db *sql.DB) (func(context.Context) error, error) {
 	// Snapshot imports touch most of the archive. Keep SQLite's crash recovery
 	// enabled; journal_mode=off can leave the live DB malformed if the process
-	// or host dies mid-import.
+	// or host dies mid-import. Keep temporary storage file-backed and bound the
+	// page cache so large imports and FTS rebuilds do not exhaust small hosts.
 	for _, stmt := range []string{
-		`pragma temp_store = memory`,
-		`pragma cache_size = -262144`,
+		`pragma temp_store = file`,
+		`pragma cache_size = -32768`,
 		`pragma journal_mode = wal`,
 		`pragma synchronous = normal`,
 	} {

--- a/internal/share/share_test.go
+++ b/internal/share/share_test.go
@@ -311,7 +311,7 @@ func TestImportIfChangedInfersLegacyManifestFilesFromGit(t *testing.T) {
 	require.Len(t, results, 1)
 }
 
-func TestApplyImportPragmasKeepCrashRecoveryEnabled(t *testing.T) {
+func TestApplyImportPragmasBoundImportMemory(t *testing.T) {
 	ctx := context.Background()
 	s := seedStore(t, filepath.Join(t.TempDir(), "dst.db"))
 	defer func() { _ = s.Close() }()
@@ -319,6 +319,14 @@ func TestApplyImportPragmasKeepCrashRecoveryEnabled(t *testing.T) {
 	restore, err := applyImportPragmas(ctx, s.DB())
 	require.NoError(t, err)
 	defer func() { require.NoError(t, restore(ctx)) }()
+
+	var tempStore int
+	require.NoError(t, s.DB().QueryRowContext(ctx, `pragma temp_store`).Scan(&tempStore))
+	require.Equal(t, 1, tempStore, "snapshot imports should use file-backed temporary storage")
+
+	var cacheSize int
+	require.NoError(t, s.DB().QueryRowContext(ctx, `pragma cache_size`).Scan(&cacheSize))
+	require.GreaterOrEqual(t, cacheSize, -65536)
 
 	var journalMode string
 	require.NoError(t, s.DB().QueryRowContext(ctx, `pragma journal_mode`).Scan(&journalMode))


### PR DESCRIPTION
## Summary

- Problem: large Git snapshot imports can exceed memory on small hosts during SQLite import / FTS rebuild.
- Why it matters: a reported 7.3GB local archive on a ~7.4GB RAM server could not reliably complete `discrawl update`; the process was killed under memory pressure.
- What changed: snapshot imports now use file-backed SQLite temporary storage and a smaller page cache (`32 MiB` instead of `256 MiB`), while preserving WAL crash recovery settings.
- What did NOT change (scope boundary): no CLI behavior changed; no `discrawl update` flags were added; no git wrapper / pull / checkout behavior was changed.
- Update behavior: `ImportIfChanged` skips already-imported manifests, uses incremental import when a previous manifest supports it, and falls back to full import only for first imports or unsupported snapshot shape changes. This PR mainly affects full imports and FTS-rebuild imports.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes N/A
- Related N/A
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: memory pressure / OOM during SQLite snapshot import and FTS rebuild.
- Real environment tested:
  - Host: Linux x86_64, 32 vCPU, 62 GiB RAM (`nproc` = 32; `free -h` reports `62Gi` total memory)
  - Repo under test: `/data/code/openclaw/discrawl-oom-import-memory`
  - Real snapshot repo: `/data/code/openclaw/discord-store`, `du -sh` reports `7.2G`
  - Snapshot import row count observed from manifest/progress: `2,305,374`
- Exact steps or command run after this patch:

```bash
cd /data/code/openclaw/discrawl-oom-import-memory
/usr/bin/time -v env \
  GOTOOLCHAIN=auto \
  DISCRAWL_REAL_REPO=/data/code/openclaw/discord-store \
  go test ./internal/share -run TestImportRealSnapshot -count=1 -timeout=90m -v
```

- Evidence after fix:

```text
=== RUN   TestImportRealSnapshot
    import_memory_test.go:36: import progress phase=start total_rows=2305374
    import_memory_test.go:36: import progress phase=rebuild_fts total_rows=0
    import_memory_test.go:36: import progress phase=done total_rows=2305374
--- PASS: TestImportRealSnapshot (576.16s)
PASS
ok  	github.com/openclaw/discrawl/internal/share	576.169s
Command being timed: "env GOTOOLCHAIN=auto DISCRAWL_REAL_REPO=/data/code/openclaw/discord-store go test ./internal/share -run TestImportRealSnapshot -count=1 -timeout=90m -v"
Elapsed (wall clock) time (h:mm:ss or m:ss): 9:36.64
Maximum resident set size (kbytes): 357076
Exit status: 0
```

- Observed result after fix: full real snapshot import completed, FTS rebuild completed, and the test verified `messages` count equals `message_fts` count.
- What was not tested: the git wrapper / `discrawl update` pull failure was intentionally out of scope for this PR.
- Before evidence:

```bash
docker run --rm \
  --memory=768m --memory-swap=768m \
  -v /usr/local/go:/usr/local/go:ro \
  -v /root/go:/root/go \
  -v /root/.cache/go-build:/root/.cache/go-build \
  -v /data/code/openclaw/discrawl-oom-import-memory:/src \
  -w /src \
  -e PATH=/usr/local/go/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin \
  -e GOTOOLCHAIN=auto \
  -e DISCRAWL_OOM_REGRESSION=1 \
  -e DISCRAWL_OOM_ROWS=80000 \
  -e DISCRAWL_OOM_TEXT_BYTES=2048 \
  openclaw-e2e-systemd-node:latest \
  go test ./internal/share -run TestImportMemoryBounded -count=1 -timeout=30m -v
```

Pre-fix output after the synthetic snapshot was built and import started:

```text
=== RUN   TestImportMemoryBounded
    import_memory_test.go:29: building synthetic snapshot rows=80000 text_bytes=2048
    import_memory_test.go:31: synthetic snapshot built; starting import
signal: killed
FAIL	github.com/openclaw/discrawl/internal/share	25.197s
FAIL
```

Post-fix, the exact same memory-limited Docker command passes:

```text
=== RUN   TestImportMemoryBounded
    import_memory_test.go:29: building synthetic snapshot rows=80000 text_bytes=2048
    import_memory_test.go:31: synthetic snapshot built; starting import
--- PASS: TestImportMemoryBounded (55.45s)
PASS
ok  	github.com/openclaw/discrawl/internal/share	55.453s
```

Performance comparison on the same high-memory host (32 vCPU / 62 GiB RAM) and real 7.2G snapshot (`2,305,374` rows), both measured with `/usr/bin/time -v`:

```text
Baseline main (temp_store=memory, cache_size=-262144):
  Elapsed: 9:35.14
  Max RSS: 1,606,248 KB

This PR (temp_store=file, cache_size=-32768):
  Elapsed: 9:36.64
  Max RSS:   357,076 KB
```

Observed trade-off in this 32 vCPU / 62 GiB RAM run: wall time increased by ~1.5s (~0.3%) while Max RSS dropped by ~1.25GB (~78%). The speed trade-off may differ on slower disks or smaller hosts, but this high-memory baseline did not show a meaningful slowdown.

## Root Cause (if applicable)

- Root cause: `applyImportPragmas` forced `pragma temp_store = memory` and set `pragma cache_size = -262144` (~256 MiB) for imports that can touch most of the archive and rebuild FTS indexes. On memory-constrained hosts, SQLite temporary structures plus page cache plus Go process memory can exceed available RAM.
- Missing detection / guardrail: no memory-limited import regression existed; default unit tests used small fixtures and did not exercise large full import + FTS rebuild under cgroup limits.
- Contributing context (if known): the JSONL gzip import path itself is streaming; the higher-risk phase is SQLite import/FTS rebuild configuration rather than reading the whole snapshot into Go memory.
- Historical context: these import PRAGMAs were introduced in `9e2fd991` (`perf: speed up git snapshot imports`) as an import-speed optimization. That original change also disabled journaling. A later hardening change, `0487ccc1` (`fix: harden discrawl archive imports`), restored WAL / synchronous safety but left `temp_store=memory` and the 256 MiB cache unchanged. This PR continues that reliability direction by bounding memory while preserving the measured import throughput.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file:
  - `internal/share/share_test.go`: lightweight PRAGMA regression.
  - `internal/share/import_memory_test.go`: opt-in synthetic OOM regression and opt-in real snapshot validation.
- Scenario the test should lock in:
  - imports use file-backed temp storage and bounded cache;
  - a synthetic large snapshot import + FTS rebuild completes under Docker memory limits after the fix;
  - a real snapshot import can be validated by maintainers with `DISCRAWL_REAL_REPO=/path/to/store`.
- Why this is the smallest reliable guardrail: the default test checks the exact SQLite PRAGMA settings quickly, while the heavier OOM reproduction is opt-in so CI does not become slow or resource-dependent.
- Existing test that already covers this (if any): none for memory-limited large import.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

None. No CLI flags, config fields, git behavior, or output format changed.

## Diagram (if applicable)

```text
Before:
snapshot import -> SQLite temp_store=memory + 256 MiB cache -> full import/FTS rebuild -> high RSS / possible OOM

After:
snapshot import -> SQLite temp_store=file + 32 MiB cache -> full import/FTS rebuild -> bounded memory, same imported data
```

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Linux x86_64
- Host resources for real-data benchmark: 32 vCPU, 62 GiB RAM
- Runtime/container: Docker `--memory=768m --memory-swap=768m` for synthetic OOM repro; host Go test for real snapshot validation.
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): snapshot repo path only; no tokens/secrets used.

### Steps

1. Run the synthetic memory regression in a constrained Docker container with `DISCRAWL_OOM_REGRESSION=1`.
2. Confirm pre-fix behavior is `signal: killed` after import starts.
3. Apply this patch.
4. Run the same Docker command again and confirm it passes.
5. Optionally validate a real snapshot with:

```bash
DISCRAWL_REAL_REPO=/path/to/discord-store \
  go test ./internal/share -run TestImportRealSnapshot -count=1 -timeout=90m -v
```

### Expected

- Synthetic large import completes under the configured memory limit after the fix.
- Real snapshot import completes and `message_fts` row count matches `messages` row count.

### Actual

- Pre-fix synthetic constrained run: `signal: killed`.
- Post-fix synthetic constrained run: `PASS`.
- Post-fix real snapshot run: `PASS`, Max RSS `357,076 KB`, `2,305,374` rows.
- Same-host real snapshot comparison: baseline `9:35.14` / `1,606,248 KB`; this PR `9:36.64` / `357,076 KB`.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [x] Perf numbers (if relevant)

## Human Verification (required)

What I personally verified (not just CI), and how:

- Verified scenarios:
  - pre-fix synthetic import under Docker 768 MiB was killed;
  - post-fix synthetic import under the same Docker limit passed;
  - post-fix real `/data/code/openclaw/discord-store` import passed;
  - compared baseline vs this PR on the same real snapshot and host;
  - `GOTOOLCHAIN=auto go test ./internal/share` passed.
- Edge cases checked:
  - crash recovery settings remain enabled (`journal_mode` is not `off`; `synchronous` is non-zero);
  - opt-in heavy tests skip by default unless env vars are set.
- What I did **not** verify:
  - `discrawl update` git wrapper behavior; intentionally out of scope.
  - Windows-specific import behavior.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

No bot review conversations have been addressed yet.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No user config changes. New env vars are test-only: `DISCRAWL_OOM_REGRESSION`, `DISCRAWL_OOM_ROWS`, `DISCRAWL_OOM_TEXT_BYTES`, `DISCRAWL_REAL_REPO`.
- Migration needed? No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: file-backed SQLite temporary storage may be slower than memory temp storage on large imports.
  - Mitigation: this only affects snapshot import/rebuild phases; it trades memory headroom for possible speed impact. On the measured 7.2G real snapshot using a 32 vCPU / 62 GiB RAM host, wall time changed from `9:35.14` to `9:36.64` (~+0.3%) while Max RSS dropped from `1,606,248 KB` to `357,076 KB`.
- Risk: file-backed temporary storage can increase temporary disk writes during full imports / FTS rebuilds, which may matter on slow disks, constrained ephemeral disks, or SSD write-budget-sensitive deployments.
  - Mitigation: the write amplification is limited to snapshot import/rebuild paths, not steady-state reads/searches. `update` is not always a full import: same manifests are skipped, supported manifest deltas use incremental import, and this PR mainly affects first imports or imports that must rebuild FTS. Operators running very large imports should keep enough temp disk space available.
- Risk: smaller SQLite page cache may reduce import throughput.
  - Mitigation: the cache remains bounded at 32 MiB and the same-host real-data comparison showed negligible throughput impact for this snapshot.
