### PR TITLE
feat(search): add turbovec vector backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Changes
 
+- Add optional `turbovec` semantic-search scoring via
+  `[search.embeddings].vector_backend`, while keeping exact cosine as the
+  default backend.
 - Added the Homebrew install command to the `discrawl.sh` landing hero and agent docs index, with a one-row desktop layout and copy button.
 - Update `crawlkit` to v0.10.0.
 - Add read-only Cloudflare remote archive scaffolding with `[remote]` config,

--- a/README.md
+++ b/README.md
@@ -816,9 +816,10 @@ Local providers can keep message and query embedding on the same machine:
 enabled = true
 provider = "ollama"
 model = "nomic-embed-text"
+vector_backend = "exact"
 ```
 
-With remote providers, message text is sent during `discrawl embed`, and search query text is sent when using `--mode semantic` or `--mode hybrid`. Stored message text is not sent during local vector scoring.
+Set `vector_backend = "turbovec"` to use the optional crawlkit turbovec bridge for semantic scoring. It requires Python plus the `turbovec` package. With remote providers, message text is sent during `discrawl embed`, and search query text is sent when using `--mode semantic` or `--mode hybrid`. Stored message text is not sent during local vector scoring.
 
 ## Data Stored Locally
 

--- a/README.md
+++ b/README.md
@@ -819,7 +819,7 @@ model = "nomic-embed-text"
 vector_backend = "exact"
 ```
 
-Set `vector_backend = "turbovec"` to use the optional crawlkit turbovec bridge for semantic scoring. It requires Python plus the `turbovec` package. With remote providers, message text is sent during `discrawl embed`, and search query text is sent when using `--mode semantic` or `--mode hybrid`. Stored message text is not sent during local vector scoring.
+Set `vector_backend = "turbovec"` to use the optional crawlkit turbovec bridge for semantic scoring. It requires Python plus the `turbovec` package, and embedding dimensions must be divisible by 8. With remote providers, message text is sent during `discrawl embed`, and search query text is sent when using `--mode semantic` or `--mode hybrid`. Stored message text is not sent during local vector scoring.
 
 ## Data Stored Locally
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -131,7 +131,7 @@ Set `discord.token_source = "keyring"` if you want to require keyring lookup and
 - `default_guild_id` is the implicit scope for `sync`, `tail`, `digest`, and `analytics` when `--guild` is not passed
 - `guild_ids` is reserved for explicit multi-guild fan-out; usually you do not set this directly
 - changing `[search.embeddings]` provider/model/input version retargets pending jobs and resets prior attempts; existing vectors for another identity remain in SQLite but are not used for semantic search
-- `[search.embeddings].vector_backend` accepts `exact` or optional `turbovec`; turbovec requires Python plus the `turbovec` package.
+- `[search.embeddings].vector_backend` accepts `exact` or optional `turbovec`; turbovec requires Python plus the `turbovec` package and embedding dimensions divisible by 8.
 - changing `db_path` does not migrate existing data; copy the file yourself if you want to keep history
 - `sync.attachment_media = true` makes `sync` behave like `sync --with-media`; media bytes are cached under `cache_dir/media`, and CDN `404`/other fetch failures are recorded on attachment rows
 - `share.media = false` makes publish/update/auto-update omit or skip restoring cached media; `subscribe --no-media` writes this for Git-only readers. With the default `share.media = true`, publish/update include cached non-DM media as gzip-compressed snapshot files, but publish does not fetch missing Discord files by itself.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -79,6 +79,9 @@ provider = "openai"
 model = "text-embedding-3-small"
 api_key_env = "OPENAI_API_KEY"
 batch_size = 64
+max_input_chars = 12000
+request_timeout = "2m"
+vector_backend = "exact"
 
 [share]
 remote = ""
@@ -128,6 +131,7 @@ Set `discord.token_source = "keyring"` if you want to require keyring lookup and
 - `default_guild_id` is the implicit scope for `sync`, `tail`, `digest`, and `analytics` when `--guild` is not passed
 - `guild_ids` is reserved for explicit multi-guild fan-out; usually you do not set this directly
 - changing `[search.embeddings]` provider/model/input version retargets pending jobs and resets prior attempts; existing vectors for another identity remain in SQLite but are not used for semantic search
+- `[search.embeddings].vector_backend` accepts `exact` or optional `turbovec`; turbovec requires Python plus the `turbovec` package.
 - changing `db_path` does not migrate existing data; copy the file yourself if you want to keep history
 - `sync.attachment_media = true` makes `sync` behave like `sync --with-media`; media bytes are cached under `cache_dir/media`, and CDN `404`/other fetch failures are recorded on attachment rows
 - `share.media = false` makes publish/update/auto-update omit or skip restoring cached media; `subscribe --no-media` writes this for Git-only readers. With the default `share.media = true`, publish/update include cached non-DM media as gzip-compressed snapshot files, but publish does not fetch missing Discord files by itself.

--- a/go.mod
+++ b/go.mod
@@ -44,7 +44,7 @@ require (
 	github.com/muesli/cancelreader v0.2.2 // indirect
 	github.com/muesli/termenv v0.16.0 // indirect
 	github.com/ncruces/go-strftime v1.0.0 // indirect
-	github.com/openclaw/crawlkit v0.11.0
+	github.com/openclaw/crawlkit v0.11.1-0.20260608023621-593a155a9b34
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect

--- a/go.mod
+++ b/go.mod
@@ -44,7 +44,7 @@ require (
 	github.com/muesli/cancelreader v0.2.2 // indirect
 	github.com/muesli/termenv v0.16.0 // indirect
 	github.com/ncruces/go-strftime v1.0.0 // indirect
-	github.com/openclaw/crawlkit v0.11.1-0.20260608023621-593a155a9b34
+	github.com/openclaw/crawlkit v0.11.1-0.20260608024201-9c66db7f57f7
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/openclaw/discrawl
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/alecthomas/kong v1.15.0

--- a/go.sum
+++ b/go.sum
@@ -71,8 +71,8 @@ github.com/muesli/termenv v0.16.0 h1:S5AlUN9dENB57rsbnkPyfdGuWIlkmzJjbFf0Tf5FWUc
 github.com/muesli/termenv v0.16.0/go.mod h1:ZRfOIKPFDYQoDFF4Olj7/QJbW60Ol/kL1pU3VfY/Cnk=
 github.com/ncruces/go-strftime v1.0.0 h1:HMFp8mLCTPp341M/ZnA4qaf7ZlsbTc+miZjCLOFAw7w=
 github.com/ncruces/go-strftime v1.0.0/go.mod h1:Fwc5htZGVVkseilnfgOVb9mKy6w1naJmn9CehxcKcls=
-github.com/openclaw/crawlkit v0.11.1-0.20260608023621-593a155a9b34 h1:772fT/82X74Pk8YQBpIDf+cyKzfLkP3ESHgzxpbdtSg=
-github.com/openclaw/crawlkit v0.11.1-0.20260608023621-593a155a9b34/go.mod h1:2XkSx3N8yzyjc+Jyf1Zl9VEQVlElh/dzBMW1cRMQQGw=
+github.com/openclaw/crawlkit v0.11.1-0.20260608024201-9c66db7f57f7 h1:uMvRdJZFXo0F4VFtZHGBziQbBN2YzrQCe+jVQx0sk+g=
+github.com/openclaw/crawlkit v0.11.1-0.20260608024201-9c66db7f57f7/go.mod h1:2XkSx3N8yzyjc+Jyf1Zl9VEQVlElh/dzBMW1cRMQQGw=
 github.com/pelletier/go-toml/v2 v2.3.1 h1:MYEvvGnQjeNkRF1qUuGolNtNExTDwct51yp7olPtrEc=
 github.com/pelletier/go-toml/v2 v2.3.1/go.mod h1:2gIqNv+qfxSVS7cM2xJQKtLSTLUE9V8t9Stt+h56mCY=
 github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=

--- a/go.sum
+++ b/go.sum
@@ -71,8 +71,8 @@ github.com/muesli/termenv v0.16.0 h1:S5AlUN9dENB57rsbnkPyfdGuWIlkmzJjbFf0Tf5FWUc
 github.com/muesli/termenv v0.16.0/go.mod h1:ZRfOIKPFDYQoDFF4Olj7/QJbW60Ol/kL1pU3VfY/Cnk=
 github.com/ncruces/go-strftime v1.0.0 h1:HMFp8mLCTPp341M/ZnA4qaf7ZlsbTc+miZjCLOFAw7w=
 github.com/ncruces/go-strftime v1.0.0/go.mod h1:Fwc5htZGVVkseilnfgOVb9mKy6w1naJmn9CehxcKcls=
-github.com/openclaw/crawlkit v0.11.0 h1:aKK8XVunwT4WYUYp7IxcgCXdg8L2WeYIX8da5HGuNyg=
-github.com/openclaw/crawlkit v0.11.0/go.mod h1:2XkSx3N8yzyjc+Jyf1Zl9VEQVlElh/dzBMW1cRMQQGw=
+github.com/openclaw/crawlkit v0.11.1-0.20260608023621-593a155a9b34 h1:772fT/82X74Pk8YQBpIDf+cyKzfLkP3ESHgzxpbdtSg=
+github.com/openclaw/crawlkit v0.11.1-0.20260608023621-593a155a9b34/go.mod h1:2XkSx3N8yzyjc+Jyf1Zl9VEQVlElh/dzBMW1cRMQQGw=
 github.com/pelletier/go-toml/v2 v2.3.1 h1:MYEvvGnQjeNkRF1qUuGolNtNExTDwct51yp7olPtrEc=
 github.com/pelletier/go-toml/v2 v2.3.1/go.mod h1:2gIqNv+qfxSVS7cM2xJQKtLSTLUE9V8t9Stt+h56mCY=
 github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=

--- a/internal/cli/query_commands.go
+++ b/internal/cli/query_commands.go
@@ -185,16 +185,17 @@ func (r *runtime) semanticSearchOptions(opts store.SearchOptions) (store.Semanti
 		dimensions = len(queryVector)
 	}
 	return store.SemanticSearchOptions{
-		QueryVector:  queryVector,
-		Provider:     r.cfg.Search.Embeddings.Provider,
-		Model:        r.cfg.Search.Embeddings.Model,
-		InputVersion: store.EmbeddingInputVersion,
-		Dimensions:   dimensions,
-		GuildIDs:     opts.GuildIDs,
-		Channel:      opts.Channel,
-		Author:       opts.Author,
-		Limit:        opts.Limit,
-		IncludeEmpty: opts.IncludeEmpty,
+		QueryVector:   queryVector,
+		Provider:      r.cfg.Search.Embeddings.Provider,
+		Model:         r.cfg.Search.Embeddings.Model,
+		InputVersion:  store.EmbeddingInputVersion,
+		Dimensions:    dimensions,
+		VectorBackend: r.cfg.Search.Embeddings.VectorBackend,
+		GuildIDs:      opts.GuildIDs,
+		Channel:       opts.Channel,
+		Author:        opts.Author,
+		Limit:         opts.Limit,
+		IncludeEmpty:  opts.IncludeEmpty,
 	}, nil
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -90,6 +90,7 @@ type EmbeddingsConfig struct {
 	BatchSize      int    `toml:"batch_size"`
 	MaxInputChars  int    `toml:"max_input_chars"`
 	RequestTimeout string `toml:"request_timeout"`
+	VectorBackend  string `toml:"vector_backend"`
 }
 
 type TokenResolution struct {
@@ -152,6 +153,7 @@ func Default() Config {
 				BatchSize:      64,
 				MaxInputChars:  12000,
 				RequestTimeout: "2m",
+				VectorBackend:  "exact",
 			},
 		},
 		Share: ShareConfig{
@@ -283,6 +285,7 @@ func (c *Config) Normalize() error {
 	c.Search.Embeddings.BaseURL = strings.TrimRight(strings.TrimSpace(c.Search.Embeddings.BaseURL), "/")
 	c.Search.Embeddings.APIKeyEnv = strings.TrimSpace(c.Search.Embeddings.APIKeyEnv)
 	c.Search.Embeddings.RequestTimeout = strings.TrimSpace(c.Search.Embeddings.RequestTimeout)
+	c.Search.Embeddings.VectorBackend = strings.ToLower(strings.TrimSpace(c.Search.Embeddings.VectorBackend))
 	if c.Search.Embeddings.Provider == "" {
 		c.Search.Embeddings.Provider = "openai"
 	}
@@ -326,6 +329,12 @@ func (c *Config) Normalize() error {
 	}
 	if c.Search.Embeddings.RequestTimeout == "" {
 		c.Search.Embeddings.RequestTimeout = "2m"
+	}
+	if c.Search.Embeddings.VectorBackend == "" {
+		c.Search.Embeddings.VectorBackend = "exact"
+	}
+	if c.Search.Embeddings.VectorBackend != "exact" && c.Search.Embeddings.VectorBackend != "turbovec" {
+		return fmt.Errorf("unsupported search.embeddings.vector_backend %q", c.Search.Embeddings.VectorBackend)
 	}
 	if timeout, err := time.ParseDuration(c.Search.Embeddings.RequestTimeout); err != nil {
 		return fmt.Errorf("parse search.embeddings.request_timeout: %w", err)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -46,6 +46,7 @@ func TestNormalizeFillsDefaults(t *testing.T) {
 	require.Equal(t, 64, cfg.Search.Embeddings.BatchSize)
 	require.Equal(t, 12000, cfg.Search.Embeddings.MaxInputChars)
 	require.Equal(t, "2m", cfg.Search.Embeddings.RequestTimeout)
+	require.Equal(t, "exact", cfg.Search.Embeddings.VectorBackend)
 }
 
 func TestDefaultPathsUseXDGDirs(t *testing.T) {
@@ -380,6 +381,14 @@ func TestNormalizeEmbeddingProviderDefaults(t *testing.T) {
 	cfg.Search.Embeddings.APIKeyEnv = "OPENAI_API_KEY"
 	require.NoError(t, cfg.Normalize())
 	require.Equal(t, "OPENAI_API_KEY", cfg.Search.Embeddings.APIKeyEnv)
+
+	cfg = Config{}
+	cfg.Search.Embeddings.VectorBackend = "TURBOVEC"
+	require.NoError(t, cfg.Normalize())
+	require.Equal(t, "turbovec", cfg.Search.Embeddings.VectorBackend)
+
+	cfg.Search.Embeddings.VectorBackend = "bogus"
+	require.ErrorContains(t, cfg.Normalize(), "unsupported search.embeddings.vector_backend")
 }
 
 func TestLoadLegacyEmbeddingConfigDefaults(t *testing.T) {

--- a/internal/store/query.go
+++ b/internal/store/query.go
@@ -268,7 +268,7 @@ func (s *Store) SearchMessagesSemantic(ctx context.Context, opts SemanticSearchO
 	})
 	if err != nil {
 		if strings.Contains(err.Error(), "candidate vector is zero") {
-			return nil, fmt.Errorf("score embedding: stored embedding vector is zero")
+			return nil, errors.New("score embedding: stored embedding vector is zero")
 		}
 		return nil, fmt.Errorf("score embeddings: %w", err)
 	}

--- a/internal/store/query.go
+++ b/internal/store/query.go
@@ -30,16 +30,17 @@ const (
 var ErrNoCompatibleEmbeddings = errors.New("no compatible message embeddings for provider/model/input version; run discrawl embed --rebuild")
 
 type SemanticSearchOptions struct {
-	QueryVector  []float32
-	Provider     string
-	Model        string
-	InputVersion string
-	Dimensions   int
-	GuildIDs     []string
-	Channel      string
-	Author       string
-	Limit        int
-	IncludeEmpty bool
+	QueryVector   []float32
+	Provider      string
+	Model         string
+	InputVersion  string
+	Dimensions    int
+	VectorBackend string
+	GuildIDs      []string
+	Channel       string
+	Author        string
+	Limit         int
+	IncludeEmpty  bool
 }
 
 func (s *Store) GetSyncState(ctx context.Context, scope string) (string, error) {
@@ -154,8 +155,12 @@ func (s *Store) SearchMessagesSemantic(ctx context.Context, opts SemanticSearchO
 	opts.Provider = strings.ToLower(strings.TrimSpace(opts.Provider))
 	opts.Model = strings.TrimSpace(opts.Model)
 	opts.InputVersion = strings.TrimSpace(opts.InputVersion)
+	opts.VectorBackend = strings.ToLower(strings.TrimSpace(opts.VectorBackend))
 	if opts.InputVersion == "" {
 		opts.InputVersion = EmbeddingInputVersion
+	}
+	if opts.VectorBackend == "" {
+		opts.VectorBackend = vector.BackendExact
 	}
 	if opts.Limit <= 0 {
 		opts.Limit = 20
@@ -222,7 +227,7 @@ func (s *Store) SearchMessagesSemantic(ctx context.Context, opts SemanticSearchO
 	}
 	defer func() { _ = rows.Close() }()
 
-	scored := make([]semanticScoredResult, 0, opts.Limit)
+	candidates := make([]vector.SearchCandidate[semanticSearchCandidate], 0, opts.Limit)
 	for rows.Next() {
 		var (
 			messageID  string
@@ -243,32 +248,31 @@ func (s *Store) SearchMessagesSemantic(ctx context.Context, opts SemanticSearchO
 		if len(storedVector) != dimensions {
 			return nil, fmt.Errorf("stored embedding vector length mismatch for message %s: got %d want %d", messageID, len(storedVector), dimensions)
 		}
-		score, err := vector.CosineSimilarity(opts.QueryVector, queryNorm, storedVector)
-		if err != nil {
-			if strings.Contains(err.Error(), "candidate vector is zero") {
-				return nil, fmt.Errorf("score embedding for message %s: stored embedding vector is zero", messageID)
-			}
-			return nil, fmt.Errorf("score embedding for message %s: %w", messageID, err)
-		}
-		row := SearchResult{MessageID: messageID, CreatedAt: parseTime(created)}
-		item := semanticScoredResult{result: row, score: score}
-		insertAt := sort.Search(len(scored), func(i int) bool {
-			return semanticScoreLess(item, scored[i])
+		candidates = append(candidates, vector.SearchCandidate[semanticSearchCandidate]{
+			Item:   semanticSearchCandidate{messageID: messageID, createdAt: parseTime(created)},
+			Vector: storedVector,
 		})
-		if insertAt >= opts.Limit {
-			continue
-		}
-		scored = append(scored, semanticScoredResult{})
-		copy(scored[insertAt+1:], scored[insertAt:])
-		scored[insertAt] = item
-		if len(scored) > opts.Limit {
-			scored = scored[:opts.Limit]
-		}
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}
-	if len(scored) == 0 {
+	results, err := vector.Search(queryCtx, opts.QueryVector, candidates, vector.SearchOptions[semanticSearchCandidate]{
+		Backend: opts.VectorBackend,
+		Limit:   opts.Limit,
+		TieLess: func(left, right semanticSearchCandidate) bool {
+			if !left.createdAt.Equal(right.createdAt) {
+				return left.createdAt.After(right.createdAt)
+			}
+			return left.messageID > right.messageID
+		},
+	})
+	if err != nil {
+		if strings.Contains(err.Error(), "candidate vector is zero") {
+			return nil, fmt.Errorf("score embedding: stored embedding vector is zero")
+		}
+		return nil, fmt.Errorf("score embeddings: %w", err)
+	}
+	if len(results) == 0 {
 		compatible, err := s.hasCompatibleMessageEmbeddings(ctx, opts)
 		if err != nil {
 			return nil, err
@@ -278,21 +282,21 @@ func (s *Store) SearchMessagesSemantic(ctx context.Context, opts SemanticSearchO
 		}
 		return []SearchResult{}, nil
 	}
-	ids := make([]string, 0, len(scored))
-	for _, item := range scored {
-		ids = append(ids, item.result.MessageID)
+	ids := make([]string, 0, len(results))
+	for _, item := range results {
+		ids = append(ids, item.Item.messageID)
 	}
 	details, err := s.searchResultDetails(queryCtx, ids)
 	if err != nil {
 		return nil, err
 	}
-	out := make([]SearchResult, 0, len(scored))
-	for _, item := range scored {
-		row, ok := details[item.result.MessageID]
+	out := make([]SearchResult, 0, len(results))
+	for _, item := range results {
+		row, ok := details[item.Item.messageID]
 		if !ok {
-			return nil, fmt.Errorf("semantic search result %s disappeared before hydration", item.result.MessageID)
+			return nil, fmt.Errorf("semantic search result %s disappeared before hydration", item.Item.messageID)
 		}
-		row.CreatedAt = item.result.CreatedAt
+		row.CreatedAt = item.Item.createdAt
 		out = append(out, row)
 	}
 	return out, nil
@@ -346,19 +350,9 @@ func (s *Store) searchResultDetails(ctx context.Context, messageIDs []string) (m
 	return out, rows.Err()
 }
 
-type semanticScoredResult struct {
-	result SearchResult
-	score  float64
-}
-
-func semanticScoreLess(left, right semanticScoredResult) bool {
-	if left.score != right.score {
-		return left.score > right.score
-	}
-	if !left.result.CreatedAt.Equal(right.result.CreatedAt) {
-		return left.result.CreatedAt.After(right.result.CreatedAt)
-	}
-	return left.result.MessageID > right.result.MessageID
+type semanticSearchCandidate struct {
+	messageID string
+	createdAt time.Time
 }
 
 func (s *Store) SearchMessagesHybrid(ctx context.Context, opts SearchOptions, semanticOpts SemanticSearchOptions) ([]SearchResult, error) {


### PR DESCRIPTION
## Summary

Adds optional turbovec-backed semantic scoring for discrawl.

- adds `[search.embeddings].vector_backend` with `exact` as the default
- wires the configured backend into semantic and hybrid search
- documents the Python `turbovec` dependency and dimensions-divisible-by-8 contract
- updates discrawl to the crawlkit turbovec branch pseudo-version

## Release order

Depends on https://github.com/openclaw/crawlkit/pull/18. Before discrawl release, replace the crawlkit pseudo-version with the final crawlkit release tag.

## Verification

- `GOWORK=off go test -count=1 ./...`
- temp-home CLI smokes using a built binary:
  - `discrawl --help`
  - `discrawl --version`
  - `discrawl metadata --json`
  - `discrawl status --json`
  - `discrawl tui --json`
