### PR TITLE
fix(cloud): use worker-safe sqlite bundle chunks

### DIFF
--- a/internal/cli/cloud_commands.go
+++ b/internal/cli/cloud_commands.go
@@ -20,7 +20,10 @@ import (
 	"github.com/openclaw/discrawl/internal/config"
 )
 
-const discrawlCloudBatchSize = 250
+const (
+	discrawlCloudBatchSize             = 250
+	discrawlCloudSQLiteBundleChunkSize = int64(64 * 1024 * 1024)
+)
 
 func (r *runtime) runCloud(args []string) error {
 	if len(args) == 0 || args[0] == "--help" || args[0] == "-h" {
@@ -246,6 +249,7 @@ func uploadSQLiteArchive(ctx context.Context, client *crawlremote.Client, app, a
 		App:        app,
 		Archive:    archive,
 		SourcePath: snapshotPath,
+		ChunkSize:  discrawlCloudSQLiteBundleChunkSize,
 		Counts:     counts,
 		Privacy: map[string]any{
 			"excludes_guild_id":         "@me",


### PR DESCRIPTION
## Summary
- cap cloud SQLite bundle parts at 64 MiB for Worker upload compatibility
- keep sqlite-only publishing and the gzip bundle manifest contract unchanged

## Validation
- GOWORK=off go test ./internal/cli -run 'TestCloudPublishSendsNonDMRows|TestCloudPublishSQLiteOnlySkipsD1Ingest'\n- go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.1 run ./internal/cli --timeout=3m