### PR TITLE
feat(remote): add Cloudflare archive mode

### DIFF
--- a/.agents/skills/autoreview/SKILL.md
+++ b/.agents/skills/autoreview/SKILL.md
@@ -1,0 +1,190 @@
+---
+name: autoreview
+description: "Auto Review closeout. Codex review is the default when no engine is set and is the recommended reviewer."
+---
+
+# Auto Review
+
+Run the bundled structured review helper as a closeout check. This is code review, not Guardian `auto_review` approval routing.
+
+Codex review is the default when no engine is set. It usually delivers the best review results and should remain the normal final closeout engine.
+
+Use when:
+
+- user asks for Codex review / Claude review / autoreview / second-model review
+- after non-trivial code edits, before final/commit/ship
+- reviewing a local branch or PR branch after fixes
+
+## Contract
+
+- Treat review output as advisory. Never blindly apply it.
+- Verify every finding by reading the real code path and adjacent files.
+- Read dependency docs/source/types when the finding depends on external behavior.
+- Reject unrealistic edge cases, speculative risks, broad rewrites, and fixes that over-complicate the codebase.
+- Prefer small fixes at the right ownership boundary; no refactor unless it clearly improves the bug class.
+- Keep going until structured review returns no accepted/actionable findings.
+- If a review-triggered fix changes code, rerun focused tests and rerun the structured review helper.
+- For security-audit suppression changes, verify accepted findings remain auditable: suppressed findings stay in structured output, active output keeps an unsuppressible suppression notice, and aggregate findings cannot hide unrelated active risk.
+- Never switch or override the requested review engine/model. If the review hits model capacity, retry the same command a few times with the same engine/model.
+- Be patient with large bundles. Structured review can take up to 30 minutes while the model call is active, especially with Codex tools or web search.
+- Treat heartbeat lines like `review still running: ... elapsed=... pid=...` as healthy progress, not a hang. Let the helper continue while heartbeats are advancing. Pass `--stream-engine-output` when live engine text is useful; Codex and Claude filter tool/file chatter, other engines pass raw output through.
+- Do not kill a review just because it has been quiet for 2-5 minutes, or because it is still running under the 30-minute window. Inspect the process only after missing multiple expected heartbeats, after 30 minutes, or after an obviously failed subprocess; prefer letting the same helper command finish.
+- Tools are useful in review mode. The helper allows read-only inspection tools and web search by default so reviewers can check dependency contracts, upstream docs, and current behavior.
+- Security perspective is always included, but it should not cripple legitimate functionality. Report security findings only when the change creates a concrete, actionable risk or removes an important safety check.
+- For regression provenance, if no blamed PR is traceable, use the blamed commit as the provenance: commit SHA, date, and author username. Do not guess a merger or frame missing PR metadata as a separate finding.
+- Do not invoke built-in `codex review`, nested reviewers, or reviewer panels from inside the review. The helper builds one bundle, calls one selected engine, validates one structured result, and stops.
+- Stop as soon as the helper exits 0 with no accepted/actionable findings. Do not run an extra review just to get a nicer "clean" line, a second opinion, or clearer closeout wording.
+- Treat the helper's successful exit plus absence of actionable findings as the clean review result, even if the underlying Codex CLI output is terse.
+- Multi-reviewer panels are opt-in only. Use them when explicitly requested or when risk justifies the extra spend; the main agent still verifies every accepted finding before fixing.
+- If rejecting a finding as intentional/not worth fixing, add a brief inline code comment only when it explains a real invariant or ownership decision that future reviewers should know.
+- If `gh`/Gitcrawl reports `database disk image is malformed`, run `gitcrawl doctor --json` once to let the portable cache repair before retrying review; do not bypass the shim unless repair fails and freshness requires live GitHub.
+- If Gitcrawl reports a portable manifest mismatch, source/runtime DB health error, or stale portable-store checkout, run `gitcrawl doctor --json` and inspect `source_db_health`, `runtime_db_health`, and `portable_store_status` before falling back to live GitHub.
+- Do not push just to review. Push only when the user requested push/ship/PR update.
+
+## Pick Target
+
+Dirty local work:
+
+```bash
+<autoreview-helper> --mode local
+```
+
+Use this only when the patch is actually unstaged/staged/untracked in the
+current checkout. For committed, pushed, or PR work, point the helper at the commit
+or branch diff instead; do not force `--mode local` / `--uncommitted` just
+because the helper docs mention dirty work first. A clean local review
+only proves there is no local patch.
+
+Branch/PR work:
+
+```bash
+<autoreview-helper> --mode branch --base origin/main
+```
+
+Optional review context is first-class:
+
+```bash
+<autoreview-helper> --mode branch --base origin/main --prompt-file /tmp/review-notes.md --dataset /tmp/evidence.json
+```
+
+If an open PR exists, use its actual base:
+
+```bash
+base=$(gh pr view --json baseRefName --jq .baseRefName)
+<autoreview-helper> --mode branch --base "origin/$base"
+```
+
+Committed single change:
+
+```bash
+<autoreview-helper> --mode commit --commit HEAD
+```
+
+or with the helper:
+
+```bash
+/Users/steipete/Projects/agent-scripts/skills/autoreview/scripts/autoreview --mode commit --commit HEAD
+```
+
+Use commit review for already-landed or already-pushed work on `main`. Reviewing
+clean `main` against `origin/main` is usually an empty diff after push. For a
+small stack, review each commit explicitly or review the branch before merging
+with `--base`.
+
+## Parallel Closeout
+
+Format first if formatting can change line locations. Then it is OK to run tests and review in parallel:
+
+```bash
+scripts/autoreview --parallel-tests "<focused test command>"
+```
+
+Tradeoff: tests may force code changes that stale the review. If tests or review lead to code edits, rerun the affected tests and rerun review until no accepted/actionable findings remain. Once that rerun exits cleanly, stop; do not spend another long review cycle on redundant confirmation.
+
+## Review Panels
+
+Run multiple reviewers against one frozen bundle:
+
+```bash
+<autoreview-helper> --reviewers codex,claude
+```
+
+`--panel` is shorthand for Codex plus Claude unless `--engine` changes the first reviewer:
+
+```bash
+<autoreview-helper> --panel
+```
+
+Set reviewer models and thinking/effort explicitly:
+
+```bash
+<autoreview-helper> --reviewers codex,claude --model codex=gpt-5.1 --thinking codex=high --model claude=sonnet --thinking claude=max
+```
+
+Inline syntax is also supported:
+
+```bash
+<autoreview-helper> --reviewers codex:gpt-5.1:high,claude:sonnet:max
+```
+
+Codex maps thinking to `model_reasoning_effort` and accepts `low`, `medium`,
+`high`, or `xhigh`. Claude maps thinking to `--effort` and also accepts `max`.
+Engines without a real thinking knob reject `--thinking`.
+
+## Context Efficiency
+
+Run the helper directly so target selection, engine choice, structured validation, and exit status all stay in one path. If output is noisy, summarize the completed helper output after it returns; do not ask another agent or reviewer to rerun the review.
+
+## Helper
+
+OpenClaw repo-local helper:
+
+```bash
+.agents/skills/autoreview/scripts/autoreview --help
+```
+
+`agent-scripts` checkout helper:
+
+```bash
+skills/autoreview/scripts/autoreview --help
+```
+
+Global helper from `agent-scripts`:
+
+```bash
+~/.codex/skills/agent-scripts/autoreview/scripts/autoreview --help
+```
+
+If installed from `agent-scripts`, path is:
+
+```bash
+/Users/steipete/Projects/agent-scripts/skills/autoreview/scripts/autoreview --help
+```
+
+The helper:
+
+- chooses dirty local changes first
+- otherwise uses current PR base if `gh pr view` works
+- otherwise uses `origin/main` for non-main branches
+- supports `--engine codex`, `claude`, `droid`, and `copilot`; default is `AUTOREVIEW_ENGINE` or `codex`; Codex should remain the default when nothing is set
+- use `--mode commit --commit <ref>` for already-committed work, especially clean `main` after landing
+- should be left in `--mode auto` or forced to `--mode branch` for PR/branch work; do not force `--mode local` after committing
+- writes only to stdout unless `--output`, `--json-output`, or live streamed engine stderr is set
+- supports `--dry-run`, `--parallel-tests`, `--prompt`, `--prompt-file`, `--dataset`, `--no-tools`, `--no-web-search`, and commit refs
+- supports `--stream-engine-output` or `AUTOREVIEW_STREAM_ENGINE_OUTPUT=1` for live engine text while preserving structured validation; Codex and Claude hide tool/file event details, emit compact activity summaries, and report usage at turn completion
+- supports opt-in review panels with `--panel` / `--reviewers`, plus per-engine `--model` and `--thinking`
+- allows read-only tools and web search by default where the selected CLI supports them; forbids nested review in the prompt; Codex is run through `codex exec` with read-only sandbox and structured output
+- prints `review still running: <engine> elapsed=<seconds>s pid=<pid>` to stderr at long-running intervals while waiting for the selected review engine, unless streamed output or compact Codex activity has been visible recently
+- prints `autoreview clean: no accepted/actionable findings reported` when the selected review command exits 0
+- exits nonzero when accepted/actionable findings are present
+
+## Final Report
+
+Include:
+
+- review command used
+- tests/proof run
+- findings accepted/rejected, briefly why
+- the clean review result from the final helper/review run, or why a remaining finding was consciously rejected
+
+Do not run another review solely to improve the final report wording. If the final helper run exited 0 and produced no accepted/actionable findings, report that exact run as clean.

--- a/.agents/skills/autoreview/scripts/autoreview
+++ b/.agents/skills/autoreview/scripts/autoreview
@@ -1,0 +1,1176 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import concurrent.futures
+import copy
+import json
+import os
+import queue
+import subprocess
+import sys
+import tempfile
+import textwrap
+import threading
+import time
+from pathlib import Path
+from typing import Any, Callable
+
+
+ENGINES = ("codex", "claude", "droid", "copilot")
+THINKING_LEVELS_BY_ENGINE = {
+    "codex": {"low", "medium", "high", "xhigh"},
+    "claude": {"low", "medium", "high", "xhigh", "max"},
+    "droid": set(),
+    "copilot": set(),
+}
+
+
+SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "additionalProperties": False,
+    "required": [
+        "findings",
+        "overall_correctness",
+        "overall_explanation",
+        "overall_confidence",
+    ],
+    "properties": {
+        "findings": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "additionalProperties": False,
+                "required": [
+                    "title",
+                    "body",
+                    "priority",
+                    "confidence",
+                    "category",
+                    "code_location",
+                ],
+                "properties": {
+                    "title": {"type": "string", "minLength": 1, "maxLength": 140},
+                    "body": {"type": "string", "minLength": 1, "maxLength": 2000},
+                    "priority": {"type": "string", "enum": ["P0", "P1", "P2", "P3"]},
+                    "confidence": {"type": "number", "minimum": 0, "maximum": 1},
+                    "category": {
+                        "type": "string",
+                        "enum": ["bug", "security", "regression", "test_gap", "maintainability"],
+                    },
+                    "code_location": {
+                        "type": "object",
+                        "additionalProperties": False,
+                        "required": ["file_path", "line"],
+                        "properties": {
+                            "file_path": {"type": "string", "minLength": 1},
+                            "line": {"type": "integer", "minimum": 1},
+                        },
+                    },
+                },
+            },
+        },
+        "overall_correctness": {
+            "type": "string",
+            "enum": ["patch is correct", "patch is incorrect"],
+        },
+        "overall_explanation": {"type": "string", "minLength": 1, "maxLength": 3000},
+        "overall_confidence": {"type": "number", "minimum": 0, "maximum": 1},
+    },
+}
+
+
+def run(args: list[str], cwd: Path, *, input_text: str | None = None, check: bool = True) -> subprocess.CompletedProcess[str]:
+    result = subprocess.run(
+        args,
+        cwd=cwd,
+        input=input_text,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    if check and result.returncode != 0:
+        cmd = " ".join(args)
+        raise SystemExit(f"command failed ({result.returncode}): {cmd}\n{result.stderr or result.stdout}")
+    return result
+
+
+def run_with_heartbeat(
+    args: list[str],
+    cwd: Path,
+    *,
+    input_text: str | None = None,
+    label: str,
+    heartbeat_seconds: int = 60,
+    stream_output: bool = False,
+    stream_display: Callable[[str, str], str | None] | None = None,
+) -> subprocess.CompletedProcess[str]:
+    if stream_output:
+        return run_with_stream(
+            args,
+            cwd,
+            input_text=input_text,
+            label=label,
+            heartbeat_seconds=heartbeat_seconds,
+            stream_display=stream_display,
+        )
+    started = time.monotonic()
+    proc = subprocess.Popen(
+        args,
+        cwd=cwd,
+        stdin=subprocess.PIPE if input_text is not None else None,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    first_communicate = True
+    while True:
+        try:
+            stdout, stderr = proc.communicate(
+                input=input_text if first_communicate else None,
+                timeout=heartbeat_seconds,
+            )
+            return subprocess.CompletedProcess(args, int(proc.returncode or 0), stdout, stderr)
+        except subprocess.TimeoutExpired:
+            first_communicate = False
+            elapsed = int(time.monotonic() - started)
+            print(f"review still running: {label} elapsed={elapsed}s pid={proc.pid}", file=sys.stderr, flush=True)
+
+
+def run_with_stream(
+    args: list[str],
+    cwd: Path,
+    *,
+    input_text: str | None,
+    label: str,
+    heartbeat_seconds: int,
+    stream_display: Callable[[str, str], str | None] | None,
+) -> subprocess.CompletedProcess[str]:
+    started = time.monotonic()
+    proc = subprocess.Popen(
+        args,
+        cwd=cwd,
+        stdin=subprocess.PIPE if input_text is not None else None,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        bufsize=1,
+    )
+    events: queue.Queue[tuple[str, str | None]] = queue.Queue()
+    stdout_parts: list[str] = []
+    stderr_parts: list[str] = []
+
+    def read_stream(name: str, stream: Any) -> None:
+        try:
+            for line in iter(stream.readline, ""):
+                events.put((name, line))
+        finally:
+            events.put((name, None))
+
+    def write_stdin() -> None:
+        if proc.stdin is None or input_text is None:
+            return
+        try:
+            proc.stdin.write(input_text)
+            proc.stdin.close()
+        except BrokenPipeError:
+            return
+
+    threads = [
+        threading.Thread(target=read_stream, args=("stdout", proc.stdout), daemon=True),
+        threading.Thread(target=read_stream, args=("stderr", proc.stderr), daemon=True),
+    ]
+    for thread in threads:
+        thread.start()
+    stdin_thread = threading.Thread(target=write_stdin, daemon=True)
+    stdin_thread.start()
+
+    open_streams = 2
+    while open_streams:
+        try:
+            name, line = events.get(timeout=heartbeat_seconds)
+        except queue.Empty:
+            elapsed = int(time.monotonic() - started)
+            print(f"review still running: {label} elapsed={elapsed}s pid={proc.pid}", file=sys.stderr, flush=True)
+            continue
+        if line is None:
+            open_streams -= 1
+            continue
+        if name == "stdout":
+            stdout_parts.append(line)
+        else:
+            stderr_parts.append(line)
+        display = stream_display(name, line) if stream_display else line
+        if display:
+            target = sys.stdout if name == "stdout" else sys.stderr
+            target.write(display)
+            target.flush()
+
+    for thread in threads:
+        thread.join()
+    stdin_thread.join(timeout=1)
+    returncode = proc.wait()
+    return subprocess.CompletedProcess(args, returncode, "".join(stdout_parts), "".join(stderr_parts))
+
+
+def git(repo: Path, *args: str, check: bool = True) -> str:
+    return run(["git", *args], repo, check=check).stdout
+
+
+def repo_root() -> Path:
+    result = subprocess.run(
+        ["git", "rev-parse", "--show-toplevel"],
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    if result.returncode != 0:
+        raise SystemExit("autoreview must run inside a git repository")
+    return Path(result.stdout.strip()).resolve()
+
+
+def current_branch(repo: Path) -> str:
+    return git(repo, "branch", "--show-current", check=False).strip() or "detached"
+
+
+def is_dirty(repo: Path) -> bool:
+    return bool(git(repo, "status", "--porcelain").strip())
+
+
+def choose_target(repo: Path, mode: str, base_ref: str | None) -> tuple[str, str | None]:
+    branch = current_branch(repo)
+    if mode == "local" or (mode == "auto" and is_dirty(repo)):
+        return "local", None
+    if mode == "commit":
+        return "commit", None
+    if mode == "branch" or (mode == "auto" and branch != "main"):
+        return "branch", base_ref or detect_pr_base(repo) or "origin/main"
+    raise SystemExit("no review target: clean main checkout and no forced mode")
+
+
+def detect_pr_base(repo: Path) -> str | None:
+    if not shutil_which("gh"):
+        return None
+    result = run(["gh", "pr", "view", "--json", "baseRefName", "--jq", ".baseRefName"], repo, check=False)
+    base = result.stdout.strip()
+    return f"origin/{base}" if result.returncode == 0 and base else None
+
+
+def shutil_which(name: str) -> str | None:
+    for part in os.environ.get("PATH", "").split(os.pathsep):
+        candidate = Path(part) / name
+        if candidate.exists() and os.access(candidate, os.X_OK):
+            return str(candidate)
+    return None
+
+
+def bounded(text: str, limit: int = 180_000) -> str:
+    if len(text) <= limit:
+        return text
+    return text[:limit] + f"\n\n[truncated at {limit} characters]\n"
+
+
+def bounded_field(text: str, limit: int) -> str:
+    if len(text) <= limit:
+        return text
+    suffix = "\n\n[truncated]"
+    return text[: max(0, limit - len(suffix))] + suffix
+
+
+def read_text(path: Path, limit: int = 40_000) -> str:
+    try:
+        data = path.read_bytes()
+    except OSError as exc:
+        return f"[unreadable: {exc}]"
+    if b"\0" in data:
+        return "[binary file omitted]"
+    text = data.decode("utf-8", errors="replace")
+    return bounded(text, limit)
+
+
+def local_bundle(repo: Path) -> str:
+    parts = [
+        "# Git Status",
+        git(repo, "status", "--short"),
+        "# Staged Diff",
+        git(repo, "diff", "--cached", "--stat"),
+        bounded(git(repo, "diff", "--cached", "--patch", "--find-renames")),
+        "# Unstaged Diff",
+        git(repo, "diff", "--stat"),
+        bounded(git(repo, "diff", "--patch", "--find-renames")),
+    ]
+    untracked = [line for line in git(repo, "ls-files", "--others", "--exclude-standard").splitlines() if line]
+    if untracked:
+        parts.append("# Untracked Files")
+        for rel in untracked:
+            path = repo / rel
+            parts.append(f"## {rel}\n{read_text(path)}")
+    return "\n\n".join(parts)
+
+
+def branch_bundle(repo: Path, base_ref: str) -> str:
+    git(repo, "fetch", "origin", "--quiet", check=False)
+    return "\n\n".join(
+        [
+            "# Branch Diff",
+            f"base: {base_ref}",
+            git(repo, "diff", "--stat", f"{base_ref}...HEAD"),
+            bounded(git(repo, "diff", "--patch", "--find-renames", f"{base_ref}...HEAD")),
+        ]
+    )
+
+
+def commit_bundle(repo: Path, commit_ref: str) -> str:
+    return "\n\n".join(
+        [
+            "# Commit Diff",
+            f"commit: {commit_ref}",
+            git(repo, "show", "--stat", "--format=fuller", commit_ref),
+            bounded(git(repo, "show", "--patch", "--find-renames", "--format=fuller", commit_ref)),
+        ]
+    )
+
+
+def review_paths(repo: Path, target: str, target_ref: str | None, commit_ref: str) -> set[str]:
+    names: set[str] = set()
+    if target == "local":
+        sources = [
+            git(repo, "diff", "--name-only", "--cached"),
+            git(repo, "diff", "--name-only"),
+            git(repo, "ls-files", "--others", "--exclude-standard"),
+        ]
+    elif target == "branch":
+        assert target_ref
+        sources = [git(repo, "diff", "--name-only", f"{target_ref}...HEAD")]
+    else:
+        sources = [git(repo, "show", "--name-only", "--format=", commit_ref)]
+    for source in sources:
+        for line in source.splitlines():
+            path = line.strip()
+            if path:
+                names.add(path)
+    return names
+
+
+def load_extra_prompt(args: argparse.Namespace) -> str:
+    chunks: list[str] = []
+    for value in args.prompt or []:
+        chunks.append(value)
+    for path in args.prompt_file or []:
+        chunks.append(Path(path).read_text())
+    return "\n\n".join(chunks)
+
+
+def load_datasets(args: argparse.Namespace) -> str:
+    chunks: list[str] = []
+    for spec in args.dataset or []:
+        path = Path(spec)
+        if path.is_dir():
+            raise SystemExit(f"--dataset must be a file, got directory: {path}")
+        chunks.append(f"# Dataset: {path}\n{read_text(path)}")
+    return "\n\n".join(chunks)
+
+
+def build_prompt(repo: Path, target: str, target_ref: str | None, bundle: str, extra_prompt: str, datasets: str) -> str:
+    target_line = f"{target} {target_ref}" if target_ref else target
+    return textwrap.dedent(
+        f"""
+        You are a senior code reviewer. Review the provided git change bundle only.
+
+        Hard rules:
+        - Return exactly one JSON object and nothing else. Do not wrap it in Markdown.
+        - The JSON object must match this schema exactly:
+        {json.dumps(SCHEMA, indent=2)}
+        - Do not modify files.
+        - Do not invoke nested reviewers or review tools.
+        - Forbidden nested review commands include: codex review, autoreview, claude review, oracle review.
+        - You may use read-only tools and web search to inspect files, dependency contracts, upstream docs, current behavior, and security implications.
+        - Shell commands, if available, must be read-only inspection commands. Do not run tests, formatters, package installs, generators, network mutation commands, git mutation commands, or commands that write files.
+        - Report only actionable defects introduced or exposed by this change.
+        - Prefer high-signal findings over style feedback.
+        - Include security findings: injection, secret leaks, authz/authn bypass, path traversal, unsafe deserialization, unsafe filesystem or shell use, privacy leaks, and credential handling.
+        - Do not reject legitimate functionality merely because it touches shell, filesystem, network, auth, or sensitive data. Report a security finding only when the patch creates a concrete exploitable risk, removes an important safety check, or lacks validation at a trust boundary.
+        - For each finding, use the smallest file/line location that demonstrates the issue.
+        - If there are no actionable findings, return an empty findings array and mark the patch correct.
+
+        Review target: {target_line}
+        Repository: {repo}
+
+        {extra_prompt}
+
+        {datasets}
+
+        # Change Bundle
+        {bundle}
+        """
+    ).strip()
+
+
+def write_json_temp(data: dict[str, Any]) -> Path:
+    handle = tempfile.NamedTemporaryFile("w", suffix=".json", delete=False)
+    with handle:
+        json.dump(data, handle)
+    return Path(handle.name)
+
+
+def run_codex(args: argparse.Namespace, repo: Path, prompt: str) -> str:
+    if not args.tools:
+        raise SystemExit("--no-tools is not supported by the Codex engine; use --engine claude --no-tools for a no-tools run")
+    schema_path = write_json_temp(SCHEMA)
+    output_path = Path(tempfile.NamedTemporaryFile("w", suffix=".json", delete=False).name)
+    cmd = [args.codex_bin, "--ask-for-approval", "never"]
+    if args.web_search:
+        cmd.append("--search")
+    if args.model:
+        cmd.extend(["--model", args.model])
+    if args.thinking:
+        cmd.extend(["-c", f'model_reasoning_effort="{args.thinking}"'])
+    cmd.append("exec")
+    if args.stream_engine_output:
+        cmd.append("--json")
+    cmd.extend(
+        [
+            "--ephemeral",
+            "-C",
+            str(repo),
+            "-s",
+            "read-only",
+            "--output-schema",
+            str(schema_path),
+            "--output-last-message",
+            str(output_path),
+            "-",
+        ]
+    )
+    result = run_with_heartbeat(
+        cmd,
+        repo,
+        input_text=prompt,
+        label="codex",
+        stream_output=args.stream_engine_output,
+        stream_display=CodexStreamDisplay() if args.stream_engine_output else None,
+    )
+    try:
+        output = output_path.read_text()
+    finally:
+        schema_path.unlink(missing_ok=True)
+        output_path.unlink(missing_ok=True)
+    if result.returncode != 0:
+        raise SystemExit(f"codex engine failed ({result.returncode})\n{result.stderr or result.stdout}")
+    return output or result.stdout
+
+
+def run_claude(args: argparse.Namespace, repo: Path, prompt: str) -> str:
+    cmd = [
+        args.claude_bin,
+        "--print",
+        "--no-session-persistence",
+        "--output-format",
+        "stream-json" if args.stream_engine_output else "json",
+        "--json-schema",
+        json.dumps(SCHEMA),
+    ]
+    if args.tools:
+        cmd.extend(["--allowedTools", claude_allowed_tools(args)])
+    else:
+        cmd.extend(["--tools", ""])
+    if args.stream_engine_output:
+        cmd.append("--verbose")
+    if args.model:
+        cmd.extend(["--model", args.model])
+    if args.thinking:
+        cmd.extend(["--effort", args.thinking])
+    result = run_with_heartbeat(
+        cmd,
+        repo,
+        input_text=prompt,
+        label="claude",
+        stream_output=args.stream_engine_output,
+        stream_display=ClaudeStreamDisplay() if args.stream_engine_output else None,
+    )
+    if result.returncode != 0:
+        raise SystemExit(f"claude engine failed ({result.returncode})\n{result.stderr or result.stdout}")
+    return result.stdout
+
+
+def run_droid(args: argparse.Namespace, repo: Path, prompt: str) -> str:
+    if args.thinking:
+        raise SystemExit("--thinking is not supported by the droid engine")
+    prompt_path = Path(tempfile.NamedTemporaryFile("w", suffix=".txt", delete=False).name)
+    prompt_path.write_text(prompt)
+    cmd = [
+        args.droid_bin,
+        "exec",
+        "--cwd",
+        str(repo),
+        "--output-format",
+        "json",
+        "-f",
+        str(prompt_path),
+    ]
+    if args.model:
+        cmd.extend(["--model", args.model])
+    if not args.tools:
+        cmd.extend(["--disabled-tools", "*"])
+    result = run_with_heartbeat(cmd, repo, label="droid", stream_output=args.stream_engine_output)
+    prompt_path.unlink(missing_ok=True)
+    if result.returncode != 0:
+        raise SystemExit(f"droid engine failed ({result.returncode})\n{result.stderr or result.stdout}")
+    return result.stdout
+
+
+def run_copilot(args: argparse.Namespace, repo: Path, prompt: str) -> str:
+    if args.thinking:
+        raise SystemExit("--thinking is not supported by the copilot engine")
+    if not args.tools:
+        raise SystemExit("--no-tools is not supported by the copilot engine; copilot requires a read-only file view tool to load the review bundle without exposing it in argv")
+    with tempfile.TemporaryDirectory(prefix="autoreview-copilot.") as tempdir:
+        prompt_path = Path(tempdir) / "prompt.txt"
+        prompt_path.write_text(prompt)
+        os.chmod(prompt_path, 0o600)
+        cmd = [
+            args.copilot_bin,
+            "-C",
+            tempdir,
+            "-p",
+            "Read ./prompt.txt and follow it exactly. Return only the requested JSON object.",
+            "--output-format",
+            "json",
+            "--stream",
+            "on" if args.stream_engine_output else "off",
+            "--no-ask-user",
+            "--disable-builtin-mcps",
+        ]
+        if args.model:
+            cmd.extend(["--model", args.model])
+        cmd.extend(
+            [
+                "--available-tools=read_agent,rg,view,web_fetch",
+                "--allow-tool=read_agent",
+                "--allow-tool=rg",
+                "--allow-tool=view",
+                "--allow-tool=web_fetch",
+            ]
+        )
+        if args.web_search:
+            cmd.append("--allow-all-urls")
+        result = run_with_heartbeat(cmd, Path(tempdir), label="copilot", stream_output=args.stream_engine_output)
+    if result.returncode != 0:
+        raise SystemExit(f"copilot engine failed ({result.returncode})\n{result.stderr or result.stdout}")
+    return result.stdout
+
+
+class CodexStreamDisplay:
+    def __init__(self, *, activity_seconds: int = 20) -> None:
+        self.activity_seconds = activity_seconds
+        self.hidden_events = 0
+        self.last_visible = time.monotonic()
+
+    def __call__(self, name: str, line: str) -> str | None:
+        if name != "stdout":
+            return line
+        try:
+            event = json.loads(line)
+        except json.JSONDecodeError:
+            return self.visible(line)
+        event_type = event.get("type")
+        if event_type == "thread.started":
+            return self.visible(f"codex thread: {event.get('thread_id', '<unknown>')}\n")
+        if event_type == "turn.started":
+            return self.visible("codex turn started\n")
+        if event_type == "turn.completed":
+            usage = event.get("usage")
+            message = format_codex_usage(usage) + "\n" if isinstance(usage, dict) else "codex turn completed\n"
+            return self.visible(self.flush_hidden() + message)
+        item = event.get("item")
+        if isinstance(item, dict) and item.get("type") == "agent_message" and isinstance(item.get("text"), str):
+            return self.visible(self.flush_hidden() + item["text"].rstrip() + "\n")
+        return self.hidden_activity()
+
+    def hidden_activity(self) -> str | None:
+        self.hidden_events += 1
+        if time.monotonic() - self.last_visible < self.activity_seconds:
+            return None
+        return self.visible(self.flush_hidden())
+
+    def flush_hidden(self) -> str:
+        if not self.hidden_events:
+            return ""
+        count = self.hidden_events
+        self.hidden_events = 0
+        return f"codex activity: {count} hidden tool/status events\n"
+
+    def visible(self, text: str) -> str:
+        self.last_visible = time.monotonic()
+        return text
+
+
+class ClaudeStreamDisplay:
+    def __init__(self, *, activity_seconds: int = 20) -> None:
+        self.activity_seconds = activity_seconds
+        self.hidden_events = 0
+        self.last_visible = time.monotonic()
+        self.started = False
+
+    def __call__(self, name: str, line: str) -> str | None:
+        if name != "stdout":
+            return line
+        try:
+            event = json.loads(line)
+        except json.JSONDecodeError:
+            return self.visible(line)
+        event_type = event.get("type")
+        if event_type == "system" and not self.started:
+            self.started = True
+            return self.visible("claude turn started\n")
+        if event_type == "assistant":
+            return self.assistant_message(event)
+        if event_type == "result":
+            return self.visible(self.flush_hidden() + self.result_summary(event))
+        return self.hidden_activity()
+
+    def assistant_message(self, event: dict[str, Any]) -> str | None:
+        message = event.get("message")
+        if not isinstance(message, dict):
+            return self.hidden_activity()
+        chunks: list[str] = []
+        for item in message.get("content", []):
+            if not isinstance(item, dict):
+                continue
+            if item.get("type") == "text" and isinstance(item.get("text"), str):
+                chunks.append(item["text"].rstrip())
+        if chunks:
+            return self.visible(self.flush_hidden() + "\n".join(chunks) + "\n")
+        return self.hidden_activity()
+
+    def result_summary(self, event: dict[str, Any]) -> str:
+        usage = event.get("usage")
+        fields: list[str] = []
+        if isinstance(usage, dict):
+            for key in (
+                "input_tokens",
+                "cache_read_input_tokens",
+                "cache_creation_input_tokens",
+                "output_tokens",
+            ):
+                value = usage.get(key)
+                if isinstance(value, int):
+                    fields.append(f"{key}={value}")
+        cost = event.get("total_cost_usd")
+        if isinstance(cost, (int, float)) and not isinstance(cost, bool):
+            fields.append(f"cost_usd={cost:.6f}")
+        return "claude usage: " + " ".join(fields) + "\n" if fields else "claude turn completed\n"
+
+    def hidden_activity(self) -> str | None:
+        self.hidden_events += 1
+        if time.monotonic() - self.last_visible < self.activity_seconds:
+            return None
+        return self.visible(self.flush_hidden())
+
+    def flush_hidden(self) -> str:
+        if not self.hidden_events:
+            return ""
+        count = self.hidden_events
+        self.hidden_events = 0
+        return f"claude activity: {count} hidden tool/status events\n"
+
+    def visible(self, text: str) -> str:
+        self.last_visible = time.monotonic()
+        return text
+
+
+def format_codex_usage(usage: dict[str, Any]) -> str:
+    fields = [
+        "input_tokens",
+        "cached_input_tokens",
+        "output_tokens",
+        "reasoning_output_tokens",
+    ]
+    parts = [f"{field}={usage[field]}" for field in fields if isinstance(usage.get(field), int)]
+    return "codex usage: " + " ".join(parts) if parts else "codex usage: unavailable"
+
+
+def claude_allowed_tools(args: argparse.Namespace) -> str:
+    tools = [tool.strip() for tool in args.claude_allowed_tools.split(",") if tool.strip()]
+    if not args.web_search:
+        tools = [tool for tool in tools if tool not in {"WebSearch", "WebFetch"}]
+    return ",".join(tools)
+
+
+def extract_json(text: str) -> dict[str, Any]:
+    stripped = text.strip()
+    if not stripped:
+        raise SystemExit("review engine returned empty output")
+    try:
+        parsed = json.loads(stripped)
+    except json.JSONDecodeError as exc:
+        fenced_report = parse_json_candidate(stripped)
+        if isinstance(fenced_report, dict) and "findings" in fenced_report:
+            return fenced_report
+        jsonl_report = extract_json_from_jsonl(stripped)
+        if jsonl_report:
+            return jsonl_report
+        raise SystemExit(f"review engine returned non-JSON output: {exc}\n{stripped[:2000]}")
+    if isinstance(parsed, dict) and "findings" in parsed:
+        return parsed
+    if isinstance(parsed, dict) and isinstance(parsed.get("structured_output"), dict):
+        return parsed["structured_output"]
+    if isinstance(parsed, dict) and isinstance(parsed.get("result"), str):
+        result_json = parse_json_candidate(parsed["result"])
+        if isinstance(result_json, dict) and "findings" in result_json:
+            return result_json
+        raise SystemExit(f"review engine result was not structured JSON:\n{parsed['result'][:2000]}")
+    jsonl_report = extract_json_from_jsonl(stripped)
+    if jsonl_report:
+        return jsonl_report
+    raise SystemExit(f"review engine returned unexpected JSON shape:\n{json.dumps(parsed)[:2000]}")
+
+
+def extract_json_from_jsonl(text: str) -> dict[str, Any] | None:
+    candidates: list[str | dict[str, Any]] = []
+    for line in text.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            event = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(event, dict):
+            continue
+        part = event.get("part")
+        if isinstance(part, dict) and isinstance(part.get("text"), str):
+            candidates.append(part["text"])
+        data = event.get("data")
+        if isinstance(data, dict) and isinstance(data.get("content"), str):
+            candidates.append(data["content"])
+        if isinstance(event.get("result"), str):
+            candidates.append(event["result"])
+        if isinstance(event.get("structured_output"), dict):
+            candidates.append(event["structured_output"])
+    for candidate in reversed(candidates):
+        if isinstance(candidate, dict):
+            if "findings" in candidate:
+                return candidate
+            continue
+        parsed = parse_json_candidate(candidate)
+        if isinstance(parsed, dict) and "findings" in parsed:
+            return parsed
+    return None
+
+
+def parse_json_candidate(text: str) -> Any | None:
+    stripped = text.strip()
+    if stripped.startswith("```"):
+        lines = stripped.splitlines()
+        if lines and lines[0].startswith("```") and lines[-1].strip() == "```":
+            stripped = "\n".join(lines[1:-1]).strip()
+    try:
+        parsed = json.loads(stripped)
+    except json.JSONDecodeError:
+        return None
+    if isinstance(parsed, str) and parsed != text:
+        nested = parse_json_candidate(parsed)
+        return nested if nested is not None else parsed
+    return parsed
+
+
+def validate_report(report: dict[str, Any], repo: Path, changed_paths: set[str], required: list[str]) -> None:
+    allowed_top = {"findings", "overall_correctness", "overall_explanation", "overall_confidence"}
+    extra_top = set(report) - allowed_top
+    if extra_top:
+        raise SystemExit(f"review JSON has unexpected top-level keys: {sorted(extra_top)}")
+    for key in SCHEMA["required"]:
+        if key not in report:
+            raise SystemExit(f"review JSON missing required key: {key}")
+    if not isinstance(report["findings"], list):
+        raise SystemExit("review JSON findings must be an array")
+    if report.get("overall_correctness") not in {"patch is correct", "patch is incorrect"}:
+        raise SystemExit(f"review JSON has invalid overall_correctness: {report.get('overall_correctness')}")
+    if not isinstance(report.get("overall_explanation"), str) or not report["overall_explanation"]:
+        raise SystemExit("review JSON overall_explanation must be a non-empty string")
+    if len(report["overall_explanation"]) > 3000:
+        raise SystemExit("review JSON overall_explanation is too long")
+    if not number_in_range(report.get("overall_confidence")):
+        raise SystemExit("review JSON overall_confidence must be numeric")
+    finding_text = ""
+    kept_findings: list[dict[str, Any]] = []
+    ignored_findings: list[tuple[int, dict[str, Any], str, int]] = []
+    for index, finding in enumerate(report["findings"]):
+        if not isinstance(finding, dict):
+            raise SystemExit(f"finding {index} must be an object")
+        allowed_finding = {"title", "body", "priority", "confidence", "category", "code_location"}
+        extra_finding = set(finding) - allowed_finding
+        if extra_finding:
+            raise SystemExit(f"finding {index} has unexpected keys: {sorted(extra_finding)}")
+        for key in allowed_finding:
+            if key not in finding:
+                raise SystemExit(f"finding {index} missing required key: {key}")
+        title = finding.get("title")
+        if not isinstance(title, str) or not title or len(title) > 140:
+            raise SystemExit(f"finding {index} has invalid title")
+        body = finding.get("body")
+        if not isinstance(body, str) or not body or len(body) > 2000:
+            raise SystemExit(f"finding {index} has invalid body")
+        priority = finding.get("priority")
+        if priority not in {"P0", "P1", "P2", "P3"}:
+            raise SystemExit(f"finding {index} has invalid priority: {priority}")
+        if not number_in_range(finding.get("confidence")):
+            raise SystemExit(f"finding {index} has invalid confidence")
+        category = finding.get("category")
+        if category not in {"bug", "security", "regression", "test_gap", "maintainability"}:
+            raise SystemExit(f"finding {index} has invalid category: {category}")
+        location = finding.get("code_location")
+        if not isinstance(location, dict):
+            raise SystemExit(f"finding {index} missing code_location")
+        rel = str(location.get("file_path", "")).strip()
+        line = location.get("line")
+        if not rel or not isinstance(line, int) or line < 1:
+            raise SystemExit(f"finding {index} has invalid location: {location}")
+        if Path(rel).is_absolute() or ".." in Path(rel).parts:
+            raise SystemExit(f"finding {index} uses invalid file path: {rel}")
+        if rel not in changed_paths:
+            ignored_findings.append((index, finding, rel, line))
+            continue
+        kept_findings.append(finding)
+        finding_text += "\n" + json.dumps(finding, sort_keys=True)
+    if ignored_findings:
+        for index, finding, rel, line in ignored_findings:
+            title = finding.get("title", "<untitled>")
+            print(
+                f"autoreview ignored out-of-scope finding {index}: {title} ({rel}:{line})",
+                file=sys.stderr,
+            )
+            print(bounded_field(str(finding.get("body", "")), 500), file=sys.stderr)
+        report["findings"] = kept_findings
+        if not kept_findings and report["overall_correctness"] == "patch is incorrect":
+            note = f"Ignored {len(ignored_findings)} out-of-scope finding(s) outside the reviewed change."
+            explanation = report["overall_explanation"].rstrip()
+            report["overall_correctness"] = "patch is correct"
+            report["overall_explanation"] = bounded_field(f"{explanation}\n\n{note}", 3000)
+    haystack = finding_text.lower()
+    for needle in required:
+        if needle.lower() not in haystack:
+            raise SystemExit(f"required finding text not found: {needle}")
+
+
+def number_in_range(value: Any) -> bool:
+    return isinstance(value, (int, float)) and not isinstance(value, bool) and 0 <= value <= 1
+
+
+def print_report(report: dict[str, Any], *, label: str = "autoreview") -> None:
+    findings = report["findings"]
+    if findings:
+        print(f"{label} findings: {len(findings)}")
+    elif report["overall_correctness"] == "patch is incorrect":
+        print(f"{label} verdict: patch is incorrect without discrete findings")
+    else:
+        print(f"{label} clean: no accepted/actionable findings reported")
+    for finding in findings:
+        loc = finding["code_location"]
+        print(f"[{finding['priority']}] {finding['title']}")
+        print(f"{loc['file_path']}:{loc['line']}")
+        print(f"{finding['body']}")
+        print()
+    print(f"overall: {report['overall_correctness']} ({report['overall_confidence']})")
+    print(report["overall_explanation"])
+
+
+def start_parallel_tests(command: str, repo: Path) -> tuple[subprocess.Popen, float]:
+    print(f"tests: {command}")
+    return subprocess.Popen(command, cwd=repo, shell=True), time.time()
+
+
+def finish_parallel_tests(proc: subprocess.Popen, started: float) -> int:
+    proc.wait()
+    print(f"tests exit: {proc.returncode} after {int(time.time() - started)}s")
+    return int(proc.returncode or 0)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Bundle-driven AI code review.")
+    parser.add_argument("--mode", choices=["auto", "local", "branch", "commit"], default="auto")
+    parser.add_argument("--base")
+    parser.add_argument("--commit", default="HEAD")
+    parser.add_argument("--engine", choices=ENGINES, default=os.environ.get("AUTOREVIEW_ENGINE", "codex"))
+    parser.add_argument("--reviewers", help="Comma-separated review panel, e.g. codex,claude or codex:gpt-5:high.")
+    parser.add_argument("--panel", action="store_true", help="Run a Codex/Claude review panel unless --engine changes the first reviewer.")
+    parser.add_argument("--model", action="append", help="Model for all reviewers or engine=model. Repeatable.")
+    parser.add_argument("--thinking", action="append", help="Thinking/effort for all reviewers or engine=level. Repeatable. Codex: low, medium, high, xhigh. Claude: low, medium, high, xhigh, max.")
+    parser.add_argument("--allow-partial-panel", action="store_true", help="Continue panel output when one reviewer fails.")
+    parser.add_argument("--codex-bin", default=os.environ.get("CODEX_BIN", "codex"))
+    parser.add_argument("--claude-bin", default=os.environ.get("CLAUDE_BIN", "claude"))
+    parser.add_argument("--droid-bin", default=os.environ.get("DROID_BIN", "droid"))
+    parser.add_argument("--copilot-bin", default=os.environ.get("COPILOT_BIN", "copilot"))
+    parser.add_argument("--no-tools", dest="tools", action="store_false", default=True, help="Disable tools for engines that support it. Codex and copilot reject no-tools review.")
+    parser.add_argument("--no-web-search", dest="web_search", action="store_false", default=True)
+    parser.add_argument(
+        "--claude-allowed-tools",
+        default=os.environ.get(
+            "AUTOREVIEW_CLAUDE_TOOLS",
+            "Read,Grep,Glob,WebSearch,WebFetch",
+        ),
+    )
+    parser.add_argument("--prompt", action="append", help="Additional review instruction text.")
+    parser.add_argument("--prompt-file", action="append", help="Additional review instruction file.")
+    parser.add_argument("--dataset", action="append", help="Extra evidence file to include in the review bundle.")
+    parser.add_argument("--output", help="Write human output to a file as well as stdout.")
+    parser.add_argument("--json-output", help="Write validated structured review JSON.")
+    parser.add_argument(
+        "--stream-engine-output",
+        action="store_true",
+        default=os.environ.get("AUTOREVIEW_STREAM_ENGINE_OUTPUT") == "1",
+        help="Stream review engine output while preserving buffered output for validation. Codex output is filtered to hide tool/file chatter.",
+    )
+    parser.add_argument("--parallel-tests", help="Run a test command concurrently with review; failure fails the helper.")
+    parser.add_argument("--require-finding", action="append", default=[], help="Require finding text to contain this substring.")
+    parser.add_argument("--expect-findings", action="store_true", help="Treat findings as success; for harness acceptance tests.")
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args()
+    if args.engine not in ENGINES:
+        raise SystemExit(f"invalid --engine/AUTOREVIEW_ENGINE: {args.engine}")
+    return args
+
+
+def run_engine(args: argparse.Namespace, repo: Path, prompt: str) -> str:
+    if args.engine == "codex":
+        return run_codex(args, repo, prompt)
+    if args.engine == "claude":
+        return run_claude(args, repo, prompt)
+    if args.engine == "droid":
+        return run_droid(args, repo, prompt)
+    if args.engine == "copilot":
+        return run_copilot(args, repo, prompt)
+    raise SystemExit(f"unsupported engine: {args.engine}")
+
+
+def parse_keyed_options(values: list[str] | None, option: str) -> tuple[str | None, dict[str, str]]:
+    global_value: str | None = None
+    per_engine: dict[str, str] = {}
+    for raw in values or []:
+        value = raw.strip()
+        if not value:
+            raise SystemExit(f"--{option} cannot be empty")
+        if "=" in value:
+            engine, engine_value = value.split("=", 1)
+            engine = engine.strip()
+            engine_value = engine_value.strip()
+            if engine not in ENGINES:
+                raise SystemExit(f"--{option} uses unknown engine: {engine}")
+            if not engine_value:
+                raise SystemExit(f"--{option} for {engine} cannot be empty")
+            if engine in per_engine:
+                raise SystemExit(f"--{option} specified more than once for {engine}")
+            per_engine[engine] = engine_value
+        else:
+            if global_value is not None:
+                raise SystemExit(f"--{option} global value specified more than once")
+            global_value = value
+    return global_value, per_engine
+
+
+def parse_reviewer_token(token: str) -> tuple[str, str | None, str | None]:
+    parts = [part.strip() for part in token.split(":")]
+    if len(parts) > 3 or not parts[0]:
+        raise SystemExit(f"invalid reviewer spec: {token}")
+    engine = parts[0]
+    if engine not in ENGINES:
+        raise SystemExit(f"unknown reviewer engine: {engine}")
+    model = parts[1] if len(parts) >= 2 and parts[1] else None
+    thinking = parts[2] if len(parts) == 3 and parts[2] else None
+    return engine, model, thinking
+
+
+def reviewer_args(args: argparse.Namespace) -> list[argparse.Namespace]:
+    global_model, model_by_engine = parse_keyed_options(args.model, "model")
+    global_thinking, thinking_by_engine = parse_keyed_options(args.thinking, "thinking")
+    reviewers: list[tuple[str, str | None, str | None]] = []
+    if args.reviewers:
+        tokens = [token.strip() for token in args.reviewers.split(",") if token.strip()]
+        if len(tokens) == 1 and tokens[0] == "all":
+            tokens = list(ENGINES)
+        reviewers = [parse_reviewer_token(token) for token in tokens]
+    elif args.panel:
+        engines = [args.engine]
+        for engine in ("codex", "claude"):
+            if engine not in engines:
+                engines.append(engine)
+        reviewers = [(engine, None, None) for engine in engines]
+    else:
+        reviewers = [(args.engine, None, None)]
+
+    seen: set[str] = set()
+    result: list[argparse.Namespace] = []
+    for engine, inline_model, inline_thinking in reviewers:
+        if engine in seen:
+            raise SystemExit(f"reviewer specified more than once: {engine}")
+        seen.add(engine)
+        model = inline_model or model_by_engine.get(engine) or global_model
+        thinking = inline_thinking or thinking_by_engine.get(engine) or global_thinking
+        if thinking and thinking not in THINKING_LEVELS_BY_ENGINE[engine]:
+            valid = ", ".join(sorted(THINKING_LEVELS_BY_ENGINE[engine])) or "none"
+            raise SystemExit(f"invalid thinking level for {engine}: {thinking} (valid: {valid})")
+        clone = copy.copy(args)
+        clone.engine = engine
+        clone.model = model
+        clone.thinking = thinking
+        result.append(clone)
+    return result
+
+
+def reviewer_label(args: argparse.Namespace) -> str:
+    parts = [args.engine]
+    if args.model:
+        parts.append(f"model={args.model}")
+    if args.thinking:
+        parts.append(f"thinking={args.thinking}")
+    return " ".join(parts)
+
+
+def run_reviewer(args: argparse.Namespace, repo: Path, prompt: str, changed_paths: set[str], required: list[str]) -> dict[str, Any]:
+    raw = run_engine(args, repo, prompt)
+    report = extract_json(raw)
+    validate_report(report, repo, changed_paths, required)
+    return report
+
+
+def merge_panel_reports(reports: list[tuple[str, dict[str, Any]]]) -> dict[str, Any]:
+    findings: list[dict[str, Any]] = []
+    seen: set[tuple[str, int, str, str]] = set()
+    for label, report in reports:
+        for finding in report["findings"]:
+            location = finding["code_location"]
+            key = (
+                location["file_path"],
+                location["line"],
+                finding["category"],
+                " ".join(finding["title"].lower().split()),
+            )
+            if key in seen:
+                continue
+            seen.add(key)
+            merged = copy.deepcopy(finding)
+            merged["body"] = bounded_field(f"Reviewer: {label}\n\n{merged['body']}", 2000)
+            findings.append(merged)
+    incorrect = bool(findings) or any(report["overall_correctness"] == "patch is incorrect" for _, report in reports)
+    summary = ", ".join(f"{label}: {len(report['findings'])} finding(s)" for label, report in reports)
+    return {
+        "findings": findings,
+        "overall_correctness": "patch is incorrect" if incorrect else "patch is correct",
+        "overall_explanation": f"Panel review complete. {summary}.",
+        "overall_confidence": max((report["overall_confidence"] for _, report in reports), default=0.5),
+    }
+
+
+def run_panel(args: argparse.Namespace, reviewers: list[argparse.Namespace], repo: Path, prompt: str, changed_paths: set[str]) -> dict[str, Any]:
+    reports: list[tuple[str, dict[str, Any]]] = []
+    failures: list[str] = []
+    with concurrent.futures.ThreadPoolExecutor(max_workers=len(reviewers)) as executor:
+        future_by_label = {
+            executor.submit(run_reviewer, reviewer, repo, prompt, changed_paths, []): reviewer_label(reviewer)
+            for reviewer in reviewers
+        }
+        for future in concurrent.futures.as_completed(future_by_label):
+            label = future_by_label[future]
+            try:
+                reports.append((label, future.result()))
+            except SystemExit as exc:
+                failures.append(f"{label}: {exc}")
+            except Exception as exc:
+                failures.append(f"{label}: {exc}")
+    if failures and not args.allow_partial_panel:
+        raise SystemExit("autoreview panel failed\n" + "\n".join(failures))
+    if failures:
+        for failure in failures:
+            print(f"panel reviewer failed: {failure}")
+    if not reports:
+        raise SystemExit("autoreview panel produced no reports")
+    reports.sort(key=lambda item: item[0])
+    report = merge_panel_reports(reports)
+    validate_report(report, repo, changed_paths, args.require_finding)
+    return report
+
+
+def main() -> int:
+    args = parse_args()
+    reviewers = reviewer_args(args)
+    repo = repo_root()
+    target, target_ref = choose_target(repo, args.mode, args.base)
+    print(f"autoreview target: {target}")
+    print(f"branch: {current_branch(repo)}")
+    if len(reviewers) == 1 and not args.reviewers and not args.panel:
+        print(f"engine: {reviewers[0].engine}")
+        if reviewers[0].model:
+            print(f"model: {reviewers[0].model}")
+        if reviewers[0].thinking:
+            print(f"thinking: {reviewers[0].thinking}")
+    else:
+        print(f"reviewers: {', '.join(reviewer_label(reviewer) for reviewer in reviewers)}")
+    print(f"tools: {'on' if args.tools else 'off'}")
+    print(f"web_search: {'on' if args.web_search else 'off'}")
+    display_ref = args.commit if target == "commit" else target_ref
+    if display_ref:
+        print(f"ref: {display_ref}")
+    if args.dry_run:
+        return 0
+
+    if target == "local":
+        bundle = local_bundle(repo)
+    elif target == "branch":
+        assert target_ref
+        bundle = branch_bundle(repo, target_ref)
+    else:
+        bundle = commit_bundle(repo, args.commit)
+        target_ref = args.commit
+    prompt = build_prompt(repo, target, target_ref, bundle, load_extra_prompt(args), load_datasets(args))
+    changed_paths = review_paths(repo, target, target_ref, args.commit)
+    print(f"bundle: {len(prompt)} chars")
+
+    tests_proc: tuple[subprocess.Popen, float] | None = None
+    if args.parallel_tests:
+        tests_proc = start_parallel_tests(args.parallel_tests, repo)
+    try:
+        if len(reviewers) == 1:
+            report = run_reviewer(reviewers[0], repo, prompt, changed_paths, args.require_finding)
+            label = "autoreview"
+        else:
+            report = run_panel(args, reviewers, repo, prompt, changed_paths)
+            label = "autoreview panel"
+        if args.json_output:
+            Path(args.json_output).write_text(json.dumps(report, indent=2) + "\n")
+
+        if args.output:
+            original_stdout = sys.stdout
+            with Path(args.output).open("w") as handle:
+                sys.stdout = Tee(original_stdout, handle)
+                print_report(report, label=label)
+                sys.stdout = original_stdout
+        else:
+            print_report(report, label=label)
+    finally:
+        tests_status = finish_parallel_tests(*tests_proc) if tests_proc else 0
+
+    has_findings = bool(report["findings"])
+    overall_incorrect = report["overall_correctness"] == "patch is incorrect"
+    if tests_status != 0:
+        return 1
+    if args.expect_findings:
+        return 0 if has_findings else 1
+    return 1 if has_findings or overall_incorrect else 0
+
+
+class Tee:
+    def __init__(self, *streams: Any) -> None:
+        self.streams = streams
+
+    def write(self, data: str) -> None:
+        for stream in self.streams:
+            stream.write(data)
+
+    def flush(self) -> None:
+        for stream in self.streams:
+            stream.flush()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/skills/autoreview/scripts/test-review-harness
+++ b/.agents/skills/autoreview/scripts/test-review-harness
@@ -1,0 +1,176 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: test-review-harness [--fixture malicious|benign] [--engine codex|claude|droid|copilot]...
+
+Creates a temporary git repo with either a deliberately unsafe patch or a
+security-sensitive-but-safe patch, then verifies each selected engine through
+autoreview.
+Default engines: codex, claude.
+EOF
+}
+
+engines=()
+fixture=malicious
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --fixture)
+      fixture=${2:-}
+      shift 2
+      ;;
+    --engine)
+      engines+=("${2:-}")
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+case "$fixture" in
+  malicious|benign) ;;
+  *)
+    usage >&2
+    exit 2
+    ;;
+esac
+
+if [[ ${#engines[@]} -eq 0 ]]; then
+  engines=(codex claude)
+fi
+
+script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+repo=$(mktemp -d "${TMPDIR:-/tmp}/autoreview-fixture.XXXXXX")
+trap 'rm -rf "$repo"' EXIT
+
+cd "$repo"
+git init --quiet
+git config user.name "Review Fixture"
+git config user.email "review-fixture@example.com"
+
+if [[ "$fixture" == malicious ]]; then
+  cat > app.js <<'EOF'
+export function uploadPath(name) {
+  return `uploads/${name.replaceAll("/", "")}`;
+}
+
+export function publicUser(user) {
+  return { id: user.id, name: user.name };
+}
+EOF
+else
+  cat > app.js <<'EOF'
+import path from "node:path";
+
+const uploadsRoot = path.resolve("uploads");
+
+function safeChildPath(root, name) {
+  if (name.includes("/") || name.includes("\\") || name.includes("\0")) {
+    throw new Error("invalid child name");
+  }
+  const resolved = path.resolve(root, name);
+  if (!resolved.startsWith(root + path.sep)) throw new Error("path escaped root");
+  return resolved;
+}
+
+export function uploadPath(name) {
+  return safeChildPath(uploadsRoot, name);
+}
+
+export function publicUser(user) {
+  return { id: user.id, name: user.name };
+}
+EOF
+fi
+
+git add app.js
+git commit --quiet -m "initial safe version"
+
+if [[ "$fixture" == malicious ]]; then
+  cat > app.js <<'EOF'
+import { execSync } from "node:child_process";
+
+export function uploadPath(name) {
+  return `uploads/${name}`;
+}
+
+export function deleteUpload(name) {
+  return execSync(`rm -rf uploads/${name}`);
+}
+
+export function publicUser(user) {
+  return { id: user.id, name: user.name, password: user.password };
+}
+EOF
+else
+  cat > app.js <<'EOF'
+import { execFile } from "node:child_process";
+import path from "node:path";
+import { promisify } from "node:util";
+
+const uploadsRoot = path.resolve("uploads");
+const reposRoot = path.resolve("repos");
+const execFileAsync = promisify(execFile);
+
+function safeChildPath(root, name) {
+  if (name.includes("/") || name.includes("\\") || name.includes("\0")) {
+    throw new Error("invalid child name");
+  }
+  const resolved = path.resolve(root, name);
+  if (!resolved.startsWith(root + path.sep)) throw new Error("path escaped root");
+  return resolved;
+}
+
+function repoChildPath(root, name) {
+  if (!/^[A-Za-z0-9._-]+$/.test(name)) throw new Error("invalid repo name");
+  return safeChildPath(root, name);
+}
+
+export function uploadPath(name) {
+  return safeChildPath(uploadsRoot, name);
+}
+
+export async function repoStatus(repoName) {
+  const { stdout } = await execFileAsync("git", ["status", "--short"], {
+    cwd: repoChildPath(reposRoot, repoName),
+    encoding: "utf8",
+    maxBuffer: 16 * 1024 * 1024,
+  });
+  return stdout;
+}
+
+export function publicUser(user) {
+  return { id: user.id, name: user.name };
+}
+
+export function accountSettingsForOwner(user, requesterId) {
+  if (String(requesterId) !== String(user.id)) throw new Error("forbidden");
+  return { id: user.id, hasPassword: Boolean(user.passwordHash) };
+}
+EOF
+fi
+
+for engine in "${engines[@]}"; do
+  echo "== $engine =="
+  if [[ "$fixture" == malicious ]]; then
+    "$script_dir/autoreview" \
+      --mode local \
+      --engine "$engine" \
+      --prompt "This is an acceptance test fixture. The changed app.js patch contains real security bugs. Review normally and report only actionable defects from the patch." \
+      --require-finding "command" \
+      --expect-findings
+  else
+    "$script_dir/autoreview" \
+      --mode local \
+      --engine "$engine" \
+      --prompt "Security calibration fixture: this patch intentionally uses filesystem paths, async execFile, and owner-gated password-adjacent state safely. Do not flag legitimate shell/filesystem/auth-adjacent functionality unless there is a concrete exploitable risk in the diff."
+  fi
+done

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Changes
 
-- Update `crawlkit` to v0.7.0.
+- Update `crawlkit` to v0.8.0.
 - Add read-only Cloudflare remote archive scaffolding with `[remote]` config,
   `subscribe-cloud`, GitHub-backed `remote login` with OAuth or token-env
   bootstrap, `remote status`, `remote archives`, and cloud-mode `status --json`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 ### Changes
 
 - Update `crawlkit` to v0.7.0.
+- Add read-only Cloudflare remote archive scaffolding with `[remote]` config,
+  `subscribe-cloud`, `remote status`, `remote archives`, and cloud-mode
+  `status --json` output that does not open or create a local SQLite database.
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@
 - Add read-only Cloudflare remote archive scaffolding with `[remote]` config,
   `subscribe-cloud`, `remote status`, `remote archives`, and cloud-mode
   `status --json` output that does not open or create a local SQLite database.
+- Route cloud-mode `search` and filtered `messages` reads to Worker named
+  queries so subscribers can inspect live D1 data without local SQLite.
+- Add `discrawl cloud publish` to export non-DM local SQLite rows into the
+  Cloudflare remote archive ingest API without changing Git snapshot
+  publishing.
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,9 @@
 
 - Update `crawlkit` to v0.7.0.
 - Add read-only Cloudflare remote archive scaffolding with `[remote]` config,
-  `subscribe-cloud`, GitHub-backed `remote login`, `remote status`,
-  `remote archives`, and cloud-mode `status --json` output that does not open
-  or create a local SQLite database.
+  `subscribe-cloud`, GitHub-backed `remote login` with OAuth or token-env
+  bootstrap, `remote status`, `remote archives`, and cloud-mode `status --json`
+  output that does not open or create a local SQLite database.
 - Route cloud-mode `search` and filtered `messages` reads to Worker named
   queries so subscribers can inspect live D1 data without local SQLite.
 - Add `discrawl cloud publish` to export non-DM local SQLite rows into the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,9 @@
 
 - Update `crawlkit` to v0.7.0.
 - Add read-only Cloudflare remote archive scaffolding with `[remote]` config,
-  `subscribe-cloud`, `remote status`, `remote archives`, and cloud-mode
-  `status --json` output that does not open or create a local SQLite database.
+  `subscribe-cloud`, GitHub-backed `remote login`, `remote status`,
+  `remote archives`, and cloud-mode `status --json` output that does not open
+  or create a local SQLite database.
 - Route cloud-mode `search` and filtered `messages` reads to Worker named
   queries so subscribers can inspect live D1 data without local SQLite.
 - Add `discrawl cloud publish` to export non-DM local SQLite rows into the

--- a/README.md
+++ b/README.md
@@ -537,6 +537,7 @@ SQLite import:
 
 ```bash
 discrawl subscribe-cloud --endpoint https://crawl.example.workers.dev --archive openclaw/discord
+discrawl remote login --endpoint https://crawl.example.workers.dev --json
 discrawl status --json
 discrawl search "release notes" --json
 discrawl messages --channel 1458141495701012561 --json
@@ -547,6 +548,8 @@ discrawl whoami
 `subscribe-cloud` writes `[remote]` config and sets `discord.token_source =
 "none"`. It does not clone a Git repo, import a snapshot, or create the local
 SQLite database.
+`remote login` starts the Worker GitHub OAuth flow, verifies org/team
+membership server-side, and stores the signed bearer token in the OS keyring.
 
 Publishers can send the current non-DM SQLite archive into the Worker-backed
 D1 archive:

--- a/README.md
+++ b/README.md
@@ -550,6 +550,9 @@ discrawl whoami
 SQLite database.
 `remote login` starts the Worker GitHub OAuth flow, verifies org/team
 membership server-side, and stores the signed bearer token in the OS keyring.
+Use `remote login --github-token-env GITHUB_TOKEN` for non-browser bootstrap;
+the Worker verifies that GitHub token against the same org/team policy and
+stores only the returned remote session token locally.
 
 Publishers can send the current non-DM SQLite archive into the Worker-backed
 D1 archive:

--- a/README.md
+++ b/README.md
@@ -538,14 +538,25 @@ SQLite import:
 ```bash
 discrawl subscribe-cloud --endpoint https://crawl.example.workers.dev --archive openclaw/discord
 discrawl status --json
+discrawl search "release notes" --json
+discrawl messages --channel 1458141495701012561 --json
 discrawl remote archives
 discrawl whoami
 ```
 
 `subscribe-cloud` writes `[remote]` config and sets `discord.token_source =
 "none"`. It does not clone a Git repo, import a snapshot, or create the local
-SQLite database. This first cloud path is read-only scaffolding; Git
-`publish`, `subscribe`, and `update` keep their existing behavior.
+SQLite database.
+
+Publishers can send the current non-DM SQLite archive into the Worker-backed
+D1 archive:
+
+```bash
+discrawl cloud publish --remote https://crawl.example.workers.dev --archive openclaw/discord
+```
+
+`cloud publish` excludes `@me`/DM rows and leaves existing Git-backed
+`publish`, `subscribe`, and `update` behavior unchanged.
 
 Configure freshness:
 

--- a/README.md
+++ b/README.md
@@ -548,6 +548,9 @@ discrawl whoami
 `subscribe-cloud` writes `[remote]` config and sets `discord.token_source =
 "none"`. It does not clone a Git repo, import a snapshot, or create the local
 SQLite database.
+The remote service is deployed separately from discrawl in `openclaw/crawl-remote`
+with Wrangler. discrawl only stores the Worker endpoint/archive in config and
+calls that service.
 `remote login` starts the Worker GitHub OAuth flow, verifies org/team
 membership server-side, and stores the signed bearer token in the OS keyring.
 Use `remote login --github-token-env GITHUB_TOKEN` for non-browser bootstrap;

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # discrawl 🛰️ — Mirror Discord into SQLite; search server history locally
 
-`discrawl` mirrors Discord guild data into local SQLite so you can search, inspect, and query server history without depending on Discord search. It can also import classifiable Discord Desktop cache messages for local DM recovery/search without using a user token. Teams can publish the guild archive as a private Git snapshot repo, so readers get fresh org memory without Discord bot credentials.
+`discrawl` mirrors Discord guild data into local SQLite so you can search, inspect, and query server history without depending on Discord search. It can also import classifiable Discord Desktop cache messages for local DM recovery/search without using a user token. Teams can publish the guild archive as a private Git snapshot repo, so readers get fresh org memory without Discord bot credentials. Read-only Cloudflare remote archives can be configured without creating a local SQLite database.
 
 There are two local archive sources:
 
@@ -26,6 +26,8 @@ Wiretap DMs stay local and are never exported to the Git-backed snapshot mirror.
 - browses stored messages and local DMs in a terminal archive UI
 - exposes `metadata --json`, `status --json`, and `doctor --json` for local
   launchers, automation, and CI
+- reports Worker-fronted cloud archive status in read-only mode without
+  touching local SQLite
 - supports Git-only read mode with no Discord credentials on reader machines
 - generates backup README activity reports, with optional AI-written field notes
 - exposes read-only SQL for ad hoc analysis
@@ -530,6 +532,21 @@ discrawl messages --channel general --hours 24
 
 `subscribe` is the Git-only setup path. It writes a config with `discord.token_source = "none"`, imports the snapshot, and does not require a Discord bot token. `sync` and `tail` remain disabled in this mode because they need live Discord access.
 
+Cloud remote subscribers can use a Worker-fronted archive without a local
+SQLite import:
+
+```bash
+discrawl subscribe-cloud --endpoint https://crawl.example.workers.dev --archive openclaw/discord
+discrawl status --json
+discrawl remote archives
+discrawl whoami
+```
+
+`subscribe-cloud` writes `[remote]` config and sets `discord.token_source =
+"none"`. It does not clone a Git repo, import a snapshot, or create the local
+SQLite database. This first cloud path is read-only scaffolding; Git
+`publish`, `subscribe`, and `update` keep their existing behavior.
+
 Configure freshness:
 
 ```bash
@@ -720,6 +737,13 @@ branch = "main"
 auto_update = true
 stale_after = "15m"
 media = true
+
+[remote]
+mode = "local" # use "cloud" for Worker-fronted remote archives
+endpoint = ""
+archive = ""
+token_env = "DISCRAWL_REMOTE_TOKEN"
+stale_after = ""
 ```
 
 The value above is an example. `init` writes an auto-sized default based on the host: `min(32, max(8, GOMAXPROCS*2))`.
@@ -730,6 +754,7 @@ Config override rules:
 - `DISCRAWL_CONFIG` overrides the default config path
 - `discord.token_source = "none"` disables live Discord access for Git-only readers
 - `discord.token_source = "keyring"` skips env lookup and reads only the configured OS keyring item
+- `remote.mode = "cloud"` makes `status --json` and `remote ...` read the configured Worker archive without opening SQLite
 - `DISCRAWL_NO_AUTO_UPDATE=1` disables Git snapshot auto-update for read commands in one process, useful for report jobs that already imported a fresh backup.
 
 ## Embeddings

--- a/docs/README.md
+++ b/docs/README.md
@@ -16,10 +16,10 @@ Mirror Discord guilds into local SQLite. Search server history without depending
 
 - **New here?** Read [Install](install.html) and run `discrawl init`.
 - **Already have a bot?** Jump to [`sync`](commands/sync.html) and [`search`](commands/search.html).
-- **Just want to read a shared archive?** Use [`subscribe`](commands/subscribe.html) - no token needed.
+- **Just want to read a shared archive?** Use [`subscribe`](commands/subscribe.html) for Git snapshots, or [`subscribe-cloud`](commands/subscribe-cloud.html) for a Worker-fronted archive - no Discord token needed.
 - **Need DM search?** [`wiretap`](commands/wiretap.html) imports local Discord Desktop cache.
 - **Want semantic search?** Configure [Embeddings](guides/embeddings.html), then run [`embed`](commands/embed.html).
-- **Wiring an agent or launcher?** `discrawl metadata --json`, `discrawl status --json`, and `discrawl doctor --json` expose the read-only crawlkit control surface.
+- **Wiring an agent or launcher?** `discrawl metadata --json`, `discrawl status --json`, `discrawl remote status`, and `discrawl doctor --json` expose the read-only crawlkit control surface.
 
 ## At a glance
 

--- a/docs/commands/remote.md
+++ b/docs/commands/remote.md
@@ -1,0 +1,29 @@
+# `remote`
+
+Reads the configured Cloudflare remote archive through the Worker API.
+
+## Usage
+
+```bash
+discrawl remote status
+discrawl remote archives
+discrawl remote whoami
+discrawl whoami
+```
+
+## Reports
+
+- `remote status` returns the crawlkit control status for the configured archive
+- `remote archives` lists archives visible to the authenticated identity
+- `remote whoami` and `whoami` report the GitHub/org identity associated with the token
+
+## Notes
+
+Remote commands require `[remote]` config with `mode = "cloud"`, `endpoint`,
+`archive`, and a token in `remote.token_env` (default:
+`DISCRAWL_REMOTE_TOKEN`). They do not open or create the local SQLite archive.
+
+## See also
+
+- [`subscribe-cloud`](subscribe-cloud.html)
+- [`status`](status.html)

--- a/docs/commands/remote.md
+++ b/docs/commands/remote.md
@@ -1,6 +1,9 @@
 # `remote`
 
 Reads the configured Cloudflare remote archive through the Worker API.
+The Worker is deployed separately from discrawl in `openclaw/crawl-remote`
+with Wrangler; discrawl stores an endpoint/archive and never deploys the
+service itself.
 
 ## Usage
 

--- a/docs/commands/status.md
+++ b/docs/commands/status.md
@@ -1,6 +1,7 @@
 # `status`
 
-Shows local archive status.
+Shows local archive status, or remote archive status when `[remote]` is in
+cloud read-only mode.
 
 ## Usage
 
@@ -16,9 +17,11 @@ discrawl status
 - message totals
 - latest archived message time
 - whether the Git share is configured and how stale the local import is
+- remote endpoint/archive metadata when `remote.mode = "cloud"`
 - embeddings status if `[search.embeddings]` is enabled
 
 ## See also
 
 - [`doctor`](doctor.html) - liveness check (config, auth, DB, FTS wiring)
+- [`remote`](remote.html) - direct Cloudflare remote archive checks
 - [`report`](report.html) - Markdown activity block for the shared backup README

--- a/docs/commands/subscribe-cloud.md
+++ b/docs/commands/subscribe-cloud.md
@@ -1,0 +1,34 @@
+# `subscribe-cloud`
+
+Writes a read-only Cloudflare remote archive config. This does not clone a Git
+repo, import a snapshot, or create a local SQLite database.
+
+## Usage
+
+```bash
+discrawl subscribe-cloud --endpoint https://crawl.example.workers.dev --archive openclaw/discord
+discrawl subscribe-cloud --token-env DISCRAWL_REMOTE_TOKEN --endpoint https://crawl.example.workers.dev --archive openclaw/discord
+```
+
+## What it does
+
+- writes `[remote]` with `mode = "cloud"`
+- sets `discord.token_source = "none"` so no Discord bot token is required
+- leaves existing `[share]` Git snapshot settings untouched
+- skips local database creation and snapshot import
+
+## After subscribing
+
+```bash
+export DISCRAWL_REMOTE_TOKEN="..."
+discrawl status --json
+discrawl remote status
+discrawl remote archives
+discrawl whoami
+```
+
+## See also
+
+- [`remote`](remote.html)
+- [`status`](status.html)
+- [`subscribe`](subscribe.html)

--- a/docs/commands/subscribe.md
+++ b/docs/commands/subscribe.md
@@ -49,5 +49,6 @@ discrawl status
 ## See also
 
 - [Git snapshots guide](../guides/git-snapshots.html)
+- [`subscribe-cloud`](subscribe-cloud.html)
 - [`publish`](publish.html)
 - [`update`](update.html)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -92,6 +92,13 @@ media = true
 public_only = false
 include_channel_ids = []
 exclude_channel_ids = []
+
+[remote]
+mode = "local" # use "cloud" for Worker-fronted remote archives
+endpoint = ""
+archive = ""
+token_env = "DISCRAWL_REMOTE_TOKEN"
+stale_after = ""
 ```
 
 `concurrency` is auto-sized at `init` to `min(32, max(8, GOMAXPROCS*2))`.
@@ -113,6 +120,7 @@ Set `discord.token_source = "keyring"` if you want to require keyring lookup and
 - `DISCRAWL_CONFIG=<path>` overrides the default config path
 - `discord.token_source = "none"` disables live Discord access for Git-only readers
 - `discord.token_source = "keyring"` skips env lookup
+- `remote.mode = "cloud"` makes `status --json` and `remote ...` read the configured Worker archive without opening SQLite
 - `DISCRAWL_NO_AUTO_UPDATE=1` disables Git snapshot auto-update for read commands in one process
 
 ## Notes

--- a/docs/install.md
+++ b/docs/install.md
@@ -68,6 +68,16 @@ discrawl messages --channel general --hours 24
 imports the snapshot. Read commands auto-refresh when the local snapshot is
 older than `15m`.
 
+For Worker-fronted archives that should stay fully remote:
+
+```bash
+discrawl subscribe-cloud --endpoint https://crawl.example.workers.dev --archive openclaw/discord
+discrawl status --json
+```
+
+This writes read-only `[remote]` config and does not create a local SQLite
+database.
+
 ## Default runtime paths
 
 Discrawl follows the OS storage convention instead of writing a new top-level directory in your

--- a/go.mod
+++ b/go.mod
@@ -44,7 +44,7 @@ require (
 	github.com/muesli/cancelreader v0.2.2 // indirect
 	github.com/muesli/termenv v0.16.0 // indirect
 	github.com/ncruces/go-strftime v1.0.0 // indirect
-	github.com/openclaw/crawlkit v0.7.0
+	github.com/openclaw/crawlkit v0.7.1-0.20260527123833-22b471a17caa
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect

--- a/go.mod
+++ b/go.mod
@@ -44,7 +44,7 @@ require (
 	github.com/muesli/cancelreader v0.2.2 // indirect
 	github.com/muesli/termenv v0.16.0 // indirect
 	github.com/ncruces/go-strftime v1.0.0 // indirect
-	github.com/openclaw/crawlkit v0.7.1-0.20260527174716-74916a98ee45
+	github.com/openclaw/crawlkit v0.8.0
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect

--- a/go.mod
+++ b/go.mod
@@ -44,7 +44,7 @@ require (
 	github.com/muesli/cancelreader v0.2.2 // indirect
 	github.com/muesli/termenv v0.16.0 // indirect
 	github.com/ncruces/go-strftime v1.0.0 // indirect
-	github.com/openclaw/crawlkit v0.7.1-0.20260527123833-22b471a17caa
+	github.com/openclaw/crawlkit v0.7.1-0.20260527173115-df4eca58a4c9
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect

--- a/go.mod
+++ b/go.mod
@@ -44,7 +44,7 @@ require (
 	github.com/muesli/cancelreader v0.2.2 // indirect
 	github.com/muesli/termenv v0.16.0 // indirect
 	github.com/ncruces/go-strftime v1.0.0 // indirect
-	github.com/openclaw/crawlkit v0.7.1-0.20260527173115-df4eca58a4c9
+	github.com/openclaw/crawlkit v0.7.1-0.20260527174716-74916a98ee45
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect

--- a/go.sum
+++ b/go.sum
@@ -71,8 +71,8 @@ github.com/muesli/termenv v0.16.0 h1:S5AlUN9dENB57rsbnkPyfdGuWIlkmzJjbFf0Tf5FWUc
 github.com/muesli/termenv v0.16.0/go.mod h1:ZRfOIKPFDYQoDFF4Olj7/QJbW60Ol/kL1pU3VfY/Cnk=
 github.com/ncruces/go-strftime v1.0.0 h1:HMFp8mLCTPp341M/ZnA4qaf7ZlsbTc+miZjCLOFAw7w=
 github.com/ncruces/go-strftime v1.0.0/go.mod h1:Fwc5htZGVVkseilnfgOVb9mKy6w1naJmn9CehxcKcls=
-github.com/openclaw/crawlkit v0.7.1-0.20260527173115-df4eca58a4c9 h1:FbutsmKLVob/J5+4fmHOgvGv4btcxq5E/n5FbWyhgDw=
-github.com/openclaw/crawlkit v0.7.1-0.20260527173115-df4eca58a4c9/go.mod h1:2XkSx3N8yzyjc+Jyf1Zl9VEQVlElh/dzBMW1cRMQQGw=
+github.com/openclaw/crawlkit v0.7.1-0.20260527174716-74916a98ee45 h1:dx8+XyE2JddHEzhhhM7BupViAhzI5Ws4qKvNDegK04g=
+github.com/openclaw/crawlkit v0.7.1-0.20260527174716-74916a98ee45/go.mod h1:2XkSx3N8yzyjc+Jyf1Zl9VEQVlElh/dzBMW1cRMQQGw=
 github.com/pelletier/go-toml/v2 v2.3.1 h1:MYEvvGnQjeNkRF1qUuGolNtNExTDwct51yp7olPtrEc=
 github.com/pelletier/go-toml/v2 v2.3.1/go.mod h1:2gIqNv+qfxSVS7cM2xJQKtLSTLUE9V8t9Stt+h56mCY=
 github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=

--- a/go.sum
+++ b/go.sum
@@ -71,8 +71,8 @@ github.com/muesli/termenv v0.16.0 h1:S5AlUN9dENB57rsbnkPyfdGuWIlkmzJjbFf0Tf5FWUc
 github.com/muesli/termenv v0.16.0/go.mod h1:ZRfOIKPFDYQoDFF4Olj7/QJbW60Ol/kL1pU3VfY/Cnk=
 github.com/ncruces/go-strftime v1.0.0 h1:HMFp8mLCTPp341M/ZnA4qaf7ZlsbTc+miZjCLOFAw7w=
 github.com/ncruces/go-strftime v1.0.0/go.mod h1:Fwc5htZGVVkseilnfgOVb9mKy6w1naJmn9CehxcKcls=
-github.com/openclaw/crawlkit v0.7.1-0.20260527174716-74916a98ee45 h1:dx8+XyE2JddHEzhhhM7BupViAhzI5Ws4qKvNDegK04g=
-github.com/openclaw/crawlkit v0.7.1-0.20260527174716-74916a98ee45/go.mod h1:2XkSx3N8yzyjc+Jyf1Zl9VEQVlElh/dzBMW1cRMQQGw=
+github.com/openclaw/crawlkit v0.8.0 h1:EZEAMy7dI6zVn+AC6lN8GycMY8bV3TF3KnheG55A0uU=
+github.com/openclaw/crawlkit v0.8.0/go.mod h1:2XkSx3N8yzyjc+Jyf1Zl9VEQVlElh/dzBMW1cRMQQGw=
 github.com/pelletier/go-toml/v2 v2.3.1 h1:MYEvvGnQjeNkRF1qUuGolNtNExTDwct51yp7olPtrEc=
 github.com/pelletier/go-toml/v2 v2.3.1/go.mod h1:2gIqNv+qfxSVS7cM2xJQKtLSTLUE9V8t9Stt+h56mCY=
 github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=

--- a/go.sum
+++ b/go.sum
@@ -71,8 +71,8 @@ github.com/muesli/termenv v0.16.0 h1:S5AlUN9dENB57rsbnkPyfdGuWIlkmzJjbFf0Tf5FWUc
 github.com/muesli/termenv v0.16.0/go.mod h1:ZRfOIKPFDYQoDFF4Olj7/QJbW60Ol/kL1pU3VfY/Cnk=
 github.com/ncruces/go-strftime v1.0.0 h1:HMFp8mLCTPp341M/ZnA4qaf7ZlsbTc+miZjCLOFAw7w=
 github.com/ncruces/go-strftime v1.0.0/go.mod h1:Fwc5htZGVVkseilnfgOVb9mKy6w1naJmn9CehxcKcls=
-github.com/openclaw/crawlkit v0.7.1-0.20260527123833-22b471a17caa h1:dzBhxJvNohpS0Eyw0fz6aHXj5kPtbKGtrYMDWopX7uY=
-github.com/openclaw/crawlkit v0.7.1-0.20260527123833-22b471a17caa/go.mod h1:2XkSx3N8yzyjc+Jyf1Zl9VEQVlElh/dzBMW1cRMQQGw=
+github.com/openclaw/crawlkit v0.7.1-0.20260527173115-df4eca58a4c9 h1:FbutsmKLVob/J5+4fmHOgvGv4btcxq5E/n5FbWyhgDw=
+github.com/openclaw/crawlkit v0.7.1-0.20260527173115-df4eca58a4c9/go.mod h1:2XkSx3N8yzyjc+Jyf1Zl9VEQVlElh/dzBMW1cRMQQGw=
 github.com/pelletier/go-toml/v2 v2.3.1 h1:MYEvvGnQjeNkRF1qUuGolNtNExTDwct51yp7olPtrEc=
 github.com/pelletier/go-toml/v2 v2.3.1/go.mod h1:2gIqNv+qfxSVS7cM2xJQKtLSTLUE9V8t9Stt+h56mCY=
 github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=

--- a/go.sum
+++ b/go.sum
@@ -71,8 +71,8 @@ github.com/muesli/termenv v0.16.0 h1:S5AlUN9dENB57rsbnkPyfdGuWIlkmzJjbFf0Tf5FWUc
 github.com/muesli/termenv v0.16.0/go.mod h1:ZRfOIKPFDYQoDFF4Olj7/QJbW60Ol/kL1pU3VfY/Cnk=
 github.com/ncruces/go-strftime v1.0.0 h1:HMFp8mLCTPp341M/ZnA4qaf7ZlsbTc+miZjCLOFAw7w=
 github.com/ncruces/go-strftime v1.0.0/go.mod h1:Fwc5htZGVVkseilnfgOVb9mKy6w1naJmn9CehxcKcls=
-github.com/openclaw/crawlkit v0.7.0 h1:mh8ZDEUP5hOQZcIY2DVo6Chy1SGu/2Re4olCuT/578k=
-github.com/openclaw/crawlkit v0.7.0/go.mod h1:2XkSx3N8yzyjc+Jyf1Zl9VEQVlElh/dzBMW1cRMQQGw=
+github.com/openclaw/crawlkit v0.7.1-0.20260527123833-22b471a17caa h1:dzBhxJvNohpS0Eyw0fz6aHXj5kPtbKGtrYMDWopX7uY=
+github.com/openclaw/crawlkit v0.7.1-0.20260527123833-22b471a17caa/go.mod h1:2XkSx3N8yzyjc+Jyf1Zl9VEQVlElh/dzBMW1cRMQQGw=
 github.com/pelletier/go-toml/v2 v2.3.1 h1:MYEvvGnQjeNkRF1qUuGolNtNExTDwct51yp7olPtrEc=
 github.com/pelletier/go-toml/v2 v2.3.1/go.mod h1:2gIqNv+qfxSVS7cM2xJQKtLSTLUE9V8t9Stt+h56mCY=
 github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=

--- a/internal/cli/admin_commands.go
+++ b/internal/cli/admin_commands.go
@@ -403,6 +403,9 @@ func (r *runtime) runStatus(args []string) error {
 	if *jsonOut {
 		r.json = true
 	}
+	if r.cfg.RemoteCloudReadOnly() {
+		return r.runRemoteStatusOutput()
+	}
 	dbPath, err := config.ExpandPath(r.cfg.DBPath)
 	if err != nil {
 		return configErr(err)

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -218,6 +218,9 @@ func (r *runtime) dispatch(rest []string) error {
 		if hasHelpArg(rest[1:]) {
 			return printCommandUsage(r.stdout, []string{"search"})
 		}
+		if r.configuredForCloudReadOnly() {
+			return r.withConfig(func() error { return r.runSearch(rest[1:]) })
+		}
 		autoShareUpdate := !hasBoolFlag(rest[1:], "--dm")
 		return r.withLocalStoreRead(autoShareUpdate, func() error { return r.runSearch(rest[1:]) })
 	case "tui":
@@ -228,6 +231,9 @@ func (r *runtime) dispatch(rest []string) error {
 	case "messages":
 		if hasHelpArg(rest[1:]) {
 			return printCommandUsage(r.stdout, []string{"messages"})
+		}
+		if r.configuredForCloudReadOnly() {
+			return r.withConfig(func() error { return r.runMessages(rest[1:]) })
 		}
 		if hasBoolFlag(rest[1:], "--sync") && !hasBoolFlag(rest[1:], "--dm") {
 			return r.withServicesAutoLocked(true, true, true, func() error { return r.runMessages(rest[1:]) })
@@ -274,6 +280,8 @@ func (r *runtime) dispatch(rest []string) error {
 		return r.withLocalStoreRead(true, func() error { return r.runReport(rest[1:]) })
 	case "publish":
 		return r.withServicesAutoLocked(false, false, true, func() error { return r.runPublish(rest[1:]) })
+	case "cloud":
+		return r.runCloud(rest[1:])
 	case "subscribe":
 		return r.runSubscribe(rest[1:])
 	case "subscribe-cloud":

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -160,6 +160,7 @@ type runtime struct {
 	lockStarted time.Time
 	openStore   func(context.Context, string) (*store.Store, error)
 	newDiscord  func(config.Config) (discordClient, error)
+	newRemote   func(config.Config) (remoteArchiveClient, error)
 	newSyncer   func(syncer.Client, *store.Store, *slog.Logger) syncService
 	newEmbed    func(config.EmbeddingsConfig) (embed.Provider, error)
 	now         func() time.Time
@@ -265,6 +266,9 @@ func (r *runtime) dispatch(rest []string) error {
 	case "channels":
 		return r.withLocalStoreRead(true, func() error { return r.runChannels(rest[1:]) })
 	case "status":
+		if r.configuredForCloudReadOnly() {
+			return r.withConfig(func() error { return r.runStatus(rest[1:]) })
+		}
 		return r.withLocalStoreReadOnly(func() error { return r.runStatus(rest[1:]) })
 	case "report":
 		return r.withLocalStoreRead(true, func() error { return r.runReport(rest[1:]) })
@@ -272,6 +276,12 @@ func (r *runtime) dispatch(rest []string) error {
 		return r.withServicesAutoLocked(false, false, true, func() error { return r.runPublish(rest[1:]) })
 	case "subscribe":
 		return r.runSubscribe(rest[1:])
+	case "subscribe-cloud":
+		return r.runSubscribeCloud(rest[1:])
+	case "remote":
+		return r.runRemote(rest[1:])
+	case "whoami":
+		return r.withConfig(func() error { return r.runRemoteWhoami(rest[1:]) })
 	case "update":
 		return r.withServicesAutoLocked(false, false, true, func() error { return r.runUpdate(rest[1:]) })
 	case "doctor":
@@ -279,6 +289,26 @@ func (r *runtime) dispatch(rest []string) error {
 	default:
 		return usageErr(fmt.Errorf("unknown command %q", rest[0]))
 	}
+}
+
+func (r *runtime) configuredForCloudReadOnly() bool {
+	cfg, err := config.Load(r.configPath)
+	return err == nil && cfg.RemoteCloudReadOnly()
+}
+
+func (r *runtime) withConfig(fn func() error) error {
+	cfg, err := config.Load(r.configPath)
+	if err != nil {
+		if !errors.Is(err, os.ErrNotExist) {
+			return configErr(err)
+		}
+		cfg = config.Default()
+		if err := cfg.Normalize(); err != nil {
+			return configErr(err)
+		}
+	}
+	r.cfg = cfg
+	return fn()
 }
 
 func (r *runtime) withServices(withDiscord bool, fn func() error) error {

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/bwmarrin/discordgo"
 	"github.com/openclaw/crawlkit/control"
+	crawlremote "github.com/openclaw/crawlkit/remote"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -1108,6 +1109,118 @@ func TestCloudStatusJSONUsesRemoteWithoutLocalDB(t *testing.T) {
 	require.Equal(t, "openclaw/discord", status.Databases[0].Archive)
 	require.Equal(t, int64(42), status.Counts[1].Value)
 	require.Equal(t, []string{"readonly"}, status.Warnings)
+}
+
+func TestCloudSearchAndMessagesUseRemoteWithoutLocalDB(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "discrawl.db")
+	tokenEnv := "DISCRAWL_TEST_REMOTE_TOKEN"
+	t.Setenv(tokenEnv, "test-token")
+	seen := map[string]bool{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		require.Equal(t, http.MethodPost, req.Method)
+		require.Equal(t, "Bearer test-token", req.Header.Get("Authorization"))
+		require.Equal(t, "/v1/apps/discrawl/archives/openclaw%2Fdiscord/query", req.URL.EscapedPath())
+		var body crawlremote.QueryRequest
+		require.NoError(t, json.NewDecoder(req.Body).Decode(&body))
+		seen[body.Name] = true
+		require.Equal(t, "openclaw/discord", body.Archive)
+		w.Header().Set("content-type", "application/json")
+		_ = json.NewEncoder(w).Encode(crawlremote.QueryResult{
+			Values: []map[string]any{{
+				"message_id":      "m1",
+				"guild_id":        "g1",
+				"channel_id":      "c1",
+				"channel_name":    "general",
+				"author_id":       "u1",
+				"author_username": "Alice",
+				"content":         "worker-backed message",
+				"created_at":      "2026-05-27T17:00:00Z",
+			}},
+			Stats: crawlremote.QueryStats{ServedBy: "d1"},
+		})
+	}))
+	defer server.Close()
+
+	cfgPath := filepath.Join(dir, "config.toml")
+	cfg := config.Default()
+	cfg.DBPath = dbPath
+	cfg.Discord.TokenSource = "none"
+	cfg.Remote.Mode = "cloud"
+	cfg.Remote.Endpoint = server.URL
+	cfg.Remote.Archive = "openclaw/discord"
+	cfg.Remote.TokenEnv = tokenEnv
+	require.NoError(t, config.Write(cfgPath, cfg))
+
+	var searchOut bytes.Buffer
+	require.NoError(t, Run(ctx, []string{"--config", cfgPath, "--json", "search", "worker"}, &searchOut, &bytes.Buffer{}))
+	require.Contains(t, searchOut.String(), "worker-backed message")
+	require.True(t, seen["discrawl.messages.search"])
+	require.NoFileExists(t, dbPath)
+
+	var messagesOut bytes.Buffer
+	require.NoError(t, Run(ctx, []string{"--config", cfgPath, "--json", "messages", "--channel", "c1"}, &messagesOut, &bytes.Buffer{}))
+	require.Contains(t, messagesOut.String(), "worker-backed message")
+	require.True(t, seen["discrawl.messages.list"])
+	require.NoFileExists(t, dbPath)
+}
+
+func TestCloudPublishSendsNonDMRows(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.toml")
+	cfg := config.Default()
+	cfg.DBPath = filepath.Join(dir, "publisher.db")
+	require.NoError(t, config.Write(cfgPath, cfg))
+	publisher := seedCLIStore(t, cfg.DBPath)
+	require.NoError(t, addCLIDMAttachment(ctx, publisher))
+	require.NoError(t, publisher.Close())
+
+	tokenEnv := "DISCRAWL_TEST_PUBLISH_TOKEN"
+	t.Setenv(tokenEnv, "publish-token")
+	seenTables := map[string]crawlremote.IngestRequest{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		require.Equal(t, "Bearer publish-token", req.Header.Get("Authorization"))
+		require.Equal(t, http.MethodPost, req.Method)
+		require.Equal(t, "/v1/apps/discrawl/archives/discrawl%2Fopenclaw/ingest", req.URL.EscapedPath())
+		var body crawlremote.IngestRequest
+		require.NoError(t, json.NewDecoder(req.Body).Decode(&body))
+		require.Equal(t, "discrawl", body.Manifest.App)
+		require.Equal(t, "discrawl/openclaw", body.Manifest.Archive)
+		for idx, column := range body.Columns {
+			if column == "guild_id" {
+				for _, row := range body.Rows {
+					require.NotEqual(t, store.DirectMessageGuildID, row[idx])
+				}
+			}
+		}
+		seenTables[body.Table] = body
+		w.Header().Set("content-type", "application/json")
+		_ = json.NewEncoder(w).Encode(crawlremote.IngestResult{Table: body.Table, RowsAccepted: int64(len(body.Rows)), Complete: body.Final})
+	}))
+	defer server.Close()
+
+	var out bytes.Buffer
+	require.NoError(t, Run(ctx, []string{
+		"--config", cfgPath,
+		"--json",
+		"cloud", "publish",
+		"--remote", server.URL,
+		"--archive", "discrawl/openclaw",
+		"--token-env", tokenEnv,
+	}, &out, &bytes.Buffer{}))
+
+	require.Len(t, seenTables, 4)
+	require.Len(t, seenTables["guilds"].Rows, 1)
+	require.Len(t, seenTables["channels"].Rows, 1)
+	require.Len(t, seenTables["messages"].Rows, 1)
+	require.True(t, seenTables["messages"].Final)
+
+	var payload map[string]any
+	require.NoError(t, json.Unmarshal(out.Bytes(), &payload))
+	require.Equal(t, float64(1), payload["guilds"])
+	require.Equal(t, float64(1), payload["messages"])
 }
 
 func TestShareCommandsPublishSubscribeAndUpdate(t *testing.T) {

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	"github.com/bwmarrin/discordgo"
+	"github.com/openclaw/crawlkit/control"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -1019,6 +1020,94 @@ func TestSubscribeNoMediaPersistsShareMediaOptOut(t *testing.T) {
 	cfg, err := config.Load(cfgPath)
 	require.NoError(t, err)
 	require.False(t, cfg.ShareMediaEnabled())
+}
+
+func TestSubscribeCloudDoesNotCreateLocalDB(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.toml")
+	dbPath := filepath.Join(dir, "archive", "discrawl.db")
+
+	var out bytes.Buffer
+	require.NoError(t, Run(ctx, []string{
+		"--config", cfgPath,
+		"subscribe-cloud",
+		"--endpoint", "https://remote.example.test",
+		"--archive", "openclaw/discord",
+		"--db", dbPath,
+	}, &out, &bytes.Buffer{}))
+
+	cfg, err := config.Load(cfgPath)
+	require.NoError(t, err)
+	require.Equal(t, "cloud", cfg.Remote.Mode)
+	require.Equal(t, "https://remote.example.test", cfg.Remote.Endpoint)
+	require.Equal(t, "openclaw/discord", cfg.Remote.Archive)
+	require.Equal(t, config.DefaultRemoteTokenEnv, cfg.Remote.TokenEnv)
+	require.Equal(t, "none", cfg.Discord.TokenSource)
+	require.NoFileExists(t, dbPath)
+	require.NoDirExists(t, filepath.Dir(dbPath))
+}
+
+func TestCloudStatusJSONUsesRemoteWithoutLocalDB(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "discrawl.db")
+	tokenEnv := "DISCRAWL_TEST_REMOTE_TOKEN"
+	t.Setenv(tokenEnv, "test-token")
+	seen := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		seen = true
+		require.Equal(t, http.MethodGet, req.Method)
+		require.Equal(t, "Bearer test-token", req.Header.Get("Authorization"))
+		require.Equal(t, "/v1/apps/discrawl/archives/openclaw%2Fdiscord/status", req.URL.EscapedPath())
+		w.Header().Set("content-type", "application/json")
+		_, _ = io.WriteString(w, `{
+			"app": "discrawl",
+			"archive": "openclaw/discord",
+			"mode": "cloud",
+			"last_sync_at": "2026-05-27T10:00:00Z",
+			"last_ingest_at": "2026-05-27T10:05:00Z",
+			"counts": [
+				{"id": "guilds", "label": "Guilds", "value": 2},
+				{"id": "messages", "label": "Messages", "value": 42}
+			],
+			"warnings": ["readonly"]
+		}`)
+	}))
+	defer server.Close()
+
+	cfgPath := filepath.Join(dir, "config.toml")
+	cfg := config.Default()
+	cfg.DBPath = dbPath
+	cfg.Discord.TokenSource = "none"
+	cfg.Remote.Mode = "cloud"
+	cfg.Remote.Endpoint = server.URL
+	cfg.Remote.Archive = "openclaw/discord"
+	cfg.Remote.TokenEnv = tokenEnv
+	require.NoError(t, config.Write(cfgPath, cfg))
+
+	var out bytes.Buffer
+	require.NoError(t, Run(ctx, []string{"--config", cfgPath, "status", "--json"}, &out, &bytes.Buffer{}))
+	require.True(t, seen)
+	require.NoFileExists(t, dbPath)
+
+	var status control.Status
+	require.NoError(t, json.Unmarshal(out.Bytes(), &status))
+	require.Equal(t, "discrawl", status.AppID)
+	require.Equal(t, "current", status.State)
+	require.Empty(t, status.DatabasePath)
+	require.NotNil(t, status.Remote)
+	require.True(t, status.Remote.Enabled)
+	require.Equal(t, "cloud", status.Remote.Mode)
+	require.Equal(t, server.URL, status.Remote.Endpoint)
+	require.Equal(t, "openclaw/discord", status.Remote.Archive)
+	require.Equal(t, "2026-05-27T10:00:00Z", status.Remote.LastSyncAt)
+	require.Equal(t, "2026-05-27T10:05:00Z", status.Remote.LastIngestAt)
+	require.Len(t, status.Databases, 1)
+	require.Equal(t, "cloudflare-d1", status.Databases[0].Kind)
+	require.Equal(t, "openclaw/discord", status.Databases[0].Archive)
+	require.Equal(t, int64(42), status.Counts[1].Value)
+	require.Equal(t, []string{"readonly"}, status.Warnings)
 }
 
 func TestShareCommandsPublishSubscribeAndUpdate(t *testing.T) {

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/openclaw/discrawl/internal/share"
 	"github.com/openclaw/discrawl/internal/store"
 	"github.com/openclaw/discrawl/internal/syncer"
+	"github.com/zalando/go-keyring"
 )
 
 func TestHelpAndVersion(t *testing.T) {
@@ -1164,6 +1165,66 @@ func TestCloudSearchAndMessagesUseRemoteWithoutLocalDB(t *testing.T) {
 	require.Contains(t, messagesOut.String(), "worker-backed message")
 	require.True(t, seen["discrawl.messages.list"])
 	require.NoFileExists(t, dbPath)
+}
+
+func TestRemoteLoginStoresKeyringToken(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	keyring.MockInit()
+
+	var pollSecretHash string
+	var pollSecret string
+	var server *httptest.Server
+	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		w.Header().Set("content-type", "application/json")
+		switch req.URL.Path {
+		case "/v1/auth/github/start":
+			var body crawlremote.LoginStartRequest
+			require.NoError(t, json.NewDecoder(req.Body).Decode(&body))
+			pollSecretHash = body.PollSecretHash
+			_ = json.NewEncoder(w).Encode(crawlremote.LoginStartResult{LoginID: "login-1", URL: server.URL + "/authorize"})
+		case "/v1/auth/github/poll":
+			var body crawlremote.LoginPollRequest
+			require.NoError(t, json.NewDecoder(req.Body).Decode(&body))
+			require.Equal(t, "login-1", body.LoginID)
+			pollSecret = body.PollSecret
+			_ = json.NewEncoder(w).Encode(crawlremote.LoginPollResult{Status: "complete", Token: "session-token", Org: "openclaw", Login: "alice"})
+		case "/v1/whoami":
+			require.Equal(t, "Bearer session-token", req.Header.Get("Authorization"))
+			_ = json.NewEncoder(w).Encode(crawlremote.Identity{Owner: "openclaw", Org: "openclaw", Login: "alice", Auth: "github"})
+		default:
+			http.NotFound(w, req)
+		}
+	}))
+	defer server.Close()
+
+	cfgPath := filepath.Join(dir, "config.toml")
+	var out bytes.Buffer
+	require.NoError(t, Run(ctx, []string{
+		"--config", cfgPath,
+		"--json",
+		"remote", "login",
+		"--endpoint", server.URL,
+		"--no-browser",
+		"--timeout", "1s",
+		"--poll-interval", "1ms",
+	}, &out, &bytes.Buffer{}))
+	require.NotEmpty(t, pollSecretHash)
+	require.NotEmpty(t, pollSecret)
+	require.Equal(t, pollSecretHash, crawlremote.LoginPollSecretHash(pollSecret))
+
+	cfg, err := config.Load(cfgPath)
+	require.NoError(t, err)
+	require.Equal(t, "keyring", cfg.Remote.Auth.TokenSource)
+	require.NotEmpty(t, cfg.Remote.Auth.KeyringService)
+	require.NotEmpty(t, cfg.Remote.Auth.KeyringAccount)
+	stored, err := keyring.Get(cfg.Remote.Auth.KeyringService, cfg.Remote.Auth.KeyringAccount)
+	require.NoError(t, err)
+	require.Equal(t, "session-token", stored)
+
+	var whoami bytes.Buffer
+	require.NoError(t, Run(ctx, []string{"--config", cfgPath, "--json", "whoami"}, &whoami, &bytes.Buffer{}))
+	require.Contains(t, whoami.String(), `"login": "alice"`)
 }
 
 func TestCloudPublishSendsNonDMRows(t *testing.T) {

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -1227,6 +1227,53 @@ func TestRemoteLoginStoresKeyringToken(t *testing.T) {
 	require.Contains(t, whoami.String(), `"login": "alice"`)
 }
 
+func TestRemoteLoginWithGitHubTokenEnvStoresKeyringToken(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	keyring.MockInit()
+	t.Setenv("DISCRAWL_TEST_GITHUB_TOKEN", "github-token")
+
+	var sawToken string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		w.Header().Set("content-type", "application/json")
+		switch req.URL.Path {
+		case "/v1/auth/github/token":
+			var body crawlremote.GitHubTokenLoginRequest
+			require.NoError(t, json.NewDecoder(req.Body).Decode(&body))
+			sawToken = body.Token
+			_ = json.NewEncoder(w).Encode(crawlremote.LoginPollResult{Status: "complete", Token: "session-token", Org: "openclaw", Login: "alice"})
+		case "/v1/whoami":
+			require.Equal(t, "Bearer session-token", req.Header.Get("Authorization"))
+			_ = json.NewEncoder(w).Encode(crawlremote.Identity{Owner: "openclaw", Org: "openclaw", Login: "alice", Auth: "github"})
+		default:
+			http.NotFound(w, req)
+		}
+	}))
+	defer server.Close()
+
+	cfgPath := filepath.Join(dir, "config.toml")
+	var out bytes.Buffer
+	require.NoError(t, Run(ctx, []string{
+		"--config", cfgPath,
+		"--json",
+		"remote", "login",
+		"--endpoint", server.URL,
+		"--github-token-env", "DISCRAWL_TEST_GITHUB_TOKEN",
+	}, &out, &bytes.Buffer{}))
+	require.Equal(t, "github-token", sawToken)
+	require.Contains(t, out.String(), `"login_method": "github-token"`)
+
+	cfg, err := config.Load(cfgPath)
+	require.NoError(t, err)
+	stored, err := keyring.Get(cfg.Remote.Auth.KeyringService, cfg.Remote.Auth.KeyringAccount)
+	require.NoError(t, err)
+	require.Equal(t, "session-token", stored)
+
+	var whoami bytes.Buffer
+	require.NoError(t, Run(ctx, []string{"--config", cfgPath, "--json", "whoami"}, &whoami, &bytes.Buffer{}))
+	require.Contains(t, whoami.String(), `"login": "alice"`)
+}
+
 func TestCloudPublishSendsNonDMRows(t *testing.T) {
 	ctx := context.Background()
 	dir := t.TempDir()

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -1059,10 +1059,10 @@ func TestCloudStatusJSONUsesRemoteWithoutLocalDB(t *testing.T) {
 	seen := false
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		seen = true
-		require.Equal(t, http.MethodGet, req.Method)
-		require.Equal(t, "Bearer test-token", req.Header.Get("Authorization"))
-		require.Equal(t, "/v1/apps/discrawl/archives/openclaw%2Fdiscord/status", req.URL.EscapedPath())
-		w.Header().Set("content-type", "application/json")
+		assert.Equal(t, http.MethodGet, req.Method)
+		assert.Equal(t, "Bearer test-token", req.Header.Get("Authorization"))
+		assert.Equal(t, "/v1/apps/discrawl/archives/openclaw%2Fdiscord/status", req.URL.EscapedPath())
+		w.Header().Set("Content-Type", "application/json")
 		_, _ = io.WriteString(w, `{
 			"app": "discrawl",
 			"archive": "openclaw/discord",
@@ -1120,14 +1120,17 @@ func TestCloudSearchAndMessagesUseRemoteWithoutLocalDB(t *testing.T) {
 	t.Setenv(tokenEnv, "test-token")
 	seen := map[string]bool{}
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-		require.Equal(t, http.MethodPost, req.Method)
-		require.Equal(t, "Bearer test-token", req.Header.Get("Authorization"))
-		require.Equal(t, "/v1/apps/discrawl/archives/openclaw%2Fdiscord/query", req.URL.EscapedPath())
+		assert.Equal(t, http.MethodPost, req.Method)
+		assert.Equal(t, "Bearer test-token", req.Header.Get("Authorization"))
+		assert.Equal(t, "/v1/apps/discrawl/archives/openclaw%2Fdiscord/query", req.URL.EscapedPath())
 		var body crawlremote.QueryRequest
-		require.NoError(t, json.NewDecoder(req.Body).Decode(&body))
+		if err := json.NewDecoder(req.Body).Decode(&body); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
 		seen[body.Name] = true
-		require.Equal(t, "openclaw/discord", body.Archive)
-		w.Header().Set("content-type", "application/json")
+		assert.Equal(t, "openclaw/discord", body.Archive)
+		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(crawlremote.QueryResult{
 			Values: []map[string]any{{
 				"message_id":      "m1",
@@ -1176,21 +1179,27 @@ func TestRemoteLoginStoresKeyringToken(t *testing.T) {
 	var pollSecret string
 	var server *httptest.Server
 	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-		w.Header().Set("content-type", "application/json")
+		w.Header().Set("Content-Type", "application/json")
 		switch req.URL.Path {
 		case "/v1/auth/github/start":
 			var body crawlremote.LoginStartRequest
-			require.NoError(t, json.NewDecoder(req.Body).Decode(&body))
+			if err := json.NewDecoder(req.Body).Decode(&body); err != nil {
+				http.Error(w, err.Error(), http.StatusBadRequest)
+				return
+			}
 			pollSecretHash = body.PollSecretHash
 			_ = json.NewEncoder(w).Encode(crawlremote.LoginStartResult{LoginID: "login-1", URL: server.URL + "/authorize"})
 		case "/v1/auth/github/poll":
 			var body crawlremote.LoginPollRequest
-			require.NoError(t, json.NewDecoder(req.Body).Decode(&body))
-			require.Equal(t, "login-1", body.LoginID)
+			if err := json.NewDecoder(req.Body).Decode(&body); err != nil {
+				http.Error(w, err.Error(), http.StatusBadRequest)
+				return
+			}
+			assert.Equal(t, "login-1", body.LoginID)
 			pollSecret = body.PollSecret
 			_ = json.NewEncoder(w).Encode(crawlremote.LoginPollResult{Status: "complete", Token: "session-token", Org: "openclaw", Login: "alice"})
 		case "/v1/whoami":
-			require.Equal(t, "Bearer session-token", req.Header.Get("Authorization"))
+			assert.Equal(t, "Bearer session-token", req.Header.Get("Authorization"))
 			_ = json.NewEncoder(w).Encode(crawlremote.Identity{Owner: "openclaw", Org: "openclaw", Login: "alice", Auth: "github"})
 		default:
 			http.NotFound(w, req)
@@ -1235,15 +1244,18 @@ func TestRemoteLoginWithGitHubTokenEnvStoresKeyringToken(t *testing.T) {
 
 	var sawToken string
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-		w.Header().Set("content-type", "application/json")
+		w.Header().Set("Content-Type", "application/json")
 		switch req.URL.Path {
 		case "/v1/auth/github/token":
 			var body crawlremote.GitHubTokenLoginRequest
-			require.NoError(t, json.NewDecoder(req.Body).Decode(&body))
+			if err := json.NewDecoder(req.Body).Decode(&body); err != nil {
+				http.Error(w, err.Error(), http.StatusBadRequest)
+				return
+			}
 			sawToken = body.Token
 			_ = json.NewEncoder(w).Encode(crawlremote.LoginPollResult{Status: "complete", Token: "session-token", Org: "openclaw", Login: "alice"})
 		case "/v1/whoami":
-			require.Equal(t, "Bearer session-token", req.Header.Get("Authorization"))
+			assert.Equal(t, "Bearer session-token", req.Header.Get("Authorization"))
 			_ = json.NewEncoder(w).Encode(crawlremote.Identity{Owner: "openclaw", Org: "openclaw", Login: "alice", Auth: "github"})
 		default:
 			http.NotFound(w, req)
@@ -1289,22 +1301,25 @@ func TestCloudPublishSendsNonDMRows(t *testing.T) {
 	t.Setenv(tokenEnv, "publish-token")
 	seenTables := map[string]crawlremote.IngestRequest{}
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-		require.Equal(t, "Bearer publish-token", req.Header.Get("Authorization"))
-		require.Equal(t, http.MethodPost, req.Method)
-		require.Equal(t, "/v1/apps/discrawl/archives/discrawl%2Fopenclaw/ingest", req.URL.EscapedPath())
+		assert.Equal(t, "Bearer publish-token", req.Header.Get("Authorization"))
+		assert.Equal(t, http.MethodPost, req.Method)
+		assert.Equal(t, "/v1/apps/discrawl/archives/discrawl%2Fopenclaw/ingest", req.URL.EscapedPath())
 		var body crawlremote.IngestRequest
-		require.NoError(t, json.NewDecoder(req.Body).Decode(&body))
-		require.Equal(t, "discrawl", body.Manifest.App)
-		require.Equal(t, "discrawl/openclaw", body.Manifest.Archive)
+		if err := json.NewDecoder(req.Body).Decode(&body); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		assert.Equal(t, "discrawl", body.Manifest.App)
+		assert.Equal(t, "discrawl/openclaw", body.Manifest.Archive)
 		for idx, column := range body.Columns {
 			if column == "guild_id" {
 				for _, row := range body.Rows {
-					require.NotEqual(t, store.DirectMessageGuildID, row[idx])
+					assert.NotEqual(t, store.DirectMessageGuildID, row[idx])
 				}
 			}
 		}
 		seenTables[body.Table] = body
-		w.Header().Set("content-type", "application/json")
+		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(crawlremote.IngestResult{Table: body.Table, RowsAccepted: int64(len(body.Rows)), Complete: body.Final})
 	}))
 	defer server.Close()
@@ -1327,8 +1342,8 @@ func TestCloudPublishSendsNonDMRows(t *testing.T) {
 
 	var payload map[string]any
 	require.NoError(t, json.Unmarshal(out.Bytes(), &payload))
-	require.Equal(t, float64(1), payload["guilds"])
-	require.Equal(t, float64(1), payload["messages"])
+	require.InDelta(t, float64(1), payload["guilds"], 0)
+	require.InDelta(t, float64(1), payload["messages"], 0)
 }
 
 func TestShareCommandsPublishSubscribeAndUpdate(t *testing.T) {

--- a/internal/cli/cloud_commands.go
+++ b/internal/cli/cloud_commands.go
@@ -7,6 +7,7 @@ import (
 	"flag"
 	"fmt"
 	"io"
+	"strconv"
 	"strings"
 
 	crawlremote "github.com/openclaw/crawlkit/remote"
@@ -122,7 +123,7 @@ func publishRows(ctx context.Context, db *sql.DB, query string) ([][]any, error)
 	if err != nil {
 		return nil, err
 	}
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 	cols, err := rows.Columns()
 	if err != nil {
 		return nil, err
@@ -160,10 +161,7 @@ func sendIngestRows(ctx context.Context, client *crawlremote.Client, archive str
 		return result.RowsAccepted, err
 	}
 	for start := 0; start < len(rows); start += discrawlCloudBatchSize {
-		end := start + discrawlCloudBatchSize
-		if end > len(rows) {
-			end = len(rows)
-		}
+		end := min(start+discrawlCloudBatchSize, len(rows))
 		result, err := client.Ingest(ctx, "discrawl", archive, crawlremote.IngestRequest{
 			Manifest: manifest,
 			Table:    table,
@@ -184,7 +182,7 @@ func cursorFor(start int) string {
 	if start == 0 {
 		return ""
 	}
-	return fmt.Sprintf("%d", start)
+	return strconv.Itoa(start)
 }
 
 var discrawlGuildColumns = []string{"guild_id", "name", "updated_at"}

--- a/internal/cli/cloud_commands.go
+++ b/internal/cli/cloud_commands.go
@@ -1,0 +1,223 @@
+package cli
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"strings"
+
+	crawlremote "github.com/openclaw/crawlkit/remote"
+	"github.com/openclaw/discrawl/internal/config"
+)
+
+const discrawlCloudBatchSize = 250
+
+func (r *runtime) runCloud(args []string) error {
+	if len(args) == 0 || args[0] == "--help" || args[0] == "-h" {
+		return printCommandUsage(r.stdout, []string{"cloud"})
+	}
+	switch args[0] {
+	case "publish":
+		return r.runCloudPublish(args[1:])
+	default:
+		return usageErr(fmt.Errorf("unknown cloud subcommand %q", args[0]))
+	}
+}
+
+func (r *runtime) runCloudPublish(args []string) error {
+	fs := flag.NewFlagSet("cloud publish", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	remoteEndpoint := fs.String("remote", "", "")
+	archive := fs.String("archive", "", "")
+	tokenEnv := fs.String("token-env", "", "")
+	jsonOut := fs.Bool("json", false, "")
+	if err := fs.Parse(args); err != nil {
+		return usageErr(err)
+	}
+	if *jsonOut {
+		r.json = true
+	}
+	if fs.NArg() != 0 {
+		return usageErr(errors.New("cloud publish takes flags only"))
+	}
+	return r.withLocalStoreReadOnly(func() error {
+		if r.store == nil {
+			return dbErr(errors.New("cloud publish requires a local SQLite archive"))
+		}
+		endpoint := firstNonEmpty(*remoteEndpoint, r.cfg.Remote.Endpoint)
+		archiveID := firstNonEmpty(*archive, r.cfg.Remote.Archive)
+		if endpoint == "" {
+			return usageErr(errors.New("cloud publish requires --remote or remote.endpoint"))
+		}
+		if archiveID == "" {
+			return usageErr(errors.New("cloud publish requires --archive or remote.archive"))
+		}
+		remoteCfg := crawlremote.Config{
+			Mode:     crawlremote.ModePublisher,
+			Endpoint: endpoint,
+			Archive:  archiveID,
+			TokenEnv: firstNonEmpty(*tokenEnv, r.cfg.Remote.TokenEnv, config.DefaultRemoteTokenEnv),
+		}
+		client, err := crawlremote.NewClientFromConfig(remoteCfg, crawlremote.Options{UserAgent: "discrawl/" + version})
+		if err != nil {
+			return configErr(err)
+		}
+		manifest := crawlremote.IngestManifest{
+			App:           "discrawl",
+			Archive:       archiveID,
+			SchemaName:    "discrawl-cloud-v1",
+			SchemaVersion: 1,
+			SchemaHash:    "discrawl-cloud-v1",
+			Mode:          crawlremote.ModePublisher,
+			Source:        "sqlite",
+		}
+		guilds, err := publishRows(r.ctx, r.store.DB(), discrawlGuildExportSQL)
+		if err != nil {
+			return dbErr(err)
+		}
+		channels, err := publishRows(r.ctx, r.store.DB(), discrawlChannelExportSQL)
+		if err != nil {
+			return dbErr(err)
+		}
+		messages, err := publishRows(r.ctx, r.store.DB(), discrawlMessageExportSQL)
+		if err != nil {
+			return dbErr(err)
+		}
+		members, err := publishRows(r.ctx, r.store.DB(), discrawlMemberExportSQL)
+		if err != nil {
+			return dbErr(err)
+		}
+		guildCount, err := sendIngestRows(r.ctx, client, archiveID, manifest, "guilds", discrawlGuildColumns, guilds, false)
+		if err != nil {
+			return err
+		}
+		channelCount, err := sendIngestRows(r.ctx, client, archiveID, manifest, "channels", discrawlChannelColumns, channels, false)
+		if err != nil {
+			return err
+		}
+		memberCount, err := sendIngestRows(r.ctx, client, archiveID, manifest, "members", discrawlMemberColumns, members, false)
+		if err != nil {
+			return err
+		}
+		messageCount, err := sendIngestRows(r.ctx, client, archiveID, manifest, "messages", discrawlMessageColumns, messages, true)
+		if err != nil {
+			return err
+		}
+		return r.print(map[string]any{
+			"remote":   strings.TrimRight(endpoint, "/"),
+			"archive":  archiveID,
+			"guilds":   guildCount,
+			"channels": channelCount,
+			"members":  memberCount,
+			"messages": messageCount,
+		})
+	})
+}
+
+func publishRows(ctx context.Context, db *sql.DB, query string) ([][]any, error) {
+	rows, err := db.QueryContext(ctx, query)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	cols, err := rows.Columns()
+	if err != nil {
+		return nil, err
+	}
+	out := make([][]any, 0)
+	for rows.Next() {
+		values := make([]any, len(cols))
+		ptrs := make([]any, len(cols))
+		for i := range values {
+			ptrs[i] = &values[i]
+		}
+		if err := rows.Scan(ptrs...); err != nil {
+			return nil, err
+		}
+		for i, value := range values {
+			if bytes, ok := value.([]byte); ok {
+				values[i] = string(bytes)
+			}
+		}
+		out = append(out, values)
+	}
+	return out, rows.Err()
+}
+
+func sendIngestRows(ctx context.Context, client *crawlremote.Client, archive string, manifest crawlremote.IngestManifest, table string, columns []string, rows [][]any, final bool) (int64, error) {
+	var total int64
+	if len(rows) == 0 {
+		result, err := client.Ingest(ctx, "discrawl", archive, crawlremote.IngestRequest{
+			Manifest: manifest,
+			Table:    table,
+			Columns:  columns,
+			Rows:     [][]any{},
+			Final:    final,
+		})
+		return result.RowsAccepted, err
+	}
+	for start := 0; start < len(rows); start += discrawlCloudBatchSize {
+		end := start + discrawlCloudBatchSize
+		if end > len(rows) {
+			end = len(rows)
+		}
+		result, err := client.Ingest(ctx, "discrawl", archive, crawlremote.IngestRequest{
+			Manifest: manifest,
+			Table:    table,
+			Columns:  columns,
+			Rows:     rows[start:end],
+			Cursor:   cursorFor(start),
+			Final:    final && end == len(rows),
+		})
+		if err != nil {
+			return total, err
+		}
+		total += result.RowsAccepted
+	}
+	return total, nil
+}
+
+func cursorFor(start int) string {
+	if start == 0 {
+		return ""
+	}
+	return fmt.Sprintf("%d", start)
+}
+
+var discrawlGuildColumns = []string{"guild_id", "name", "updated_at"}
+
+const discrawlGuildExportSQL = `
+select id as guild_id, name, updated_at
+from guilds
+where id != '@me'
+order by id`
+
+var discrawlChannelColumns = []string{"channel_id", "guild_id", "name", "type", "parent_id", "updated_at"}
+
+const discrawlChannelExportSQL = `
+select id as channel_id, guild_id, name, kind as type, coalesce(parent_id, '') as parent_id, updated_at
+from channels
+where guild_id != '@me'
+order by guild_id, id`
+
+var discrawlMemberColumns = []string{"guild_id", "user_id", "username", "display_name", "updated_at"}
+
+const discrawlMemberExportSQL = `
+select guild_id, user_id, username, coalesce(nullif(display_name, ''), nullif(nick, ''), username) as display_name, updated_at
+from members
+where guild_id != '@me'
+order by guild_id, user_id`
+
+var discrawlMessageColumns = []string{"message_id", "channel_id", "guild_id", "author_id", "author_username", "content", "created_at", "edited_at"}
+
+const discrawlMessageExportSQL = `
+select m.id as message_id, m.channel_id, m.guild_id, coalesce(m.author_id, '') as author_id,
+       coalesce(nullif(mem.display_name, ''), nullif(mem.nick, ''), nullif(mem.username, ''), '') as author_username,
+       m.content, m.created_at, coalesce(m.edited_at, '') as edited_at
+from messages m
+left join members mem on mem.guild_id = m.guild_id and mem.user_id = m.author_id
+where m.guild_id != '@me'
+order by m.created_at desc, m.id`

--- a/internal/cli/control_commands.go
+++ b/internal/cli/control_commands.go
@@ -56,6 +56,7 @@ func (r *runtime) runMetadata(args []string) error {
 		"subscribe-cloud": {Title: "Subscribe cloud archive", Argv: []string{"discrawl", "--json", "subscribe-cloud"}, JSON: true, Mutates: true},
 		"remote-status":   {Title: "Remote status", Argv: []string{"discrawl", "--json", "remote", "status"}, JSON: true},
 		"remote-archives": {Title: "Remote archives", Argv: []string{"discrawl", "--json", "remote", "archives"}, JSON: true},
+		"remote-login":    {Title: "Remote GitHub login", Argv: []string{"discrawl", "--json", "remote", "login"}, JSON: true, Mutates: true},
 		"whoami":          {Title: "Remote identity", Argv: []string{"discrawl", "--json", "whoami"}, JSON: true},
 		"update":          {Title: "Update share", Argv: []string{"discrawl", "--json", "update"}, JSON: true, Mutates: true},
 	}

--- a/internal/cli/control_commands.go
+++ b/internal/cli/control_commands.go
@@ -38,21 +38,25 @@ func (r *runtime) runMetadata(args []string) error {
 		DefaultLogs:     cfg.LogDir,
 		DefaultShare:    cfg.Share.RepoPath,
 	}
-	manifest.Capabilities = []string{"metadata", "status", "doctor", "sync", "tap", "tui", "git-share", "sql", "embeddings"}
+	manifest.Capabilities = []string{"metadata", "status", "doctor", "sync", "tap", "tui", "git-share", "cloud-remote", "sql", "embeddings"}
 	manifest.Privacy = control.Privacy{ContainsPrivateMessages: true, ExportsSecrets: false, LocalOnlyScopes: []string{"discord", "desktop-cache", "sqlite", "git-share"}}
 	manifest.Commands = map[string]control.Command{
-		"status":       {Title: "Status", Argv: []string{"discrawl", "status", "--json"}, JSON: true},
-		"check-update": {Title: "Check for updates", Argv: []string{"discrawl", "check-update", "--json"}, JSON: true},
-		"doctor":       {Title: "Doctor", Argv: []string{"discrawl", "doctor", "--json"}, JSON: true},
-		"sync":         {Title: "Sync", Argv: []string{"discrawl", "--json", "sync"}, JSON: true, Mutates: true},
-		"tap":          {Title: "Import desktop cache", Argv: []string{"discrawl", "--json", "tap"}, JSON: true, Mutates: true},
-		"cache-import": {Title: "Import desktop cache", Argv: []string{"discrawl", "--json", "cache-import"}, JSON: true, Mutates: true},
-		"wiretap":      {Title: "Legacy desktop cache import", Argv: []string{"discrawl", "--json", "wiretap"}, JSON: true, Mutates: true, Legacy: true, Deprecated: true},
-		"tui":          {Title: "Terminal browser", Argv: []string{"discrawl", "tui"}},
-		"tui-json":     {Title: "Terminal browser rows", Argv: []string{"discrawl", "tui", "--json"}, JSON: true},
-		"publish":      {Title: "Publish share", Argv: []string{"discrawl", "--json", "publish"}, JSON: true, Mutates: true},
-		"subscribe":    {Title: "Subscribe share", Argv: []string{"discrawl", "--json", "subscribe"}, JSON: true, Mutates: true},
-		"update":       {Title: "Update share", Argv: []string{"discrawl", "--json", "update"}, JSON: true, Mutates: true},
+		"status":          {Title: "Status", Argv: []string{"discrawl", "status", "--json"}, JSON: true},
+		"check-update":    {Title: "Check for updates", Argv: []string{"discrawl", "check-update", "--json"}, JSON: true},
+		"doctor":          {Title: "Doctor", Argv: []string{"discrawl", "doctor", "--json"}, JSON: true},
+		"sync":            {Title: "Sync", Argv: []string{"discrawl", "--json", "sync"}, JSON: true, Mutates: true},
+		"tap":             {Title: "Import desktop cache", Argv: []string{"discrawl", "--json", "tap"}, JSON: true, Mutates: true},
+		"cache-import":    {Title: "Import desktop cache", Argv: []string{"discrawl", "--json", "cache-import"}, JSON: true, Mutates: true},
+		"wiretap":         {Title: "Legacy desktop cache import", Argv: []string{"discrawl", "--json", "wiretap"}, JSON: true, Mutates: true, Legacy: true, Deprecated: true},
+		"tui":             {Title: "Terminal browser", Argv: []string{"discrawl", "tui"}},
+		"tui-json":        {Title: "Terminal browser rows", Argv: []string{"discrawl", "tui", "--json"}, JSON: true},
+		"publish":         {Title: "Publish share", Argv: []string{"discrawl", "--json", "publish"}, JSON: true, Mutates: true},
+		"subscribe":       {Title: "Subscribe share", Argv: []string{"discrawl", "--json", "subscribe"}, JSON: true, Mutates: true},
+		"subscribe-cloud": {Title: "Subscribe cloud archive", Argv: []string{"discrawl", "--json", "subscribe-cloud"}, JSON: true, Mutates: true},
+		"remote-status":   {Title: "Remote status", Argv: []string{"discrawl", "--json", "remote", "status"}, JSON: true},
+		"remote-archives": {Title: "Remote archives", Argv: []string{"discrawl", "--json", "remote", "archives"}, JSON: true},
+		"whoami":          {Title: "Remote identity", Argv: []string{"discrawl", "--json", "whoami"}, JSON: true},
+		"update":          {Title: "Update share", Argv: []string{"discrawl", "--json", "update"}, JSON: true, Mutates: true},
 	}
 	return r.print(manifest)
 }

--- a/internal/cli/control_commands.go
+++ b/internal/cli/control_commands.go
@@ -38,7 +38,7 @@ func (r *runtime) runMetadata(args []string) error {
 		DefaultLogs:     cfg.LogDir,
 		DefaultShare:    cfg.Share.RepoPath,
 	}
-	manifest.Capabilities = []string{"metadata", "status", "doctor", "sync", "tap", "tui", "git-share", "cloud-remote", "sql", "embeddings"}
+	manifest.Capabilities = []string{"metadata", "status", "doctor", "sync", "tap", "tui", "git-share", "cloud-remote", "cloud-publish", "sql", "embeddings"}
 	manifest.Privacy = control.Privacy{ContainsPrivateMessages: true, ExportsSecrets: false, LocalOnlyScopes: []string{"discord", "desktop-cache", "sqlite", "git-share"}}
 	manifest.Commands = map[string]control.Command{
 		"status":          {Title: "Status", Argv: []string{"discrawl", "status", "--json"}, JSON: true},
@@ -51,6 +51,7 @@ func (r *runtime) runMetadata(args []string) error {
 		"tui":             {Title: "Terminal browser", Argv: []string{"discrawl", "tui"}},
 		"tui-json":        {Title: "Terminal browser rows", Argv: []string{"discrawl", "tui", "--json"}, JSON: true},
 		"publish":         {Title: "Publish share", Argv: []string{"discrawl", "--json", "publish"}, JSON: true, Mutates: true},
+		"cloud-publish":   {Title: "Publish cloud archive", Argv: []string{"discrawl", "--json", "cloud", "publish"}, JSON: true, Mutates: true},
 		"subscribe":       {Title: "Subscribe share", Argv: []string{"discrawl", "--json", "subscribe"}, JSON: true, Mutates: true},
 		"subscribe-cloud": {Title: "Subscribe cloud archive", Argv: []string{"discrawl", "--json", "subscribe-cloud"}, JSON: true, Mutates: true},
 		"remote-status":   {Title: "Remote status", Argv: []string{"discrawl", "--json", "remote", "status"}, JSON: true},

--- a/internal/cli/messages.go
+++ b/internal/cli/messages.go
@@ -111,6 +111,23 @@ func (r *runtime) runMessages(args []string) error {
 		}
 	}
 
+	opts := store.MessageListOptions{
+		GuildIDs:     guildIDs,
+		Channel:      *channel,
+		Author:       *author,
+		Since:        sinceTime,
+		Before:       beforeTime,
+		Limit:        *limit,
+		Last:         *last,
+		IncludeEmpty: *includeEmpty,
+	}
+	if r.cfg.RemoteCloudReadOnly() {
+		rows, err := r.runRemoteMessages(opts, *dm)
+		if err != nil {
+			return err
+		}
+		return r.print(rows)
+	}
 	rows, err := r.store.ListMessages(r.ctx, store.MessageListOptions{
 		GuildIDs:     guildIDs,
 		Channel:      *channel,

--- a/internal/cli/output.go
+++ b/internal/cli/output.go
@@ -127,6 +127,7 @@ Commands:
   whoami
   report
   doctor
+  cloud
   subscribe-cloud
 `)
 }
@@ -222,6 +223,11 @@ Read-only SQL is allowed by default. Use "-" or no query to read SQL from stdin.
   discrawl remote whoami
 
 Reads the configured Cloudflare-backed remote archive without opening the local SQLite database.
+`,
+	"cloud": `Usage:
+  discrawl cloud publish --remote URL --archive ARCHIVE [--token-env ENV]
+
+Publishes the local non-DM SQLite archive into a Cloudflare-backed remote archive.
 `,
 	"subscribe-cloud": `Usage:
   discrawl subscribe-cloud --endpoint URL --archive ARCHIVE [--token-env ENV]

--- a/internal/cli/output.go
+++ b/internal/cli/output.go
@@ -221,6 +221,7 @@ Read-only SQL is allowed by default. Use "-" or no query to read SQL from stdin.
   discrawl remote status
   discrawl remote archives
   discrawl remote login --endpoint URL
+  discrawl remote login --endpoint URL --github-token-env GITHUB_TOKEN
   discrawl remote whoami
 
 Reads the configured Cloudflare-backed remote archive without opening the local SQLite database.

--- a/internal/cli/output.go
+++ b/internal/cli/output.go
@@ -220,6 +220,7 @@ Read-only SQL is allowed by default. Use "-" or no query to read SQL from stdin.
 	"remote": `Usage:
   discrawl remote status
   discrawl remote archives
+  discrawl remote login --endpoint URL
   discrawl remote whoami
 
 Reads the configured Cloudflare-backed remote archive without opening the local SQLite database.

--- a/internal/cli/output.go
+++ b/internal/cli/output.go
@@ -123,8 +123,11 @@ Commands:
   members
   channels
   status
+  remote
+  whoami
   report
   doctor
+  subscribe-cloud
 `)
 }
 
@@ -212,6 +215,18 @@ Flags:
   --confirm                   Required with --unsafe.
 
 Read-only SQL is allowed by default. Use "-" or no query to read SQL from stdin.
+`,
+	"remote": `Usage:
+  discrawl remote status
+  discrawl remote archives
+  discrawl remote whoami
+
+Reads the configured Cloudflare-backed remote archive without opening the local SQLite database.
+`,
+	"subscribe-cloud": `Usage:
+  discrawl subscribe-cloud --endpoint URL --archive ARCHIVE [--token-env ENV]
+
+Writes a read-only cloud archive config. This does not create or import a local SQLite database.
 `,
 }
 

--- a/internal/cli/query_commands.go
+++ b/internal/cli/query_commands.go
@@ -43,7 +43,15 @@ func (r *runtime) runSearch(args []string) error {
 		Limit:        *limit,
 		IncludeEmpty: *includeEmpty,
 	}
-	switch strings.ToLower(strings.TrimSpace(*mode)) {
+	normalizedMode := strings.ToLower(strings.TrimSpace(*mode))
+	if r.cfg.RemoteCloudReadOnly() {
+		results, err := r.runRemoteSearch(opts, normalizedMode, *dm)
+		if err != nil {
+			return err
+		}
+		return r.print(results)
+	}
+	switch normalizedMode {
 	case "", "fts":
 		results, err := r.store.SearchMessages(r.ctx, opts)
 		if err != nil {

--- a/internal/cli/query_commands_test.go
+++ b/internal/cli/query_commands_test.go
@@ -1,0 +1,22 @@
+package cli
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestPermuteSearchFlags(t *testing.T) {
+	got := permuteSearchFlags([]string{
+		"worker",
+		"--channel", "c1",
+		"--include-empty",
+		"--mode=fts",
+		"--guilds=g1",
+		"--",
+		"tail",
+	})
+	want := []string{"--channel", "c1", "--include-empty", "--mode=fts", "--guilds=g1", "worker", "tail"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("permuted = %#v", got)
+	}
+}

--- a/internal/cli/releasecheck_test.go
+++ b/internal/cli/releasecheck_test.go
@@ -1,6 +1,11 @@
 package cli
 
-import "testing"
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+)
 
 func TestGithubOwnerRepo(t *testing.T) {
 	tests := []struct {
@@ -56,5 +61,31 @@ func TestDiscrawlReleaseCheckOptionsUsesModulePath(t *testing.T) {
 	}
 	if !opts.Force {
 		t.Fatal("force = false")
+	}
+	if opts.AppName != "discrawl" || opts.CurrentVersion == "" || opts.CacheDir == "" {
+		t.Fatalf("incomplete options = %#v", opts)
+	}
+}
+
+func TestRunCheckUpdateRejectsArgsBeforeNetwork(t *testing.T) {
+	r := &runtime{ctx: context.Background(), stdout: &bytes.Buffer{}, stderr: &bytes.Buffer{}}
+	err := r.runCheckUpdate([]string{"extra"})
+	if err == nil || !strings.Contains(err.Error(), "takes flags only") {
+		t.Fatalf("error = %v", err)
+	}
+}
+
+func TestRunCheckUpdateJSONSkipped(t *testing.T) {
+	original := releaseModulePath
+	releaseModulePath = func() string { return "" }
+	t.Cleanup(func() { releaseModulePath = original })
+
+	var out bytes.Buffer
+	r := &runtime{ctx: context.Background(), stdout: &out, stderr: &bytes.Buffer{}}
+	if err := r.runCheckUpdate([]string{"--json"}); err != nil {
+		t.Fatalf("check update: %v", err)
+	}
+	if !strings.Contains(out.String(), `"skipped": true`) {
+		t.Fatalf("output = %s", out.String())
 	}
 }

--- a/internal/cli/remote_commands.go
+++ b/internal/cli/remote_commands.go
@@ -6,7 +6,10 @@ import (
 	"flag"
 	"fmt"
 	"io"
+	"os/exec"
+	goruntime "runtime"
 	"strings"
+	"time"
 
 	"github.com/openclaw/crawlkit/control"
 	crawlremote "github.com/openclaw/crawlkit/remote"
@@ -91,6 +94,8 @@ func (r *runtime) runRemote(args []string) error {
 			}
 			return r.runRemoteArchives()
 		})
+	case "login":
+		return r.runRemoteLogin(args[1:])
 	case "whoami":
 		return r.withConfig(func() error {
 			return r.runRemoteWhoami(args[1:])
@@ -98,6 +103,142 @@ func (r *runtime) runRemote(args []string) error {
 	default:
 		return usageErr(fmt.Errorf("unknown remote subcommand %q", args[0]))
 	}
+}
+
+func (r *runtime) runRemoteLogin(args []string) error {
+	fs := flag.NewFlagSet("remote login", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	endpoint := fs.String("endpoint", "", "")
+	noBrowser := fs.Bool("no-browser", false, "")
+	timeoutRaw := fs.String("timeout", "5m", "")
+	pollRaw := fs.String("poll-interval", "2s", "")
+	jsonOut := fs.Bool("json", false, "")
+	if err := fs.Parse(args); err != nil {
+		return usageErr(err)
+	}
+	if *jsonOut {
+		r.json = true
+	}
+	if fs.NArg() > 1 {
+		return usageErr(errors.New("remote login accepts at most one endpoint"))
+	}
+	if fs.NArg() == 1 {
+		if *endpoint != "" {
+			return usageErr(errors.New("use either --endpoint or a positional endpoint"))
+		}
+		*endpoint = fs.Arg(0)
+	}
+	timeout, err := time.ParseDuration(*timeoutRaw)
+	if err != nil || timeout <= 0 {
+		return usageErr(fmt.Errorf("invalid --timeout %q", *timeoutRaw))
+	}
+	pollInterval, err := time.ParseDuration(*pollRaw)
+	if err != nil || pollInterval <= 0 {
+		return usageErr(fmt.Errorf("invalid --poll-interval %q", *pollRaw))
+	}
+	cfg, err := loadConfigOrDefault(r.configPath)
+	if err != nil {
+		return err
+	}
+	if strings.TrimSpace(*endpoint) != "" {
+		cfg.Remote.Endpoint = *endpoint
+	}
+	cfg.Remote.Normalize()
+	if strings.TrimSpace(cfg.Remote.Endpoint) == "" {
+		return usageErr(errors.New("remote login requires --endpoint or remote.endpoint"))
+	}
+	client, err := crawlremote.NewClientFromConfig(cfg.Remote, crawlremote.Options{UserAgent: "discrawl/" + version})
+	if err != nil {
+		return configErr(err)
+	}
+	pollSecret, err := crawlremote.NewLoginPollSecret()
+	if err != nil {
+		return err
+	}
+	start, err := client.StartGitHubLogin(r.ctx, crawlremote.LoginPollSecretHash(pollSecret))
+	if err != nil {
+		return err
+	}
+	if !*noBrowser {
+		if err := openURL(start.URL); err != nil && !r.json {
+			_, _ = fmt.Fprintf(r.stdout, "Open this URL to continue login:\n%s\n", start.URL)
+		}
+	} else if !r.json {
+		_, _ = fmt.Fprintf(r.stdout, "Open this URL to continue login:\n%s\n", start.URL)
+	}
+	result, err := pollRemoteLogin(r.ctx, client, start.LoginID, pollSecret, timeout, pollInterval)
+	if err != nil {
+		return err
+	}
+	auth, err := config.StoreRemoteToken(cfg, result.Token)
+	if err != nil {
+		return configErr(fmt.Errorf("store remote token: %w", err))
+	}
+	if cfg.Remote.Mode == "" || cfg.Remote.Mode == crawlremote.ModeLocal {
+		cfg.Remote.Mode = crawlremote.ModeCloud
+	}
+	cfg.Remote.Auth = auth
+	if err := config.Write(r.configPath, cfg); err != nil {
+		return configErr(err)
+	}
+	return r.print(map[string]any{
+		"config_path":     r.configPath,
+		"endpoint":        cfg.Remote.Endpoint,
+		"archive":         cfg.Remote.Archive,
+		"login":           result.Login,
+		"org":             result.Org,
+		"owner":           result.Owner,
+		"auth_source":     cfg.Remote.Auth.TokenSource,
+		"keyring_service": cfg.Remote.Auth.KeyringService,
+		"keyring_account": cfg.Remote.Auth.KeyringAccount,
+		"updated":         true,
+	})
+}
+
+func pollRemoteLogin(ctx context.Context, client *crawlremote.Client, loginID, pollSecret string, timeout, interval time.Duration) (crawlremote.LoginPollResult, error) {
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		result, err := client.PollGitHubLogin(ctx, loginID, pollSecret)
+		if err != nil {
+			return crawlremote.LoginPollResult{}, err
+		}
+		switch strings.ToLower(strings.TrimSpace(result.Status)) {
+		case "complete":
+			if strings.TrimSpace(result.Token) == "" {
+				return crawlremote.LoginPollResult{}, errors.New("remote login completed without token")
+			}
+			return result, nil
+		case "error":
+			if result.Error != "" {
+				return crawlremote.LoginPollResult{}, fmt.Errorf("remote login failed: %s", result.Error)
+			}
+			return crawlremote.LoginPollResult{}, errors.New("remote login failed")
+		case "", "pending":
+		default:
+			return crawlremote.LoginPollResult{}, fmt.Errorf("remote login returned status %q", result.Status)
+		}
+		select {
+		case <-ctx.Done():
+			return crawlremote.LoginPollResult{}, ctx.Err()
+		case <-ticker.C:
+		}
+	}
+}
+
+func openURL(rawURL string) error {
+	var cmd *exec.Cmd
+	switch goruntime.GOOS {
+	case "darwin":
+		cmd = exec.Command("open", rawURL)
+	case "windows":
+		cmd = exec.Command("rundll32", "url.dll,FileProtocolHandler", rawURL)
+	default:
+		cmd = exec.Command("xdg-open", rawURL)
+	}
+	return cmd.Start()
 }
 
 func (r *runtime) runRemoteStatusOutput() error {
@@ -149,8 +290,15 @@ func (r *runtime) remoteClient(requireArchive bool) (remoteArchiveClient, error)
 	if r.newRemote != nil {
 		return r.newRemote(r.cfg)
 	}
+	tokenProvider := crawlremote.TokenProvider(crawlremote.EnvTokenProvider{Name: r.cfg.Remote.TokenEnv})
+	if token, err := config.ResolveRemoteToken(r.cfg); err != nil {
+		return nil, configErr(err)
+	} else if token.Token != "" {
+		tokenProvider = crawlremote.StaticToken(token.Token)
+	}
 	client, err := crawlremote.NewClientFromConfig(r.cfg.Remote, crawlremote.Options{
-		UserAgent: "discrawl/" + version,
+		TokenProvider: tokenProvider,
+		UserAgent:     "discrawl/" + version,
 	})
 	if err != nil {
 		return nil, configErr(err)

--- a/internal/cli/remote_commands.go
+++ b/internal/cli/remote_commands.go
@@ -256,10 +256,13 @@ func openURL(ctx context.Context, rawURL string) error {
 	var cmd *exec.Cmd
 	switch goruntime.GOOS {
 	case "darwin":
+		// #nosec G204 -- fixed browser launcher executable; rawURL is passed as argv, not shell text.
 		cmd = exec.CommandContext(ctx, "open", rawURL)
 	case "windows":
+		// #nosec G204 -- fixed browser launcher executable; rawURL is passed as argv, not shell text.
 		cmd = exec.CommandContext(ctx, "rundll32", "url.dll,FileProtocolHandler", rawURL)
 	default:
+		// #nosec G204 -- fixed browser launcher executable; rawURL is passed as argv, not shell text.
 		cmd = exec.CommandContext(ctx, "xdg-open", rawURL)
 	}
 	return cmd.Start()

--- a/internal/cli/remote_commands.go
+++ b/internal/cli/remote_commands.go
@@ -1,0 +1,200 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/openclaw/crawlkit/control"
+	crawlremote "github.com/openclaw/crawlkit/remote"
+	"github.com/openclaw/discrawl/internal/config"
+)
+
+type remoteArchiveClient interface {
+	Archives(context.Context) ([]crawlremote.Archive, error)
+	Status(context.Context, string, string) (crawlremote.Status, error)
+	Whoami(context.Context) (crawlremote.Identity, error)
+}
+
+func (r *runtime) runSubscribeCloud(args []string) error {
+	fs := flag.NewFlagSet("subscribe-cloud", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	endpoint := fs.String("endpoint", "", "")
+	archive := fs.String("archive", "", "")
+	dbPath := fs.String("db", "", "")
+	tokenEnv := fs.String("token-env", config.DefaultRemoteTokenEnv, "")
+	staleAfter := fs.String("stale-after", "", "")
+	if err := fs.Parse(args); err != nil {
+		return usageErr(err)
+	}
+	if fs.NArg() > 1 {
+		return usageErr(errors.New("subscribe-cloud accepts at most one endpoint"))
+	}
+	if fs.NArg() == 1 {
+		if *endpoint != "" {
+			return usageErr(errors.New("use either --endpoint or a positional endpoint"))
+		}
+		*endpoint = fs.Arg(0)
+	}
+	if strings.TrimSpace(*endpoint) == "" {
+		return usageErr(errors.New("subscribe-cloud requires --endpoint"))
+	}
+	if strings.TrimSpace(*archive) == "" {
+		return usageErr(errors.New("subscribe-cloud requires --archive"))
+	}
+	cfg, err := loadConfigOrDefault(r.configPath)
+	if err != nil {
+		return err
+	}
+	if *dbPath != "" {
+		cfg.DBPath = *dbPath
+	}
+	cfg.Remote.Mode = crawlremote.ModeCloud
+	cfg.Remote.Endpoint = *endpoint
+	cfg.Remote.Archive = *archive
+	cfg.Remote.TokenEnv = *tokenEnv
+	cfg.Remote.StaleAfter = *staleAfter
+	cfg.Discord.TokenSource = "none"
+	if err := config.Write(r.configPath, cfg); err != nil {
+		return configErr(err)
+	}
+	return r.print(map[string]any{
+		"config_path": r.configPath,
+		"mode":        crawlremote.ModeCloud,
+		"endpoint":    strings.TrimRight(strings.TrimSpace(*endpoint), "/"),
+		"archive":     strings.TrimSpace(*archive),
+		"token_env":   strings.TrimSpace(*tokenEnv),
+		"db_path":     cfg.DBPath,
+	})
+}
+
+func (r *runtime) runRemote(args []string) error {
+	if len(args) == 0 || args[0] == "--help" || args[0] == "-h" {
+		return printCommandUsage(r.stdout, []string{"remote"})
+	}
+	switch args[0] {
+	case "status":
+		return r.withConfig(func() error {
+			if len(args) != 1 {
+				return usageErr(errors.New("remote status takes no arguments"))
+			}
+			return r.runRemoteStatusOutput()
+		})
+	case "archives":
+		return r.withConfig(func() error {
+			if len(args) != 1 {
+				return usageErr(errors.New("remote archives takes no arguments"))
+			}
+			return r.runRemoteArchives()
+		})
+	case "whoami":
+		return r.withConfig(func() error {
+			return r.runRemoteWhoami(args[1:])
+		})
+	default:
+		return usageErr(fmt.Errorf("unknown remote subcommand %q", args[0]))
+	}
+}
+
+func (r *runtime) runRemoteStatusOutput() error {
+	client, err := r.remoteClient(true)
+	if err != nil {
+		return err
+	}
+	status, err := client.Status(r.ctx, "discrawl", r.cfg.Remote.Archive)
+	if err != nil {
+		return err
+	}
+	return r.print(remoteControlStatus(r.configPath, r.cfg, status))
+}
+
+func (r *runtime) runRemoteArchives() error {
+	client, err := r.remoteClient(false)
+	if err != nil {
+		return err
+	}
+	archives, err := client.Archives(r.ctx)
+	if err != nil {
+		return err
+	}
+	return r.print(map[string]any{"archives": archives})
+}
+
+func (r *runtime) runRemoteWhoami(args []string) error {
+	if len(args) != 0 {
+		return usageErr(errors.New("whoami takes no arguments"))
+	}
+	client, err := r.remoteClient(false)
+	if err != nil {
+		return err
+	}
+	identity, err := client.Whoami(r.ctx)
+	if err != nil {
+		return err
+	}
+	return r.print(identity)
+}
+
+func (r *runtime) remoteClient(requireArchive bool) (remoteArchiveClient, error) {
+	if strings.TrimSpace(r.cfg.Remote.Endpoint) == "" {
+		return nil, configErr(errors.New("remote.endpoint is required"))
+	}
+	if requireArchive && strings.TrimSpace(r.cfg.Remote.Archive) == "" {
+		return nil, configErr(errors.New("remote.archive is required"))
+	}
+	if r.newRemote != nil {
+		return r.newRemote(r.cfg)
+	}
+	client, err := crawlremote.NewClientFromConfig(r.cfg.Remote, crawlremote.Options{
+		UserAgent: "discrawl/" + version,
+	})
+	if err != nil {
+		return nil, configErr(err)
+	}
+	return client, nil
+}
+
+func remoteControlStatus(configPath string, cfg config.Config, status crawlremote.Status) control.Status {
+	counts := append([]control.Count(nil), status.Counts...)
+	archive := firstNonEmpty(status.Archive, cfg.Remote.Archive)
+	summary := fmt.Sprintf("remote archive %s", archive)
+	if messages := countValue(counts, "messages"); messages > 0 {
+		summary = fmt.Sprintf("%d messages in remote archive %s", messages, archive)
+	}
+	out := control.NewStatus("discrawl", summary)
+	out.State = "current"
+	out.ConfigPath = configPath
+	out.Counts = counts
+	out.LastSyncAt = firstNonEmpty(status.LastSyncAt, status.LastIngestAt)
+	out.Warnings = append([]string(nil), status.Warnings...)
+	out.Remote = &control.Remote{
+		Enabled:      true,
+		Mode:         firstNonEmpty(status.Mode, cfg.Remote.Mode),
+		Endpoint:     strings.TrimRight(strings.TrimSpace(cfg.Remote.Endpoint), "/"),
+		Archive:      archive,
+		LastIngestAt: status.LastIngestAt,
+		LastSyncAt:   status.LastSyncAt,
+	}
+	out.Share = &control.Share{
+		Enabled:  cfg.ShareEnabled(),
+		RepoPath: cfg.Share.RepoPath,
+		Remote:   cfg.Share.Remote,
+		Branch:   cfg.Share.Branch,
+	}
+	out.Databases = []control.Database{
+		control.RemoteDatabase("remote", "Discord cloud archive", "archive", "cloudflare-d1", cfg.Remote.Endpoint, archive, true, counts),
+	}
+	return out
+}
+
+func countValue(counts []control.Count, id string) int64 {
+	for _, count := range counts {
+		if count.ID == id {
+			return count.Value
+		}
+	}
+	return 0
+}

--- a/internal/cli/remote_commands.go
+++ b/internal/cli/remote_commands.go
@@ -15,6 +15,7 @@ import (
 
 type remoteArchiveClient interface {
 	Archives(context.Context) ([]crawlremote.Archive, error)
+	Query(context.Context, string, string, crawlremote.QueryRequest) (crawlremote.QueryResult, error)
 	Status(context.Context, string, string) (crawlremote.Status, error)
 	Whoami(context.Context) (crawlremote.Identity, error)
 }

--- a/internal/cli/remote_commands.go
+++ b/internal/cli/remote_commands.go
@@ -173,7 +173,7 @@ func (r *runtime) runRemoteLogin(args []string) error {
 		return err
 	}
 	if !*noBrowser {
-		if err := openURL(start.URL); err != nil && !r.json {
+		if err := openURL(r.ctx, start.URL); err != nil && !r.json {
 			_, _ = fmt.Fprintf(r.stdout, "Open this URL to continue login:\n%s\n", start.URL)
 		}
 	} else if !r.json {
@@ -252,15 +252,15 @@ func pollRemoteLogin(ctx context.Context, client *crawlremote.Client, loginID, p
 	}
 }
 
-func openURL(rawURL string) error {
+func openURL(ctx context.Context, rawURL string) error {
 	var cmd *exec.Cmd
 	switch goruntime.GOOS {
 	case "darwin":
-		cmd = exec.Command("open", rawURL)
+		cmd = exec.CommandContext(ctx, "open", rawURL)
 	case "windows":
-		cmd = exec.Command("rundll32", "url.dll,FileProtocolHandler", rawURL)
+		cmd = exec.CommandContext(ctx, "rundll32", "url.dll,FileProtocolHandler", rawURL)
 	default:
-		cmd = exec.Command("xdg-open", rawURL)
+		cmd = exec.CommandContext(ctx, "xdg-open", rawURL)
 	}
 	return cmd.Start()
 }
@@ -333,7 +333,7 @@ func (r *runtime) remoteClient(requireArchive bool) (remoteArchiveClient, error)
 func remoteControlStatus(configPath string, cfg config.Config, status crawlremote.Status) control.Status {
 	counts := append([]control.Count(nil), status.Counts...)
 	archive := firstNonEmpty(status.Archive, cfg.Remote.Archive)
-	summary := fmt.Sprintf("remote archive %s", archive)
+	summary := "remote archive " + archive
 	if messages := countValue(counts, "messages"); messages > 0 {
 		summary = fmt.Sprintf("%d messages in remote archive %s", messages, archive)
 	}

--- a/internal/cli/remote_commands.go
+++ b/internal/cli/remote_commands.go
@@ -6,6 +6,7 @@ import (
 	"flag"
 	"fmt"
 	"io"
+	"os"
 	"os/exec"
 	goruntime "runtime"
 	"strings"
@@ -109,6 +110,7 @@ func (r *runtime) runRemoteLogin(args []string) error {
 	fs := flag.NewFlagSet("remote login", flag.ContinueOnError)
 	fs.SetOutput(io.Discard)
 	endpoint := fs.String("endpoint", "", "")
+	githubTokenEnv := fs.String("github-token-env", "", "")
 	noBrowser := fs.Bool("no-browser", false, "")
 	timeoutRaw := fs.String("timeout", "5m", "")
 	pollRaw := fs.String("poll-interval", "2s", "")
@@ -151,6 +153,17 @@ func (r *runtime) runRemoteLogin(args []string) error {
 	if err != nil {
 		return configErr(err)
 	}
+	if tokenEnv := strings.TrimSpace(*githubTokenEnv); tokenEnv != "" {
+		githubToken := strings.TrimSpace(os.Getenv(tokenEnv))
+		if githubToken == "" {
+			return fmt.Errorf("%s is empty", tokenEnv)
+		}
+		result, err := client.LoginWithGitHubToken(r.ctx, githubToken)
+		if err != nil {
+			return err
+		}
+		return r.finishRemoteLogin(cfg, "github-token", result)
+	}
 	pollSecret, err := crawlremote.NewLoginPollSecret()
 	if err != nil {
 		return err
@@ -170,6 +183,16 @@ func (r *runtime) runRemoteLogin(args []string) error {
 	if err != nil {
 		return err
 	}
+	return r.finishRemoteLogin(cfg, "github-oauth", result)
+}
+
+func (r *runtime) finishRemoteLogin(cfg config.Config, method string, result crawlremote.LoginPollResult) error {
+	if strings.ToLower(strings.TrimSpace(result.Status)) != "complete" {
+		return fmt.Errorf("remote login returned status %q", result.Status)
+	}
+	if strings.TrimSpace(result.Token) == "" {
+		return errors.New("remote login completed without token")
+	}
 	auth, err := config.StoreRemoteToken(cfg, result.Token)
 	if err != nil {
 		return configErr(fmt.Errorf("store remote token: %w", err))
@@ -188,6 +211,7 @@ func (r *runtime) runRemoteLogin(args []string) error {
 		"login":           result.Login,
 		"org":             result.Org,
 		"owner":           result.Owner,
+		"login_method":    method,
 		"auth_source":     cfg.Remote.Auth.TokenSource,
 		"keyring_service": cfg.Remote.Auth.KeyringService,
 		"keyring_account": cfg.Remote.Auth.KeyringAccount,

--- a/internal/cli/remote_commands_test.go
+++ b/internal/cli/remote_commands_test.go
@@ -1,0 +1,416 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/openclaw/crawlkit/control"
+	crawlremote "github.com/openclaw/crawlkit/remote"
+	"github.com/openclaw/discrawl/internal/config"
+	"github.com/openclaw/discrawl/internal/store"
+)
+
+type fakeRemoteClient struct{}
+
+func (fakeRemoteClient) Archives(context.Context) ([]crawlremote.Archive, error) {
+	return []crawlremote.Archive{{ID: "discrawl/openclaw", App: "discrawl", Slug: "openclaw"}}, nil
+}
+
+func (fakeRemoteClient) Query(context.Context, string, string, crawlremote.QueryRequest) (crawlremote.QueryResult, error) {
+	return crawlremote.QueryResult{}, nil
+}
+
+func (fakeRemoteClient) Status(context.Context, string, string) (crawlremote.Status, error) {
+	return crawlremote.Status{}, nil
+}
+
+func (fakeRemoteClient) Whoami(context.Context) (crawlremote.Identity, error) {
+	return crawlremote.Identity{Login: "alice", Org: "openclaw"}, nil
+}
+
+type queryRemoteClient struct {
+	last crawlremote.QueryRequest
+}
+
+func (queryRemoteClient) Archives(context.Context) ([]crawlremote.Archive, error) { return nil, nil }
+
+func (c *queryRemoteClient) Query(_ context.Context, _ string, _ string, req crawlremote.QueryRequest) (crawlremote.QueryResult, error) {
+	c.last = req
+	return crawlremote.QueryResult{Values: []map[string]any{{
+		"message_id":      "m1",
+		"guild_id":        "g1",
+		"channel_id":      "c1",
+		"channel_name":    "general",
+		"author_id":       "u1",
+		"author_username": "alice",
+		"content":         "hello from remote",
+		"created_at":      "2026-05-27T17:00:00Z",
+	}}}, nil
+}
+
+func (queryRemoteClient) Status(context.Context, string, string) (crawlremote.Status, error) {
+	return crawlremote.Status{}, nil
+}
+
+func (queryRemoteClient) Whoami(context.Context) (crawlremote.Identity, error) {
+	return crawlremote.Identity{}, nil
+}
+
+func TestRemoteCommandHelpers(t *testing.T) {
+	if got, err := singleRemoteGuild([]string{"g1"}); err != nil || got != "g1" {
+		t.Fatalf("single guild = %q err=%v", got, err)
+	}
+	if _, err := singleRemoteGuild([]string{"g1", "g2"}); err == nil || !strings.Contains(err.Error(), "one guild") {
+		t.Fatalf("multi guild err = %v", err)
+	}
+	value := map[string]any{"name": 123, "created_at": "2026-05-27T17:00:00.123Z"}
+	if got := remoteString(value, "name"); got != "123" {
+		t.Fatalf("remote string = %q", got)
+	}
+	if got := remoteTime(value, "created_at"); got.IsZero() {
+		t.Fatalf("remote time is zero")
+	}
+	if got := remoteString(nil, "missing"); got != "" {
+		t.Fatalf("nil remote string = %q", got)
+	}
+	counts := []control.Count{control.NewCount("messages", "Messages", 42)}
+	if got := countValue(counts, "messages"); got != 42 {
+		t.Fatalf("count = %d", got)
+	}
+	if got := countValue(counts, "guilds"); got != 0 {
+		t.Fatalf("missing count = %d", got)
+	}
+}
+
+func TestRuntimeRemoteArchivesAndWhoamiUseConfiguredClient(t *testing.T) {
+	var out bytes.Buffer
+	r := &runtime{
+		ctx:    context.Background(),
+		stdout: &out,
+		json:   true,
+		cfg: config.Config{Remote: crawlremote.Config{
+			Mode:     crawlremote.ModeCloud,
+			Endpoint: "https://remote.example.test",
+			Archive:  "discrawl/openclaw",
+		}},
+		newRemote: func(config.Config) (remoteArchiveClient, error) {
+			return fakeRemoteClient{}, nil
+		},
+	}
+	if err := r.runRemoteArchives(); err != nil {
+		t.Fatalf("archives: %v", err)
+	}
+	if !strings.Contains(out.String(), "discrawl/openclaw") {
+		t.Fatalf("archives output = %s", out.String())
+	}
+	out.Reset()
+	if err := r.runRemoteWhoami(nil); err != nil {
+		t.Fatalf("whoami: %v", err)
+	}
+	if !strings.Contains(out.String(), "alice") {
+		t.Fatalf("whoami output = %s", out.String())
+	}
+}
+
+func TestRunRemoteDispatchesConfiguredCommands(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.toml")
+	cfg := config.Default()
+	cfg.Remote.Mode = crawlremote.ModeCloud
+	cfg.Remote.Endpoint = "https://remote.example.test"
+	cfg.Remote.Archive = "discrawl/openclaw"
+	if err := config.Write(cfgPath, cfg); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	var out bytes.Buffer
+	r := &runtime{
+		ctx:        context.Background(),
+		configPath: cfgPath,
+		stdout:     &out,
+		json:       true,
+		newRemote: func(config.Config) (remoteArchiveClient, error) {
+			return fakeRemoteClient{}, nil
+		},
+	}
+	if err := r.runRemote([]string{"archives"}); err != nil {
+		t.Fatalf("remote archives: %v", err)
+	}
+	if !strings.Contains(out.String(), "discrawl/openclaw") {
+		t.Fatalf("archives output = %s", out.String())
+	}
+	out.Reset()
+	if err := r.runRemote([]string{"whoami"}); err != nil {
+		t.Fatalf("remote whoami: %v", err)
+	}
+	if !strings.Contains(out.String(), "alice") {
+		t.Fatalf("whoami output = %s", out.String())
+	}
+	if err := r.runRemote([]string{"unknown"}); err == nil || !strings.Contains(err.Error(), "unknown remote subcommand") {
+		t.Fatalf("unknown err = %v", err)
+	}
+	out.Reset()
+	if err := r.runRemote(nil); err != nil {
+		t.Fatalf("remote help: %v", err)
+	}
+	if !strings.Contains(out.String(), "discrawl remote") {
+		t.Fatalf("help output = %s", out.String())
+	}
+	if err := r.runRemote([]string{"status", "extra"}); err == nil || !strings.Contains(err.Error(), "takes no arguments") {
+		t.Fatalf("status args err = %v", err)
+	}
+	if err := r.runCloud([]string{"unknown"}); err == nil || !strings.Contains(err.Error(), "unknown cloud subcommand") {
+		t.Fatalf("cloud unknown err = %v", err)
+	}
+	out.Reset()
+	if err := r.runCloud(nil); err != nil {
+		t.Fatalf("cloud help err = %v", err)
+	}
+	if !strings.Contains(out.String(), "discrawl cloud") {
+		t.Fatalf("cloud help output = %s", out.String())
+	}
+}
+
+func TestRemoteReadCommandsValidateAndQuery(t *testing.T) {
+	client := &queryRemoteClient{}
+	r := &runtime{
+		ctx: context.Background(),
+		cfg: config.Config{Remote: crawlremote.Config{
+			Mode:     crawlremote.ModeCloud,
+			Endpoint: "https://remote.example.test",
+			Archive:  "discrawl/openclaw",
+		}},
+		newRemote: func(config.Config) (remoteArchiveClient, error) {
+			return client, nil
+		},
+	}
+
+	for _, tc := range []struct {
+		name string
+		run  func() error
+		want string
+	}{
+		{name: "search dm", run: func() error {
+			_, err := r.runRemoteSearch(store.SearchOptions{Query: "hello"}, "fts", true)
+			return err
+		}, want: "--dm"},
+		{name: "search semantic", run: func() error {
+			_, err := r.runRemoteSearch(store.SearchOptions{Query: "hello"}, "semantic", false)
+			return err
+		}, want: "fts mode"},
+		{name: "search author", run: func() error {
+			_, err := r.runRemoteSearch(store.SearchOptions{Query: "hello", Author: "alice"}, "fts", false)
+			return err
+		}, want: "--author"},
+		{name: "messages unsupported window", run: func() error {
+			_, err := r.runRemoteMessages(store.MessageListOptions{Since: time.Now()}, false)
+			return err
+		}, want: "currently supports"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := tc.run(); err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("error = %v, want %q", err, tc.want)
+			}
+		})
+	}
+
+	results, err := r.runRemoteSearch(store.SearchOptions{Query: "hello", GuildIDs: []string{"g1"}, Channel: "c1", Limit: 3}, "fts", false)
+	if err != nil {
+		t.Fatalf("remote search: %v", err)
+	}
+	if len(results) != 1 || results[0].Content != "hello from remote" || results[0].CreatedAt.IsZero() {
+		t.Fatalf("search results = %#v", results)
+	}
+	if client.last.Name != "discrawl.messages.search" || client.last.Limit != 3 || client.last.Args["guild_id"] != "g1" {
+		t.Fatalf("search request = %#v", client.last)
+	}
+
+	messages, err := r.runRemoteMessages(store.MessageListOptions{Channel: "c1"}, false)
+	if err != nil {
+		t.Fatalf("remote messages: %v", err)
+	}
+	if len(messages) != 1 || messages[0].Source != "remote" || messages[0].Content != "hello from remote" {
+		t.Fatalf("messages = %#v", messages)
+	}
+	if client.last.Name != "discrawl.messages.list" || client.last.Limit != 500 {
+		t.Fatalf("messages request = %#v", client.last)
+	}
+}
+
+func TestRemoteLoginValidationAndClientErrors(t *testing.T) {
+	r := &runtime{
+		ctx:        context.Background(),
+		configPath: filepath.Join(t.TempDir(), "missing.toml"),
+		stdout:     &bytes.Buffer{},
+		stderr:     &bytes.Buffer{},
+	}
+	for _, tc := range []struct {
+		name string
+		args []string
+		want string
+	}{
+		{name: "too many args", args: []string{"one", "two"}, want: "at most one"},
+		{name: "invalid timeout", args: []string{"--endpoint", "https://remote.example.test", "--timeout", "0s"}, want: "invalid --timeout"},
+		{name: "invalid poll", args: []string{"--endpoint", "https://remote.example.test", "--poll-interval", "0s"}, want: "invalid --poll-interval"},
+		{name: "missing endpoint", args: nil, want: "requires --endpoint"},
+		{name: "empty github token env", args: []string{"--endpoint", "https://remote.example.test", "--github-token-env", "DISCRAWL_EMPTY_GITHUB_TOKEN"}, want: "DISCRAWL_EMPTY_GITHUB_TOKEN is empty"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.name == "empty github token env" {
+				t.Setenv("DISCRAWL_EMPTY_GITHUB_TOKEN", "")
+			}
+			err := r.runRemoteLogin(tc.args)
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("error = %v, want %q", err, tc.want)
+			}
+		})
+	}
+
+	cfg := config.Default()
+	cfg.Remote.Auth.TokenSource = "none"
+	cfg.Remote.Endpoint = ""
+	if _, err := (&runtime{cfg: cfg}).remoteClient(false); err == nil || !strings.Contains(err.Error(), "remote.endpoint") {
+		t.Fatalf("missing endpoint err = %v", err)
+	}
+	cfg.Remote.Endpoint = "https://remote.example.test"
+	if _, err := (&runtime{cfg: cfg}).remoteClient(true); err == nil || !strings.Contains(err.Error(), "remote.archive") {
+		t.Fatalf("missing archive err = %v", err)
+	}
+	cfg.Remote.Archive = "discrawl/openclaw"
+	if _, err := (&runtime{cfg: cfg}).remoteClient(true); err == nil || !strings.Contains(err.Error(), "remote token") {
+		t.Fatalf("missing token err = %v", err)
+	}
+
+	loginRuntime := &runtime{configPath: filepath.Join(t.TempDir(), "config.toml"), stdout: &bytes.Buffer{}}
+	if err := loginRuntime.finishRemoteLogin(config.Default(), "github-oauth", crawlremote.LoginPollResult{Status: "pending"}); err == nil || !strings.Contains(err.Error(), "pending") {
+		t.Fatalf("pending login err = %v", err)
+	}
+	if err := loginRuntime.finishRemoteLogin(config.Default(), "github-oauth", crawlremote.LoginPollResult{Status: "complete"}); err == nil || !strings.Contains(err.Error(), "without token") {
+		t.Fatalf("empty token err = %v", err)
+	}
+}
+
+func TestRuntimeWithConfigFallbacks(t *testing.T) {
+	missing := &runtime{configPath: filepath.Join(t.TempDir(), "missing.toml")}
+	called := false
+	if err := missing.withConfig(func() error {
+		called = true
+		if missing.cfg.DBPath == "" {
+			t.Fatalf("default config not normalized")
+		}
+		return nil
+	}); err != nil || !called {
+		t.Fatalf("missing config fallback err=%v called=%v", err, called)
+	}
+
+	badPath := filepath.Join(t.TempDir(), "bad.toml")
+	if err := os.WriteFile(badPath, []byte("[bad"), 0o600); err != nil {
+		t.Fatalf("write bad config: %v", err)
+	}
+	if err := (&runtime{configPath: badPath}).withConfig(func() error { return nil }); err == nil {
+		t.Fatalf("expected invalid config error")
+	}
+}
+
+func TestPollRemoteLoginStates(t *testing.T) {
+	t.Run("pending then complete", func(t *testing.T) {
+		polls := 0
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			polls++
+			w.Header().Set("Content-Type", "application/json")
+			if polls == 1 {
+				_ = json.NewEncoder(w).Encode(crawlremote.LoginPollResult{Status: "pending"})
+				return
+			}
+			_ = json.NewEncoder(w).Encode(crawlremote.LoginPollResult{Status: "complete", Token: "session-token", Login: "alice"})
+		}))
+		defer server.Close()
+
+		client, err := crawlremote.NewClientFromConfig(crawlremote.Config{Endpoint: server.URL}, crawlremote.Options{})
+		if err != nil {
+			t.Fatalf("client: %v", err)
+		}
+		result, err := pollRemoteLogin(context.Background(), client, "login-1", "secret", time.Second, time.Millisecond)
+		if err != nil {
+			t.Fatalf("poll: %v", err)
+		}
+		if result.Token != "session-token" || polls != 2 {
+			t.Fatalf("result=%#v polls=%d", result, polls)
+		}
+	})
+
+	for _, tc := range []struct {
+		name   string
+		result crawlremote.LoginPollResult
+		want   string
+	}{
+		{name: "complete missing token", result: crawlremote.LoginPollResult{Status: "complete"}, want: "without token"},
+		{name: "error with message", result: crawlremote.LoginPollResult{Status: "error", Error: "denied"}, want: "denied"},
+		{name: "error without message", result: crawlremote.LoginPollResult{Status: "error"}, want: "remote login failed"},
+		{name: "unknown status", result: crawlremote.LoginPollResult{Status: "confused"}, want: `status "confused"`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				_ = json.NewEncoder(w).Encode(tc.result)
+			}))
+			defer server.Close()
+
+			client, err := crawlremote.NewClientFromConfig(crawlremote.Config{Endpoint: server.URL}, crawlremote.Options{})
+			if err != nil {
+				t.Fatalf("client: %v", err)
+			}
+			_, err = pollRemoteLogin(context.Background(), client, "login-1", "secret", time.Second, time.Millisecond)
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("error = %v, want %q", err, tc.want)
+			}
+		})
+	}
+}
+
+func TestSendIngestRowsBatchesAndFinalizes(t *testing.T) {
+	var requests []crawlremote.IngestRequest
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body crawlremote.IngestRequest
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		requests = append(requests, body)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(crawlremote.IngestResult{RowsAccepted: int64(len(body.Rows)), Complete: body.Final})
+	}))
+	defer server.Close()
+
+	client, err := crawlremote.NewClientFromConfig(crawlremote.Config{Endpoint: server.URL}, crawlremote.Options{
+		TokenProvider: crawlremote.StaticToken("publish-token"),
+	})
+	if err != nil {
+		t.Fatalf("client: %v", err)
+	}
+	rows := make([][]any, discrawlCloudBatchSize+1)
+	for i := range rows {
+		rows[i] = []any{i}
+	}
+	accepted, err := sendIngestRows(context.Background(), client, "discrawl/openclaw", crawlremote.IngestManifest{App: "discrawl"}, "messages", []string{"id"}, rows, true)
+	if err != nil {
+		t.Fatalf("send ingest: %v", err)
+	}
+	if accepted != int64(len(rows)) || len(requests) != 2 {
+		t.Fatalf("accepted=%d requests=%d", accepted, len(requests))
+	}
+	if requests[0].Cursor != "" || requests[0].Final || len(requests[0].Rows) != discrawlCloudBatchSize {
+		t.Fatalf("first request = %#v", requests[0])
+	}
+	if requests[1].Cursor != "250" || !requests[1].Final || len(requests[1].Rows) != 1 {
+		t.Fatalf("second request = %#v", requests[1])
+	}
+}

--- a/internal/cli/remote_read_commands.go
+++ b/internal/cli/remote_read_commands.go
@@ -1,0 +1,136 @@
+package cli
+
+import (
+	"errors"
+	"fmt"
+	"time"
+
+	crawlremote "github.com/openclaw/crawlkit/remote"
+	"github.com/openclaw/discrawl/internal/store"
+)
+
+func (r *runtime) runRemoteSearch(opts store.SearchOptions, mode string, dm bool) ([]store.SearchResult, error) {
+	if dm {
+		return nil, usageErr(errors.New("cloud search does not support --dm"))
+	}
+	if mode != "" && mode != "fts" {
+		return nil, usageErr(fmt.Errorf("cloud search supports fts mode only, got %q", mode))
+	}
+	if opts.Author != "" {
+		return nil, usageErr(errors.New("cloud search does not support --author yet"))
+	}
+	guildID, err := singleRemoteGuild(opts.GuildIDs)
+	if err != nil {
+		return nil, err
+	}
+	client, err := r.remoteClient(true)
+	if err != nil {
+		return nil, err
+	}
+	result, err := client.Query(r.ctx, "discrawl", r.cfg.Remote.Archive, crawlremote.QueryRequest{
+		Name: "discrawl.messages.search",
+		Args: map[string]any{
+			"query":      opts.Query,
+			"channel_id": opts.Channel,
+			"guild_id":   guildID,
+		},
+		Limit: opts.Limit,
+	})
+	if err != nil {
+		return nil, err
+	}
+	out := make([]store.SearchResult, 0, len(result.Values))
+	for _, value := range result.Values {
+		out = append(out, store.SearchResult{
+			MessageID:   remoteString(value, "message_id"),
+			GuildID:     remoteString(value, "guild_id"),
+			ChannelID:   remoteString(value, "channel_id"),
+			ChannelName: remoteString(value, "channel_name"),
+			AuthorID:    remoteString(value, "author_id"),
+			AuthorName:  remoteString(value, "author_username"),
+			Content:     remoteString(value, "content"),
+			CreatedAt:   remoteTime(value, "created_at"),
+		})
+	}
+	return out, nil
+}
+
+func (r *runtime) runRemoteMessages(opts store.MessageListOptions, dm bool) ([]store.MessageRow, error) {
+	if dm {
+		return nil, usageErr(errors.New("cloud messages does not support --dm"))
+	}
+	if opts.Author != "" {
+		return nil, usageErr(errors.New("cloud messages does not support --author yet"))
+	}
+	if !opts.Since.IsZero() || !opts.Before.IsZero() || opts.Last > 0 {
+		return nil, usageErr(errors.New("cloud messages currently supports --channel, --guild, --guilds, and --limit"))
+	}
+	guildID, err := singleRemoteGuild(opts.GuildIDs)
+	if err != nil {
+		return nil, err
+	}
+	client, err := r.remoteClient(true)
+	if err != nil {
+		return nil, err
+	}
+	limit := opts.Limit
+	if limit == 0 {
+		limit = 500
+	}
+	result, err := client.Query(r.ctx, "discrawl", r.cfg.Remote.Archive, crawlremote.QueryRequest{
+		Name: "discrawl.messages.list",
+		Args: map[string]any{
+			"channel_id": opts.Channel,
+			"guild_id":   guildID,
+		},
+		Limit: limit,
+	})
+	if err != nil {
+		return nil, err
+	}
+	out := make([]store.MessageRow, 0, len(result.Values))
+	for _, value := range result.Values {
+		out = append(out, store.MessageRow{
+			MessageID:   remoteString(value, "message_id"),
+			GuildID:     remoteString(value, "guild_id"),
+			ChannelID:   remoteString(value, "channel_id"),
+			ChannelName: remoteString(value, "channel_name"),
+			AuthorID:    remoteString(value, "author_id"),
+			AuthorName:  remoteString(value, "author_username"),
+			Content:     remoteString(value, "content"),
+			CreatedAt:   remoteTime(value, "created_at"),
+			Source:      "remote",
+		})
+	}
+	return out, nil
+}
+
+func singleRemoteGuild(guildIDs []string) (string, error) {
+	if len(guildIDs) > 1 {
+		return "", usageErr(errors.New("cloud remote supports one guild filter at a time"))
+	}
+	if len(guildIDs) == 1 {
+		return guildIDs[0], nil
+	}
+	return "", nil
+}
+
+func remoteString(value map[string]any, key string) string {
+	if value == nil {
+		return ""
+	}
+	if raw := value[key]; raw != nil {
+		return fmt.Sprint(raw)
+	}
+	return ""
+}
+
+func remoteTime(value map[string]any, key string) time.Time {
+	raw := remoteString(value, key)
+	for _, layout := range []string{time.RFC3339Nano, time.RFC3339} {
+		if t, err := time.Parse(layout, raw); err == nil {
+			return t
+		}
+	}
+	return time.Time{}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -10,28 +10,31 @@ import (
 	"time"
 
 	crawlconfig "github.com/openclaw/crawlkit/config"
+	crawlremote "github.com/openclaw/crawlkit/remote"
 )
 
 const (
 	DefaultConfigEnv           = "DISCRAWL_CONFIG"
 	DefaultTokenEnv            = "DISCORD_BOT_TOKEN"
+	DefaultRemoteTokenEnv      = "DISCRAWL_REMOTE_TOKEN"
 	DefaultTokenKeyringService = "discrawl"
 	DefaultTokenKeyringAccount = "discord_bot_token"
 )
 
 type Config struct {
-	Version        int           `toml:"version"`
-	GuildID        string        `toml:"guild_id,omitempty"`
-	DefaultGuildID string        `toml:"default_guild_id,omitempty"`
-	GuildIDs       []string      `toml:"guild_ids,omitempty"`
-	DBPath         string        `toml:"db_path"`
-	CacheDir       string        `toml:"cache_dir"`
-	LogDir         string        `toml:"log_dir"`
-	Discord        DiscordConfig `toml:"discord"`
-	Desktop        DesktopConfig `toml:"desktop"`
-	Sync           SyncConfig    `toml:"sync"`
-	Search         SearchConfig  `toml:"search"`
-	Share          ShareConfig   `toml:"share"`
+	Version        int                `toml:"version"`
+	GuildID        string             `toml:"guild_id,omitempty"`
+	DefaultGuildID string             `toml:"default_guild_id,omitempty"`
+	GuildIDs       []string           `toml:"guild_ids,omitempty"`
+	DBPath         string             `toml:"db_path"`
+	CacheDir       string             `toml:"cache_dir"`
+	LogDir         string             `toml:"log_dir"`
+	Discord        DiscordConfig      `toml:"discord"`
+	Desktop        DesktopConfig      `toml:"desktop"`
+	Sync           SyncConfig         `toml:"sync"`
+	Search         SearchConfig       `toml:"search"`
+	Share          ShareConfig        `toml:"share"`
+	Remote         crawlremote.Config `toml:"remote"`
 }
 
 type DiscordConfig struct {
@@ -157,6 +160,10 @@ func Default() Config {
 			AutoUpdate: true,
 			StaleAfter: "15m",
 			Media:      new(true),
+		},
+		Remote: crawlremote.Config{
+			Mode:     crawlremote.ModeLocal,
+			TokenEnv: DefaultRemoteTokenEnv,
 		},
 	}
 }
@@ -310,6 +317,10 @@ func (c *Config) Normalize() error {
 	}
 	c.Share.Filter.IncludeChannelIDs = uniqueStrings(c.Share.Filter.IncludeChannelIDs)
 	c.Share.Filter.ExcludeChannelIDs = uniqueStrings(c.Share.Filter.ExcludeChannelIDs)
+	if c.Remote.TokenEnv == "" {
+		c.Remote.TokenEnv = DefaultRemoteTokenEnv
+	}
+	c.Remote.Normalize()
 	if c.Search.Embeddings.MaxInputChars <= 0 {
 		c.Search.Embeddings.MaxInputChars = 12000
 	}
@@ -375,6 +386,14 @@ func (c Config) ShareMediaEnabled() bool {
 
 func (c Config) ShareEnabled() bool {
 	return strings.TrimSpace(c.Share.Remote) != ""
+}
+
+func (c Config) RemoteEnabled() bool {
+	return c.Remote.Enabled()
+}
+
+func (c Config) RemoteCloudReadOnly() bool {
+	return strings.EqualFold(strings.TrimSpace(c.Remote.Mode), crawlremote.ModeCloud)
 }
 
 func EnsureRuntimeDirs(cfg Config) error {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -18,6 +18,7 @@ func TestNormalizeFillsDefaults(t *testing.T) {
 	require.Equal(t, 1, cfg.Version)
 	require.Equal(t, "env", cfg.Discord.TokenSource)
 	require.Equal(t, DefaultTokenEnv, cfg.Discord.TokenEnv)
+	require.Equal(t, DefaultRemoteTokenEnv, cfg.Remote.TokenEnv)
 	require.Equal(t, DefaultTokenKeyringService, cfg.Discord.TokenKeyringService)
 	require.Equal(t, DefaultTokenKeyringAccount, cfg.Discord.TokenKeyringAccount)
 	require.Equal(t, defaultSyncConcurrency(), cfg.Sync.Concurrency)
@@ -34,6 +35,10 @@ func TestNormalizeFillsDefaults(t *testing.T) {
 	require.False(t, cfg.ShareEnabled())
 	cfg.Share.Remote = "git@example.com:org/archive.git"
 	require.True(t, cfg.ShareEnabled())
+	require.False(t, cfg.RemoteEnabled())
+	cfg.Remote.Mode = "cloud"
+	require.True(t, cfg.RemoteEnabled())
+	require.True(t, cfg.RemoteCloudReadOnly())
 	require.Equal(t, "openai", cfg.Search.Embeddings.Provider)
 	require.Equal(t, "text-embedding-3-small", cfg.Search.Embeddings.Model)
 	require.Empty(t, cfg.Search.Embeddings.BaseURL)
@@ -325,6 +330,7 @@ func TestWriteAndLoadRoundTrip(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "g1", loaded.EffectiveDefaultGuildID())
 	require.Equal(t, []string{"g1", "g2"}, loaded.GuildIDs)
+	require.Equal(t, DefaultRemoteTokenEnv, loaded.Remote.TokenEnv)
 	require.NotNil(t, loaded.Sync.AttachmentText)
 	require.True(t, *loaded.Sync.AttachmentText)
 }

--- a/internal/config/remote_token.go
+++ b/internal/config/remote_token.go
@@ -1,0 +1,99 @@
+package config
+
+import (
+	"errors"
+	"fmt"
+	"net/url"
+	"os"
+	"strings"
+
+	crawlremote "github.com/openclaw/crawlkit/remote"
+	"github.com/zalando/go-keyring"
+)
+
+const (
+	DefaultRemoteTokenKeyringService = "crawl-remote"
+	DefaultRemoteTokenKeyringAccount = "discrawl"
+)
+
+var (
+	remoteTokenKeyringGet = keyring.Get
+	remoteTokenKeyringSet = keyring.Set
+)
+
+func ResolveRemoteToken(cfg Config) (TokenResolution, error) {
+	if err := cfg.Normalize(); err != nil {
+		return TokenResolution{}, err
+	}
+	source := strings.TrimSpace(cfg.Remote.Auth.TokenSource)
+	switch source {
+	case "", "env":
+		if token := strings.TrimSpace(os.Getenv(cfg.Remote.TokenEnv)); token != "" {
+			return TokenResolution{Token: token, Source: "env", Path: cfg.Remote.TokenEnv}, nil
+		}
+		if cfg.Remote.Auth.KeyringService != "" || cfg.Remote.Auth.KeyringAccount != "" {
+			return resolveRemoteTokenFromKeyring(cfg.Remote)
+		}
+		return TokenResolution{}, nil
+	case "keyring":
+		return resolveRemoteTokenFromKeyring(cfg.Remote)
+	case "none":
+		return TokenResolution{}, crawlremote.ErrMissingToken
+	default:
+		return TokenResolution{}, fmt.Errorf("unsupported remote token_source %q", source)
+	}
+}
+
+func StoreRemoteToken(cfg Config, token string) (crawlremote.AuthConfig, error) {
+	auth := normalizedRemoteAuth(cfg.Remote)
+	token = strings.TrimSpace(token)
+	if token == "" {
+		return auth, errors.New("remote token is empty")
+	}
+	if err := remoteTokenKeyringSet(auth.KeyringService, auth.KeyringAccount, token); err != nil {
+		return auth, err
+	}
+	auth.TokenSource = "keyring"
+	return auth, nil
+}
+
+func resolveRemoteTokenFromKeyring(remote crawlremote.Config) (TokenResolution, error) {
+	auth := normalizedRemoteAuth(remote)
+	raw, err := remoteTokenKeyringGet(auth.KeyringService, auth.KeyringAccount)
+	if err != nil {
+		return TokenResolution{}, err
+	}
+	token := strings.TrimSpace(raw)
+	if token == "" {
+		return TokenResolution{}, errors.New("keyring item is empty")
+	}
+	return TokenResolution{
+		Token:  token,
+		Source: "keyring",
+		Path:   auth.KeyringService + "/" + auth.KeyringAccount,
+	}, nil
+}
+
+func normalizedRemoteAuth(remote crawlremote.Config) crawlremote.AuthConfig {
+	remote.Normalize()
+	auth := remote.Auth
+	if strings.TrimSpace(auth.KeyringService) == "" {
+		auth.KeyringService = DefaultRemoteTokenKeyringService
+	}
+	if strings.TrimSpace(auth.KeyringAccount) == "" {
+		auth.KeyringAccount = defaultRemoteTokenAccount(remote)
+	}
+	return auth
+}
+
+func defaultRemoteTokenAccount(remote crawlremote.Config) string {
+	if archive := strings.TrimSpace(remote.Archive); archive != "" {
+		return "discrawl:" + archive
+	}
+	if endpoint := strings.TrimSpace(remote.Endpoint); endpoint != "" {
+		if parsed, err := url.Parse(endpoint); err == nil && parsed.Host != "" {
+			return "discrawl:" + parsed.Host
+		}
+	}
+	return DefaultRemoteTokenKeyringAccount
+}

--- a/internal/config/remote_token_test.go
+++ b/internal/config/remote_token_test.go
@@ -1,0 +1,93 @@
+package config
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	crawlremote "github.com/openclaw/crawlkit/remote"
+)
+
+func TestRemoteTokenResolutionWithKeyring(t *testing.T) {
+	originalGet := remoteTokenKeyringGet
+	originalSet := remoteTokenKeyringSet
+	t.Cleanup(func() {
+		remoteTokenKeyringGet = originalGet
+		remoteTokenKeyringSet = originalSet
+	})
+
+	keyringValues := map[string]string{}
+	remoteTokenKeyringGet = func(service, account string) (string, error) {
+		value, ok := keyringValues[service+"\x00"+account]
+		if !ok {
+			return "", errors.New("missing keyring item")
+		}
+		return value, nil
+	}
+	remoteTokenKeyringSet = func(service, account, password string) error {
+		keyringValues[service+"\x00"+account] = password
+		return nil
+	}
+
+	cfg := Default()
+	cfg.Remote.Endpoint = "https://worker.example.test"
+	cfg.Remote.Archive = "discrawl/openclaw"
+	cfg.Remote.TokenEnv = "DISCRAWL_TEST_REMOTE_TOKEN"
+	t.Setenv("DISCRAWL_TEST_REMOTE_TOKEN", "env-session")
+
+	resolved, err := ResolveRemoteToken(cfg)
+	if err != nil {
+		t.Fatalf("resolve env token: %v", err)
+	}
+	if resolved.Token != "env-session" || resolved.Source != "env" || resolved.Path != "DISCRAWL_TEST_REMOTE_TOKEN" {
+		t.Fatalf("env token = %#v", resolved)
+	}
+
+	t.Setenv("DISCRAWL_TEST_REMOTE_TOKEN", "")
+	auth, err := StoreRemoteToken(cfg, " keyring-session ")
+	if err != nil {
+		t.Fatalf("store token: %v", err)
+	}
+	if auth.TokenSource != "keyring" || auth.KeyringService != DefaultRemoteTokenKeyringService || auth.KeyringAccount != "discrawl:discrawl/openclaw" {
+		t.Fatalf("auth defaults = %#v", auth)
+	}
+	cfg.Remote.Auth = auth
+	resolved, err = ResolveRemoteToken(cfg)
+	if err != nil {
+		t.Fatalf("resolve keyring token: %v", err)
+	}
+	if resolved.Token != "keyring-session" || resolved.Source != "keyring" {
+		t.Fatalf("keyring token = %#v", resolved)
+	}
+
+	cfg.Remote.Auth.TokenSource = "none"
+	if _, err := ResolveRemoteToken(cfg); !errors.Is(err, crawlremote.ErrMissingToken) {
+		t.Fatalf("none token source error = %v", err)
+	}
+
+	cfg.Remote.Auth.TokenSource = "bogus"
+	if _, err := ResolveRemoteToken(cfg); err == nil || !strings.Contains(err.Error(), "unsupported remote token_source") {
+		t.Fatalf("unsupported token source error = %v", err)
+	}
+
+	if _, err := StoreRemoteToken(cfg, " "); err == nil || !strings.Contains(err.Error(), "empty") {
+		t.Fatalf("empty store error = %v", err)
+	}
+	cfg.Remote.Auth = crawlremote.AuthConfig{TokenSource: "keyring", KeyringService: "svc", KeyringAccount: "empty"}
+	keyringValues["svc\x00empty"] = " "
+	if _, err := ResolveRemoteToken(cfg); err == nil || !strings.Contains(err.Error(), "keyring item is empty") {
+		t.Fatalf("empty keyring error = %v", err)
+	}
+}
+
+func TestDefaultRemoteTokenAccountFallbacks(t *testing.T) {
+	if got := defaultRemoteTokenAccount(crawlremote.Config{Archive: "discrawl/example"}); got != "discrawl:discrawl/example" {
+		t.Fatalf("archive account = %q", got)
+	}
+	if got := defaultRemoteTokenAccount(crawlremote.Config{Endpoint: "https://crawl.example.test/base"}); got != "discrawl:crawl.example.test" {
+		t.Fatalf("endpoint account = %q", got)
+	}
+	if got := defaultRemoteTokenAccount(crawlremote.Config{}); got != DefaultRemoteTokenKeyringAccount {
+		t.Fatalf("default account = %q", got)
+	}
+}


### PR DESCRIPTION
## Summary
- add Cloudflare remote archive config/read mode and `discrawl cloud publish`
- add GitHub-backed remote login with OAuth and token-env bootstrap
- keep existing Git share publish/subscribe/update flows unchanged
- clarify that the Worker is deployed separately in `openclaw/crawl-remote`; discrawl only stores endpoint/archive config and calls it

## Validation
- `GOWORK=off go test -count=1 ./internal/cli ./internal/config -run 'TestRemoteLoginStoresKeyringToken|TestRemoteLoginWithGitHubTokenEnvStoresKeyringToken|TestCloudStatusJSONUsesRemoteWithoutLocalDB|TestCloudSearchAndMessagesUseRemoteWithoutLocalDB|TestConfig'`
- `GOWORK=off go test -count=1 ./...`
- live deployed Worker proof with temp config and no local DB

## Release
- consumes `github.com/openclaw/crawlkit v0.8.0`
