### PR TITLE
ci: add deadcode check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,13 @@ jobs:
         run: '"$(go env GOPATH)/bin/staticcheck" ./...'
 
       - name: Deadcode
-        run: '"$(go env GOPATH)/bin/deadcode" -test ./...'
+        run: |
+          output_file=$(mktemp)
+          "$(go env GOPATH)/bin/deadcode" -test ./... > "$output_file"
+          if [ -s "$output_file" ]; then
+            cat "$output_file"
+            exit 1
+          fi
 
       - name: Gofumpt
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,12 +37,16 @@ jobs:
           go install honnef.co/go/tools/cmd/staticcheck@v0.7.0
           go install mvdan.cc/gofumpt@v0.9.2
           go install github.com/securego/gosec/v2/cmd/gosec@v2.26.1
+          go install golang.org/x/tools/cmd/deadcode@v0.45.0
 
       - name: Vet
         run: go vet ./...
 
       - name: Staticcheck
         run: '"$(go env GOPATH)/bin/staticcheck" ./...'
+
+      - name: Deadcode
+        run: '"$(go env GOPATH)/bin/deadcode" -test ./...'
 
       - name: Gofumpt
         run: |

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/openclaw/discrawl
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/alecthomas/kong v1.15.0


### PR DESCRIPTION
## Summary
- add an enforced Go deadcode CI gate pinned to `golang.org/x/tools/cmd/deadcode@v0.45.0`
- make the workflow fail when deadcode emits findings
- bump the Go directive to the patched 1.26.4 toolchain so existing govulncheck stays green

## Validation
- `git diff --check`
- `go run golang.org/x/tools/cmd/deadcode@v0.45.0 -test ./...`
- `GOTOOLCHAIN=go1.26.4+auto go test -count=1 ./...`
- `GOTOOLCHAIN=go1.26.4+auto go run golang.org/x/vuln/cmd/govulncheck@v1.3.0 ./...`
- `go build ./cmd/discrawl`
- `autoreview --mode branch --base origin/main --no-web-search --thinking low` clean
