### PR TITLE
fix(cloud): allow sqlite-only archive publish

### DIFF
--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -1444,6 +1444,84 @@ func TestCloudPublishSendsNonDMRows(t *testing.T) {
 	require.NoError(t, json.Unmarshal(out.Bytes(), &payload))
 	require.InDelta(t, float64(1), payload["guilds"], 0)
 	require.InDelta(t, float64(1), payload["messages"], 0)
+	require.Equal(t, false, payload["sqlite_only"])
+	require.NotNil(t, payload["sqlite_bundle"])
+}
+
+func TestCloudPublishSQLiteOnlySkipsD1Ingest(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.toml")
+	cfg := config.Default()
+	cfg.DBPath = filepath.Join(dir, "publisher.db")
+	require.NoError(t, config.Write(cfgPath, cfg))
+	publisher := seedCLIStore(t, cfg.DBPath)
+	require.NoError(t, publisher.Close())
+
+	tokenEnv := "DISCRAWL_TEST_PUBLISH_TOKEN"
+	t.Setenv(tokenEnv, "publish-token")
+	var sawSQLitePart bool
+	var sawSQLiteManifest bool
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		assert.Equal(t, "Bearer publish-token", req.Header.Get("Authorization"))
+		if req.Method != http.MethodPut || req.URL.EscapedPath() != "/v1/apps/discrawl/archives/discrawl%2Fopenclaw/sqlite" {
+			http.Error(w, "sqlite-only publish should not ingest D1 rows", http.StatusBadRequest)
+			return
+		}
+		payload, err := io.ReadAll(req.Body)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		switch req.Header.Get("X-Crawl-Sqlite-Upload") {
+		case "bundle-part":
+			sawSQLitePart = true
+			assert.True(t, bytes.HasPrefix(payload, []byte{0x1f, 0x8b}), "sqlite bundle part should be gzip")
+			_ = json.NewEncoder(w).Encode(crawlremote.SQLiteUploadResult{
+				App:      "discrawl",
+				Archive:  "discrawl/openclaw",
+				Complete: false,
+				Object:   &crawlremote.SQLiteObject{Key: "v1/discrawl/discrawl%2Fopenclaw/sqlite/chunks/current.db.gz.part-0000", Size: int64(len(payload))},
+			})
+		case "bundle-manifest":
+			sawSQLiteManifest = true
+			var manifest crawlremote.SQLiteBundleManifest
+			if err := json.Unmarshal(payload, &manifest); err != nil {
+				t.Errorf("decode sqlite bundle manifest: %v", err)
+				http.Error(w, err.Error(), http.StatusBadRequest)
+				return
+			}
+			assert.Equal(t, int64(1), manifest.Counts["messages"])
+			_ = json.NewEncoder(w).Encode(crawlremote.SQLiteBundleUploadResult{
+				App:      "discrawl",
+				Archive:  "discrawl/openclaw",
+				Complete: true,
+				Bundle:   &crawlremote.SQLiteBundle{Key: "v1/discrawl/discrawl%2Fopenclaw/sqlite/current.manifest.json", Manifest: &manifest},
+			})
+		default:
+			http.Error(w, "missing sqlite bundle upload kind", http.StatusBadRequest)
+		}
+	}))
+	defer server.Close()
+
+	var out bytes.Buffer
+	require.NoError(t, Run(ctx, []string{
+		"--config", cfgPath,
+		"--json",
+		"cloud", "publish",
+		"--sqlite-only",
+		"--remote", server.URL,
+		"--archive", "discrawl/openclaw",
+		"--token-env", tokenEnv,
+	}, &out, &bytes.Buffer{}))
+	require.True(t, sawSQLitePart)
+	require.True(t, sawSQLiteManifest)
+
+	var payload map[string]any
+	require.NoError(t, json.Unmarshal(out.Bytes(), &payload))
+	require.Equal(t, true, payload["sqlite_only"])
+	require.InDelta(t, float64(1), payload["messages"], 0)
 	require.NotNil(t, payload["sqlite_bundle"])
 }
 

--- a/internal/cli/cloud_commands.go
+++ b/internal/cli/cloud_commands.go
@@ -40,6 +40,7 @@ func (r *runtime) runCloudPublish(args []string) error {
 	remoteEndpoint := fs.String("remote", "", "")
 	archive := fs.String("archive", "", "")
 	tokenEnv := fs.String("token-env", "", "")
+	sqliteOnly := fs.Bool("sqlite-only", false, "")
 	jsonOut := fs.Bool("json", false, "")
 	if err := fs.Parse(args); err != nil {
 		return usageErr(err)
@@ -84,37 +85,43 @@ func (r *runtime) runCloudPublish(args []string) error {
 			Mode:          crawlremote.ModePublisher,
 			Source:        "sqlite",
 		}
-		guilds, err := publishRows(r.ctx, r.store.DB(), discrawlGuildExportSQL)
+		guildCount, channelCount, memberCount, messageCount, err := cloudPublishCounts(r.ctx, r.store.DB())
 		if err != nil {
 			return dbErr(err)
 		}
-		channels, err := publishRows(r.ctx, r.store.DB(), discrawlChannelExportSQL)
-		if err != nil {
-			return dbErr(err)
-		}
-		messages, err := publishRows(r.ctx, r.store.DB(), discrawlMessageExportSQL)
-		if err != nil {
-			return dbErr(err)
-		}
-		members, err := publishRows(r.ctx, r.store.DB(), discrawlMemberExportSQL)
-		if err != nil {
-			return dbErr(err)
-		}
-		guildCount, err := sendIngestRows(r.ctx, client, archiveID, manifest, "guilds", discrawlGuildColumns, guilds, false)
-		if err != nil {
-			return err
-		}
-		channelCount, err := sendIngestRows(r.ctx, client, archiveID, manifest, "channels", discrawlChannelColumns, channels, false)
-		if err != nil {
-			return err
-		}
-		memberCount, err := sendIngestRows(r.ctx, client, archiveID, manifest, "members", discrawlMemberColumns, members, false)
-		if err != nil {
-			return err
-		}
-		messageCount, err := sendIngestRows(r.ctx, client, archiveID, manifest, "messages", discrawlMessageColumns, messages, true)
-		if err != nil {
-			return err
+		if !*sqliteOnly {
+			guilds, err := publishRows(r.ctx, r.store.DB(), discrawlGuildExportSQL)
+			if err != nil {
+				return dbErr(err)
+			}
+			channels, err := publishRows(r.ctx, r.store.DB(), discrawlChannelExportSQL)
+			if err != nil {
+				return dbErr(err)
+			}
+			messages, err := publishRows(r.ctx, r.store.DB(), discrawlMessageExportSQL)
+			if err != nil {
+				return dbErr(err)
+			}
+			members, err := publishRows(r.ctx, r.store.DB(), discrawlMemberExportSQL)
+			if err != nil {
+				return dbErr(err)
+			}
+			guildCount, err = sendIngestRows(r.ctx, client, archiveID, manifest, "guilds", discrawlGuildColumns, guilds, false)
+			if err != nil {
+				return err
+			}
+			channelCount, err = sendIngestRows(r.ctx, client, archiveID, manifest, "channels", discrawlChannelColumns, channels, false)
+			if err != nil {
+				return err
+			}
+			memberCount, err = sendIngestRows(r.ctx, client, archiveID, manifest, "members", discrawlMemberColumns, members, false)
+			if err != nil {
+				return err
+			}
+			messageCount, err = sendIngestRows(r.ctx, client, archiveID, manifest, "messages", discrawlMessageColumns, messages, true)
+			if err != nil {
+				return err
+			}
 		}
 		sqliteBundle, err := uploadSQLiteArchive(r.ctx, client, "discrawl", archiveID, r.store.DB(), r.cfg.DBPath, manifest, map[string]int64{
 			"guilds":   guildCount,
@@ -132,9 +139,34 @@ func (r *runtime) runCloudPublish(args []string) error {
 			"channels":      channelCount,
 			"members":       memberCount,
 			"messages":      messageCount,
+			"sqlite_only":   *sqliteOnly,
 			"sqlite_bundle": sqliteBundle,
 		})
 	})
+}
+
+func cloudPublishCounts(ctx context.Context, db *sql.DB) (guilds int64, channels int64, members int64, messages int64, err error) {
+	if guilds, err = countCloudRows(ctx, db, "select count(*) from guilds where id != '@me'"); err != nil {
+		return 0, 0, 0, 0, err
+	}
+	if channels, err = countCloudRows(ctx, db, "select count(*) from channels where guild_id != '@me'"); err != nil {
+		return 0, 0, 0, 0, err
+	}
+	if members, err = countCloudRows(ctx, db, "select count(*) from members where guild_id != '@me'"); err != nil {
+		return 0, 0, 0, 0, err
+	}
+	if messages, err = countCloudRows(ctx, db, "select count(*) from messages where guild_id != '@me'"); err != nil {
+		return 0, 0, 0, 0, err
+	}
+	return guilds, channels, members, messages, nil
+}
+
+func countCloudRows(ctx context.Context, db *sql.DB, query string) (int64, error) {
+	var count int64
+	if err := db.QueryRowContext(ctx, query).Scan(&count); err != nil {
+		return 0, err
+	}
+	return count, nil
 }
 
 func publishRows(ctx context.Context, db *sql.DB, query string) ([][]any, error) {


### PR DESCRIPTION
## Summary
- add `discrawl cloud publish --sqlite-only` for refreshing the compressed R2 SQLite bundle without re-ingesting D1 rows
- preserve count/privacy manifest metadata from local non-DM row counts
- cover the no-D1-ingest path so large archives can repair R2 after D1 is already hydrated

## Why
A full live `discrawl cloud publish` can hit D1 `SQLITE_NOMEM` on the large OpenClaw archive before R2 upload. The sqlite-only path avoids hammering D1 when only the R2 bootstrap bundle needs refreshing.

## Validation
- GOWORK=off go test ./internal/cli -run 'TestCloudPublishSendsNonDMRows|TestCloudPublishSQLiteOnlySkipsD1Ingest'\n- go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.1 run ./internal/cli --timeout=3m