### PR TITLE
feat(remote): publish sanitized cloud SQLite archive objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Changes
 
-- Update `crawlkit` to v0.8.0.
+- Update `crawlkit` to v0.10.0.
 - Add read-only Cloudflare remote archive scaffolding with `[remote]` config,
   `subscribe-cloud`, GitHub-backed `remote login` with OAuth or token-env
   bootstrap, `remote status`, `remote archives`, and cloud-mode `status --json`
@@ -14,6 +14,9 @@
 - Add `discrawl cloud publish` to export non-DM local SQLite rows into the
   Cloudflare remote archive ingest API without changing Git snapshot
   publishing.
+- Mirror the non-DM local SQLite archive into the Worker-backed R2 object store
+  during `discrawl cloud publish`, alongside the D1 row ingest used for live
+  queries.
 
 ### Fixes
 

--- a/go.mod
+++ b/go.mod
@@ -44,7 +44,7 @@ require (
 	github.com/muesli/cancelreader v0.2.2 // indirect
 	github.com/muesli/termenv v0.16.0 // indirect
 	github.com/ncruces/go-strftime v1.0.0 // indirect
-	github.com/openclaw/crawlkit v0.8.0
+	github.com/openclaw/crawlkit v0.10.0
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect

--- a/go.sum
+++ b/go.sum
@@ -71,8 +71,8 @@ github.com/muesli/termenv v0.16.0 h1:S5AlUN9dENB57rsbnkPyfdGuWIlkmzJjbFf0Tf5FWUc
 github.com/muesli/termenv v0.16.0/go.mod h1:ZRfOIKPFDYQoDFF4Olj7/QJbW60Ol/kL1pU3VfY/Cnk=
 github.com/ncruces/go-strftime v1.0.0 h1:HMFp8mLCTPp341M/ZnA4qaf7ZlsbTc+miZjCLOFAw7w=
 github.com/ncruces/go-strftime v1.0.0/go.mod h1:Fwc5htZGVVkseilnfgOVb9mKy6w1naJmn9CehxcKcls=
-github.com/openclaw/crawlkit v0.8.0 h1:EZEAMy7dI6zVn+AC6lN8GycMY8bV3TF3KnheG55A0uU=
-github.com/openclaw/crawlkit v0.8.0/go.mod h1:2XkSx3N8yzyjc+Jyf1Zl9VEQVlElh/dzBMW1cRMQQGw=
+github.com/openclaw/crawlkit v0.10.0 h1:FKe5Aus+lgik76KswimTvnlwMdfiuaZV1MGign6z73k=
+github.com/openclaw/crawlkit v0.10.0/go.mod h1:2XkSx3N8yzyjc+Jyf1Zl9VEQVlElh/dzBMW1cRMQQGw=
 github.com/pelletier/go-toml/v2 v2.3.1 h1:MYEvvGnQjeNkRF1qUuGolNtNExTDwct51yp7olPtrEc=
 github.com/pelletier/go-toml/v2 v2.3.1/go.mod h1:2gIqNv+qfxSVS7cM2xJQKtLSTLUE9V8t9Stt+h56mCY=
 github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"bytes"
 	"context"
+	"database/sql"
 	"encoding/json"
 	"errors"
 	"flag"
@@ -92,6 +93,10 @@ func TestCommandValidationEdges(t *testing.T) {
 		{"--config", cfgPath, "sync", "--source", "bogus"},
 		{"--config", cfgPath, "sync", "--since", "not-time"},
 		{"--config", cfgPath, "sync", "--no-update", "--update", "force"},
+		{"--config", cfgPath, "cloud", "publish", "--bogus"},
+		{"--config", cfgPath, "cloud", "publish", "extra"},
+		{"--config", cfgPath, "cloud", "publish", "--json"},
+		{"--config", cfgPath, "cloud", "publish", "--remote", "https://remote.example"},
 		{"--config", cfgPath, "publish", "--remote", ""},
 		{"--config", cfgPath, "subscribe"},
 		{"--config", cfgPath, "update", "extra"},
@@ -1300,8 +1305,59 @@ func TestCloudPublishSendsNonDMRows(t *testing.T) {
 	tokenEnv := "DISCRAWL_TEST_PUBLISH_TOKEN"
 	t.Setenv(tokenEnv, "publish-token")
 	seenTables := map[string]crawlremote.IngestRequest{}
+	var sawSQLiteUpload bool
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		assert.Equal(t, "Bearer publish-token", req.Header.Get("Authorization"))
+		if req.Method == http.MethodPut && req.URL.EscapedPath() == "/v1/apps/discrawl/archives/discrawl%2Fopenclaw/sqlite" {
+			sawSQLiteUpload = true
+			payload, err := io.ReadAll(req.Body)
+			if err != nil {
+				t.Errorf("read sqlite upload: %v", err)
+				http.Error(w, err.Error(), http.StatusBadRequest)
+				return
+			}
+			if !bytes.HasPrefix(payload, []byte("SQLite format 3")) {
+				t.Errorf("sqlite upload should contain a sqlite image")
+				http.Error(w, "not sqlite", http.StatusBadRequest)
+				return
+			}
+			uploadPath := filepath.Join(dir, "uploaded-cloud.db")
+			if err := os.WriteFile(uploadPath, payload, 0o600); err != nil {
+				t.Errorf("write sqlite upload: %v", err)
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+				return
+			}
+			uploadDB, err := sql.Open("sqlite", uploadPath)
+			if err != nil {
+				t.Errorf("open sqlite upload: %v", err)
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+				return
+			}
+			defer func() { _ = uploadDB.Close() }()
+			var dmMessages int
+			if err := uploadDB.QueryRowContext(ctx, "select count(*) from messages where guild_id = ?", store.DirectMessageGuildID).Scan(&dmMessages); err != nil {
+				t.Errorf("count dm messages: %v", err)
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+				return
+			}
+			assert.Zero(t, dmMessages)
+			var tableCount int
+			if err := uploadDB.QueryRowContext(ctx, "select count(*) from sqlite_master where type = 'table' and name in ('guilds', 'channels', 'members', 'messages')").Scan(&tableCount); err != nil {
+				t.Errorf("count cloud tables: %v", err)
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+				return
+			}
+			assert.Equal(t, 4, tableCount)
+			assert.NotEmpty(t, req.Header.Get("X-Crawl-Content-Sha256"))
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(crawlremote.SQLiteUploadResult{
+				App:      "discrawl",
+				Archive:  "discrawl/openclaw",
+				Complete: true,
+				Object:   &crawlremote.SQLiteObject{Key: "v1/discrawl/discrawl%2Fopenclaw/sqlite/current.db", Size: int64(len(payload))},
+			})
+			return
+		}
 		assert.Equal(t, http.MethodPost, req.Method)
 		assert.Equal(t, "/v1/apps/discrawl/archives/discrawl%2Fopenclaw/ingest", req.URL.EscapedPath())
 		var body crawlremote.IngestRequest
@@ -1339,11 +1395,101 @@ func TestCloudPublishSendsNonDMRows(t *testing.T) {
 	require.Len(t, seenTables["channels"].Rows, 1)
 	require.Len(t, seenTables["messages"].Rows, 1)
 	require.True(t, seenTables["messages"].Final)
+	require.True(t, sawSQLiteUpload)
 
 	var payload map[string]any
 	require.NoError(t, json.Unmarshal(out.Bytes(), &payload))
 	require.InDelta(t, float64(1), payload["guilds"], 0)
 	require.InDelta(t, float64(1), payload["messages"], 0)
+	require.NotNil(t, payload["sqlite_object"])
+}
+
+func TestCloudSQLiteExportHelpers(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	sourcePath := filepath.Join(dir, "source.db")
+	s := seedCLIStore(t, sourcePath)
+	require.NoError(t, s.UpsertMember(ctx, store.MemberRecord{
+		GuildID:     "g1",
+		UserID:      "u1",
+		Username:    "peter",
+		DisplayName: "Peter",
+		RoleIDsJSON: `[]`,
+		RawJSON:     `{"private":"ignored"}`,
+	}))
+	require.NoError(t, addCLIDMAttachment(ctx, s))
+
+	require.Empty(t, sqlPlaceholders(0))
+	require.Equal(t, "?,?,?", sqlPlaceholders(3))
+
+	snapshotPath, cleanup, err := sqliteSnapshotPath(ctx, s.DB())
+	require.NoError(t, err)
+	require.FileExists(t, snapshotPath)
+	cleanup()
+	require.NoFileExists(t, snapshotPath)
+
+	exportPath := filepath.Join(dir, "cloud.db")
+	require.NoError(t, writeCloudSQLiteExport(ctx, s.DB(), exportPath))
+	require.NoError(t, s.Close())
+
+	sum, err := cloudFileSHA256(exportPath)
+	require.NoError(t, err)
+	require.Len(t, sum, 64)
+	_, err = cloudFileSHA256(filepath.Join(dir, "missing.db"))
+	require.Error(t, err)
+
+	cloudDB, err := sql.Open("sqlite", exportPath)
+	require.NoError(t, err)
+	defer func() { _ = cloudDB.Close() }()
+
+	var guilds, channels, members, messages int
+	require.NoError(t, cloudDB.QueryRowContext(ctx, "select count(*) from guilds").Scan(&guilds))
+	require.NoError(t, cloudDB.QueryRowContext(ctx, "select count(*) from channels").Scan(&channels))
+	require.NoError(t, cloudDB.QueryRowContext(ctx, "select count(*) from members").Scan(&members))
+	require.NoError(t, cloudDB.QueryRowContext(ctx, "select count(*) from messages").Scan(&messages))
+	require.Equal(t, 1, guilds)
+	require.Equal(t, 1, channels)
+	require.Equal(t, 1, members)
+	require.Equal(t, 1, messages)
+
+	var dmRows int
+	require.NoError(t, cloudDB.QueryRowContext(ctx, "select count(*) from messages where guild_id = ?", store.DirectMessageGuildID).Scan(&dmRows))
+	require.Zero(t, dmRows)
+
+	var authorUsername string
+	require.NoError(t, cloudDB.QueryRowContext(ctx, "select author_username from messages where message_id = 'm100'").Scan(&authorUsername))
+	require.Equal(t, "Peter", authorUsername)
+
+	var rawJSONColumns int
+	require.NoError(t, cloudDB.QueryRowContext(ctx, "select count(*) from pragma_table_info('messages') where name = 'raw_json'").Scan(&rawJSONColumns))
+	require.Zero(t, rawJSONColumns)
+}
+
+func TestCopyCloudSQLiteRowsErrorsAndBytes(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	source, err := sql.Open("sqlite", filepath.Join(dir, "source.db"))
+	require.NoError(t, err)
+	defer func() { _ = source.Close() }()
+	out, err := sql.Open("sqlite", filepath.Join(dir, "out.db"))
+	require.NoError(t, err)
+	defer func() { _ = out.Close() }()
+
+	_, err = source.ExecContext(ctx, `create table source_rows(value blob)`)
+	require.NoError(t, err)
+	_, err = source.ExecContext(ctx, `insert into source_rows(value) values(x'68656c6c6f')`)
+	require.NoError(t, err)
+	_, err = out.ExecContext(ctx, `create table copied(value text)`)
+	require.NoError(t, err)
+
+	require.NoError(t, copyCloudSQLiteRows(ctx, source, out, "copied", []string{"value"}, `select value from source_rows`))
+	var value string
+	require.NoError(t, out.QueryRowContext(ctx, `select value from copied`).Scan(&value))
+	require.Equal(t, "hello", value)
+
+	err = copyCloudSQLiteRows(ctx, source, out, "copied", []string{"value"}, `select missing from source_rows`)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "query sqlite cloud export copied")
 }
 
 func TestShareCommandsPublishSubscribeAndUpdate(t *testing.T) {

--- a/internal/cli/cloud_commands.go
+++ b/internal/cli/cloud_commands.go
@@ -2,13 +2,19 @@ package cli
 
 import (
 	"context"
+	"crypto/sha256"
 	"database/sql"
+	"encoding/hex"
 	"errors"
 	"flag"
 	"fmt"
 	"io"
+	"net/http"
+	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
+	"time"
 
 	crawlremote "github.com/openclaw/crawlkit/remote"
 	"github.com/openclaw/discrawl/internal/config"
@@ -62,7 +68,10 @@ func (r *runtime) runCloudPublish(args []string) error {
 			Archive:  archiveID,
 			TokenEnv: firstNonEmpty(*tokenEnv, r.cfg.Remote.TokenEnv, config.DefaultRemoteTokenEnv),
 		}
-		client, err := crawlremote.NewClientFromConfig(remoteCfg, crawlremote.Options{UserAgent: "discrawl/" + version})
+		client, err := crawlremote.NewClientFromConfig(remoteCfg, crawlremote.Options{
+			UserAgent:  "discrawl/" + version,
+			HTTPClient: &http.Client{Timeout: 10 * time.Minute},
+		})
 		if err != nil {
 			return configErr(err)
 		}
@@ -107,13 +116,18 @@ func (r *runtime) runCloudPublish(args []string) error {
 		if err != nil {
 			return err
 		}
+		sqliteObject, err := uploadSQLiteArchive(r.ctx, client, "discrawl", archiveID, r.store.DB(), r.cfg.DBPath, manifest)
+		if err != nil {
+			return err
+		}
 		return r.print(map[string]any{
-			"remote":   strings.TrimRight(endpoint, "/"),
-			"archive":  archiveID,
-			"guilds":   guildCount,
-			"channels": channelCount,
-			"members":  memberCount,
-			"messages": messageCount,
+			"remote":        strings.TrimRight(endpoint, "/"),
+			"archive":       archiveID,
+			"guilds":        guildCount,
+			"channels":      channelCount,
+			"members":       memberCount,
+			"messages":      messageCount,
+			"sqlite_object": sqliteObject,
 		})
 	})
 }
@@ -183,6 +197,182 @@ func cursorFor(start int) string {
 		return ""
 	}
 	return strconv.Itoa(start)
+}
+
+func uploadSQLiteArchive(ctx context.Context, client *crawlremote.Client, app, archive string, db *sql.DB, dbPath string, manifest crawlremote.IngestManifest) (*crawlremote.SQLiteObject, error) {
+	snapshotPath, cleanup, err := sqliteSnapshotPath(ctx, db)
+	if err != nil {
+		return nil, err
+	}
+	defer cleanup()
+	file, err := os.Open(snapshotPath)
+	if err != nil {
+		return nil, fmt.Errorf("open sqlite snapshot: %w", err)
+	}
+	defer func() { _ = file.Close() }()
+	info, err := file.Stat()
+	if err != nil {
+		return nil, fmt.Errorf("stat sqlite snapshot: %w", err)
+	}
+	sum, err := cloudFileSHA256(snapshotPath)
+	if err != nil {
+		return nil, err
+	}
+	if _, err := file.Seek(0, io.SeekStart); err != nil {
+		return nil, fmt.Errorf("rewind sqlite snapshot: %w", err)
+	}
+	result, err := client.UploadSQLite(ctx, app, archive, crawlremote.SQLiteUploadRequest{
+		Body:          file,
+		Size:          info.Size(),
+		ContentSHA256: sum,
+		SchemaName:    manifest.SchemaName,
+		SchemaVersion: manifest.SchemaVersion,
+		SchemaHash:    manifest.SchemaHash,
+		SourceSyncAt:  manifest.SourceSyncAt,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return result.Object, nil
+}
+
+func sqliteSnapshotPath(ctx context.Context, db *sql.DB) (string, func(), error) {
+	tmpDir, err := os.MkdirTemp("", "discrawl-cloud-sqlite-*")
+	if err != nil {
+		return "", func() {}, fmt.Errorf("create sqlite snapshot dir: %w", err)
+	}
+	cleanup := func() { _ = os.RemoveAll(tmpDir) }
+	snapshotPath := filepath.Join(tmpDir, "archive.db")
+	if err := writeCloudSQLiteExport(ctx, db, snapshotPath); err != nil {
+		cleanup()
+		return "", func() {}, err
+	}
+	return snapshotPath, cleanup, nil
+}
+
+func writeCloudSQLiteExport(ctx context.Context, source *sql.DB, snapshotPath string) error {
+	out, err := sql.Open("sqlite", snapshotPath)
+	if err != nil {
+		return fmt.Errorf("open sqlite cloud export: %w", err)
+	}
+	defer func() { _ = out.Close() }()
+	if _, err := out.ExecContext(ctx, "pragma busy_timeout = 5000"); err != nil {
+		return fmt.Errorf("configure sqlite cloud export: %w", err)
+	}
+	for _, stmt := range discrawlCloudSQLiteSchema {
+		if _, err := out.ExecContext(ctx, stmt); err != nil {
+			return fmt.Errorf("write sqlite cloud export: %w", err)
+		}
+	}
+	for _, export := range discrawlCloudSQLiteExports {
+		if err := copyCloudSQLiteRows(ctx, source, out, export.table, export.columns, export.query); err != nil {
+			return err
+		}
+	}
+	for _, stmt := range discrawlCloudSQLiteIndexes {
+		if _, err := out.ExecContext(ctx, stmt); err != nil {
+			return fmt.Errorf("index sqlite cloud export: %w", err)
+		}
+	}
+	if _, err := out.ExecContext(ctx, "vacuum"); err != nil {
+		return fmt.Errorf("vacuum sqlite cloud export: %w", err)
+	}
+	return nil
+}
+
+func copyCloudSQLiteRows(ctx context.Context, source, out *sql.DB, table string, columns []string, query string) error {
+	rows, err := source.QueryContext(ctx, query)
+	if err != nil {
+		return fmt.Errorf("query sqlite cloud export %s: %w", table, err)
+	}
+	defer func() { _ = rows.Close() }()
+	tx, err := out.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin sqlite cloud export %s: %w", table, err)
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_ = tx.Rollback()
+		}
+	}()
+	stmt, err := tx.PrepareContext(ctx, fmt.Sprintf("insert into %s(%s) values(%s)", table, strings.Join(columns, ","), sqlPlaceholders(len(columns))))
+	if err != nil {
+		return fmt.Errorf("prepare sqlite cloud export %s: %w", table, err)
+	}
+	defer func() { _ = stmt.Close() }()
+	values := make([]any, len(columns))
+	ptrs := make([]any, len(columns))
+	for i := range values {
+		ptrs[i] = &values[i]
+	}
+	for rows.Next() {
+		if err := rows.Scan(ptrs...); err != nil {
+			return fmt.Errorf("scan sqlite cloud export %s: %w", table, err)
+		}
+		for i, value := range values {
+			if bytes, ok := value.([]byte); ok {
+				values[i] = string(bytes)
+			}
+		}
+		if _, err := stmt.ExecContext(ctx, values...); err != nil {
+			return fmt.Errorf("insert sqlite cloud export %s: %w", table, err)
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("iterate sqlite cloud export %s: %w", table, err)
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit sqlite cloud export %s: %w", table, err)
+	}
+	committed = true
+	return nil
+}
+
+func sqlPlaceholders(n int) string {
+	if n <= 0 {
+		return ""
+	}
+	return strings.TrimSuffix(strings.Repeat("?,", n), ",")
+}
+
+func cloudFileSHA256(path string) (string, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return "", fmt.Errorf("open sqlite snapshot for hash: %w", err)
+	}
+	defer func() { _ = file.Close() }()
+	hash := sha256.New()
+	if _, err := io.Copy(hash, file); err != nil {
+		return "", fmt.Errorf("hash sqlite snapshot: %w", err)
+	}
+	return hex.EncodeToString(hash.Sum(nil)), nil
+}
+
+var discrawlCloudSQLiteSchema = []string{
+	`pragma journal_mode = off`,
+	`pragma synchronous = off`,
+	`create table guilds(guild_id text primary key, name text, updated_at text)`,
+	`create table channels(channel_id text primary key, guild_id text not null, name text, type text, parent_id text, updated_at text)`,
+	`create table members(guild_id text not null, user_id text not null, username text, display_name text, updated_at text, primary key(guild_id, user_id))`,
+	`create table messages(message_id text primary key, channel_id text not null, guild_id text not null, author_id text, author_username text, content text, created_at text, edited_at text)`,
+}
+
+var discrawlCloudSQLiteExports = []struct {
+	table   string
+	columns []string
+	query   string
+}{
+	{table: "guilds", columns: discrawlGuildColumns, query: discrawlGuildExportSQL},
+	{table: "channels", columns: discrawlChannelColumns, query: discrawlChannelExportSQL},
+	{table: "members", columns: discrawlMemberColumns, query: discrawlMemberExportSQL},
+	{table: "messages", columns: discrawlMessageColumns, query: discrawlMessageExportSQL},
+}
+
+var discrawlCloudSQLiteIndexes = []string{
+	`create index idx_messages_created on messages(created_at, message_id)`,
+	`create index idx_messages_channel_created on messages(channel_id, created_at, message_id)`,
+	`create index idx_messages_guild_created on messages(guild_id, created_at, message_id)`,
 }
 
 var discrawlGuildColumns = []string{"guild_id", "name", "updated_at"}


### PR DESCRIPTION
## Summary
- update crawlkit to v0.10.0
- upload a sanitized SQLite cloud archive during `discrawl cloud publish` after D1 ingest
- keep `@me` rows, raw JSON, attachment URLs, embeddings, and local-only tables out of the remote SQLite artifact

## Verification
- GOWORK=off go test ./internal/cli -run 'TestCloudPublishSendsNonDMRows|TestCloud'\n- GOWORK=off go test ./...\n- built and uploaded a sanitized `discrawl/openclaw` chunked R2 bundle: 845,058,048 bytes, 1,417,329 messages, `@me` excluded