### PR TITLE
fix(syncer): stop backfill from regressing latest_message_id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@
 
 ### Fixes
 
+- Kept resumed `sync --full` backfills from moving channel latest-message checkpoints backward, avoiding duplicate head recrawls on large interrupted channels. Thanks @hannesrudolph.
+
 ## 0.9.1 - 2026-05-18
 
 ### Changes

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strconv"
+	"sync"
 	"testing"
 	"time"
 
@@ -1641,6 +1642,104 @@ func TestEventsSyncStateAndHelpers(t *testing.T) {
 	require.True(t, IsReadOnlySQL("-- comment\nselect 1"))
 	require.True(t, IsReadOnlySQL("with latest as (select 1 as one) select one from latest"))
 	require.False(t, IsReadOnlySQL("delete from messages"))
+}
+
+func TestAdvanceChannelLatestMessageIDKeepsSnowflakeMax(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	s, err := Open(ctx, filepath.Join(t.TempDir(), "discrawl.db"))
+	require.NoError(t, err)
+	defer func() { _ = s.Close() }()
+
+	require.NoError(t, s.AdvanceChannelLatestMessageID(ctx, "c1", ""))
+	_, rows, err := s.ReadOnlyQuery(ctx, `select count(*) from sync_state where scope = 'channel:c1:latest_message_id'`)
+	require.NoError(t, err)
+	require.Equal(t, [][]string{{"0"}}, rows)
+
+	require.NoError(t, s.AdvanceChannelLatestMessageID(ctx, "c1", "9"))
+	require.NoError(t, s.AdvanceChannelLatestMessageID(ctx, "c1", "8"))
+	cursor, err := s.GetSyncState(ctx, "channel:c1:latest_message_id")
+	require.NoError(t, err)
+	require.Equal(t, "9", cursor)
+
+	require.NoError(t, s.AdvanceChannelLatestMessageID(ctx, "c1", "10"))
+	require.NoError(t, s.AdvanceChannelLatestMessageID(ctx, "c1", "11"))
+	require.NoError(t, s.AdvanceChannelLatestMessageID(ctx, "c1", "10"))
+	cursor, err = s.GetSyncState(ctx, "channel:c1:latest_message_id")
+	require.NoError(t, err)
+	require.Equal(t, "11", cursor)
+
+	require.NoError(t, s.EnsureChannelLatestMessageState(ctx, "c2"))
+	cursor, err = s.GetSyncState(ctx, "channel:c2:latest_message_id")
+	require.NoError(t, err)
+	require.Empty(t, cursor)
+	require.NoError(t, s.AdvanceChannelLatestMessageID(ctx, "c2", "10"))
+	require.NoError(t, s.EnsureChannelLatestMessageState(ctx, "c2"))
+	cursor, err = s.GetSyncState(ctx, "channel:c2:latest_message_id")
+	require.NoError(t, err)
+	require.Equal(t, "10", cursor)
+}
+
+func TestAdvanceChannelLatestMessageIDRejectsMalformedCursors(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	s, err := Open(ctx, filepath.Join(t.TempDir(), "discrawl.db"))
+	require.NoError(t, err)
+	defer func() { _ = s.Close() }()
+
+	require.Error(t, s.AdvanceChannelLatestMessageID(ctx, "", "1"))
+	require.Error(t, s.AdvanceChannelLatestMessageID(ctx, "c1", "01"))
+	require.Error(t, s.AdvanceChannelLatestMessageID(ctx, "c1", "abc"))
+	require.Error(t, s.AdvanceChannelLatestMessageID(ctx, "c1", "1a"))
+
+	require.NoError(t, s.SetSyncState(ctx, "opaque:cursor", "page:abc/10"))
+	cursor, err := s.GetSyncState(ctx, "opaque:cursor")
+	require.NoError(t, err)
+	require.Equal(t, "page:abc/10", cursor)
+
+	require.NoError(t, s.SetSyncState(ctx, "channel:c2:latest_message_id", "opaque"))
+	require.Error(t, s.AdvanceChannelLatestMessageID(ctx, "c2", "10"))
+	cursor, err = s.GetSyncState(ctx, "channel:c2:latest_message_id")
+	require.NoError(t, err)
+	require.Equal(t, "opaque", cursor)
+}
+
+func TestAdvanceChannelLatestMessageIDConcurrentWrites(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	s, err := Open(ctx, filepath.Join(t.TempDir(), "discrawl.db"))
+	require.NoError(t, err)
+	defer func() { _ = s.Close() }()
+
+	ids := []string{
+		"100000000000000101",
+		"100000000000000099",
+		"99999999999999999",
+		"100000000000000250",
+		"100000000000000001",
+		"100000000000000200",
+	}
+	var wg sync.WaitGroup
+	errs := make(chan error, len(ids)*25)
+	for range 25 {
+		for _, id := range ids {
+			wg.Go(func() {
+				errs <- s.AdvanceChannelLatestMessageID(ctx, "c1", id)
+			})
+		}
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		require.NoError(t, err)
+	}
+
+	cursor, err := s.GetSyncState(ctx, "channel:c1:latest_message_id")
+	require.NoError(t, err)
+	require.Equal(t, "100000000000000250", cursor)
 }
 
 func TestIncompleteMessageChannelIDs(t *testing.T) {

--- a/internal/store/write.go
+++ b/internal/store/write.go
@@ -459,6 +459,77 @@ func (s *Store) SetSyncState(ctx context.Context, scope, cursor string) error {
 	})
 }
 
+func (s *Store) AdvanceChannelLatestMessageID(ctx context.Context, channelID, messageID string) error {
+	if messageID == "" {
+		return nil
+	}
+	if channelID == "" {
+		return errors.New("channel id is required")
+	}
+	if !isCanonicalDecimalSnowflake(messageID) {
+		return errors.New("channel latest message id must be a canonical decimal snowflake")
+	}
+	result, err := s.db.ExecContext(ctx, `
+insert into sync_state(scope, cursor, updated_at)
+values(?, ?, ?)
+on conflict(scope) do update set
+	cursor = excluded.cursor,
+	updated_at = excluded.updated_at
+where sync_state.cursor is null
+	or sync_state.cursor = ''
+	or (
+		sync_state.cursor not glob '*[^0-9]*'
+		and (sync_state.cursor = '0' or sync_state.cursor not glob '0*')
+		and (
+			length(excluded.cursor) > length(sync_state.cursor)
+			or (length(excluded.cursor) = length(sync_state.cursor) and excluded.cursor > sync_state.cursor)
+		)
+	)
+`, "channel:"+channelID+":latest_message_id", messageID, time.Now().UTC().Format(timeLayout))
+	if err != nil {
+		return err
+	}
+	rows, err := result.RowsAffected()
+	if err != nil || rows != 0 {
+		return err
+	}
+	current, err := s.GetSyncState(ctx, "channel:"+channelID+":latest_message_id")
+	if err != nil {
+		return err
+	}
+	if current != "" && !isCanonicalDecimalSnowflake(current) {
+		return errors.New("stored channel latest message id is not a canonical decimal snowflake")
+	}
+	return nil
+}
+
+func (s *Store) EnsureChannelLatestMessageState(ctx context.Context, channelID string) error {
+	if channelID == "" {
+		return errors.New("channel id is required")
+	}
+	_, err := s.db.ExecContext(ctx, `
+insert into sync_state(scope, cursor, updated_at)
+values(?, '', ?)
+on conflict(scope) do nothing
+`, "channel:"+channelID+":latest_message_id", time.Now().UTC().Format(timeLayout))
+	return err
+}
+
+func isCanonicalDecimalSnowflake(value string) bool {
+	if value == "" {
+		return false
+	}
+	if len(value) > 1 && value[0] == '0' {
+		return false
+	}
+	for _, r := range value {
+		if r < '0' || r > '9' {
+			return false
+		}
+	}
+	return true
+}
+
 func (s *Store) DeleteSyncState(ctx context.Context, scope string) error {
 	return s.q.DeleteSyncState(ctx, scope)
 }

--- a/internal/syncer/message_sync.go
+++ b/internal/syncer/message_sync.go
@@ -306,7 +306,7 @@ func (s *Syncer) syncFullChannelHistory(ctx context.Context, channel *discordgo.
 			return messageCount, err
 		}
 		newest = maxSnowflake(newest, latest)
-		if err := s.store.SetSyncState(ctx, channelLatestScope(channel.ID), newest); err != nil {
+		if err := s.advanceChannelLatest(ctx, channel.ID, newest); err != nil {
 			return messageCount, err
 		}
 	}
@@ -323,7 +323,13 @@ func (s *Syncer) syncFullChannelHistory(ctx context.Context, channel *discordgo.
 		}
 	}
 	if newest != "" || state.Latest != "" || !state.BackfillComplete {
-		if err := s.store.SetSyncState(ctx, channelLatestScope(channel.ID), newest); err != nil {
+		if newest == "" {
+			if err := s.store.EnsureChannelLatestMessageState(ctx, channel.ID); err != nil {
+				return messageCount, err
+			}
+			return messageCount, nil
+		}
+		if err := s.advanceChannelLatest(ctx, channel.ID, newest); err != nil {
 			return messageCount, err
 		}
 	}
@@ -341,7 +347,7 @@ func (s *Syncer) syncIncrementalChannelHistory(ctx context.Context, channel *dis
 	if newest == "" && state.Latest == "" {
 		return count, nil
 	}
-	if err := s.store.SetSyncState(ctx, channelLatestScope(channel.ID), maxSnowflake(state.Latest, newest)); err != nil {
+	if err := s.advanceChannelLatest(ctx, channel.ID, maxSnowflake(state.Latest, newest)); err != nil {
 		return count, err
 	}
 	return count, nil
@@ -387,7 +393,7 @@ func (s *Syncer) bootstrapChannelHistory(ctx context.Context, channel *discordgo
 		}
 	}
 	if newest != "" {
-		if err := s.store.SetSyncState(ctx, channelLatestScope(channel.ID), newest); err != nil {
+		if err := s.advanceChannelLatest(ctx, channel.ID, newest); err != nil {
 			return messageCount, err
 		}
 	}
@@ -413,7 +419,7 @@ func (s *Syncer) syncForwardPages(ctx context.Context, channel *discordgo.Channe
 		after = maxSnowflake(after, pageNewest)
 		newest = maxSnowflake(newest, pageNewest)
 		messageCount += len(page)
-		if err := s.store.SetSyncState(ctx, channelLatestScope(channel.ID), newest); err != nil {
+		if err := s.advanceChannelLatest(ctx, channel.ID, newest); err != nil {
 			return messageCount, newest, err
 		}
 		if len(page) < 100 {
@@ -451,7 +457,7 @@ func (s *Syncer) syncBackfillPages(ctx context.Context, channel *discordgo.Chann
 		// over a stored head would make resumed full syncs re-crawl the
 		// whole span between the backfill cursor and the head.
 		if newest != "" && maxSnowflake(latestFloor, newest) == newest {
-			if err := s.store.SetSyncState(ctx, channelLatestScope(channel.ID), newest); err != nil {
+			if err := s.advanceChannelLatest(ctx, channel.ID, newest); err != nil {
 				return messageCount, newest, err
 			}
 		}
@@ -476,6 +482,10 @@ func (s *Syncer) syncBackfillPages(ctx context.Context, channel *discordgo.Chann
 		}
 	}
 	return messageCount, newest, nil
+}
+
+func (s *Syncer) advanceChannelLatest(ctx context.Context, channelID, cursor string) error {
+	return s.store.AdvanceChannelLatestMessageID(ctx, channelID, cursor)
 }
 
 func (s *Syncer) persistMessagePage(ctx context.Context, messages []*discordgo.Message, channelName string, fallbackGuildID string, embeddings bool) (string, error) {

--- a/internal/syncer/message_sync.go
+++ b/internal/syncer/message_sync.go
@@ -315,7 +315,7 @@ func (s *Syncer) syncFullChannelHistory(ctx context.Context, channel *discordgo.
 		if before == "" && state.Latest != "" {
 			before = state.Latest
 		}
-		count, latest, err := s.syncBackfillPages(ctx, channel, before, channel.Name, embeddings, since, progress)
+		count, latest, err := s.syncBackfillPages(ctx, channel, before, newest, channel.Name, embeddings, since, progress)
 		messageCount += count
 		newest = maxSnowflake(newest, latest)
 		if err != nil {
@@ -423,7 +423,7 @@ func (s *Syncer) syncForwardPages(ctx context.Context, channel *discordgo.Channe
 	return messageCount, newest, nil
 }
 
-func (s *Syncer) syncBackfillPages(ctx context.Context, channel *discordgo.Channel, before, channelName string, embeddings bool, since time.Time, progress *messageSyncProgress) (int, string, error) {
+func (s *Syncer) syncBackfillPages(ctx context.Context, channel *discordgo.Channel, before, latestFloor, channelName string, embeddings bool, since time.Time, progress *messageSyncProgress) (int, string, error) {
 	messageCount := 0
 	newest := ""
 	for {
@@ -445,7 +445,12 @@ func (s *Syncer) syncBackfillPages(ctx context.Context, channel *discordgo.Chann
 		progress.touch(channel, len(eligible))
 		newest = maxSnowflake(newest, pageNewest)
 		messageCount += len(eligible)
-		if newest != "" {
+		// Backfill pages are older than any previously synced head, so only
+		// checkpoint the latest pointer when it actually advances (backfill
+		// starting from the channel head); persisting backfill-region ids
+		// over a stored head would make resumed full syncs re-crawl the
+		// whole span between the backfill cursor and the head.
+		if newest != "" && maxSnowflake(latestFloor, newest) == newest {
 			if err := s.store.SetSyncState(ctx, channelLatestScope(channel.ID), newest); err != nil {
 				return messageCount, newest, err
 			}

--- a/internal/syncer/syncer_history_test.go
+++ b/internal/syncer/syncer_history_test.go
@@ -93,6 +93,82 @@ func TestSyncFullBackfillResumesFromCheckpoint(t *testing.T) {
 	require.Len(t, results, 1)
 }
 
+func TestSyncFullBackfillDoesNotRegressLatestPointer(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	s, err := store.Open(ctx, filepath.Join(t.TempDir(), "discrawl.db"))
+	require.NoError(t, err)
+	defer func() { _ = s.Close() }()
+
+	// Resume state for a half-backfilled channel: head already synced up to
+	// 250, backfill cursor parked at 200.
+	require.NoError(t, s.SetSyncState(ctx, channelLatestScope("c1"), "250"))
+	require.NoError(t, s.SetSyncState(ctx, channelBackfillScope("c1"), "200"))
+
+	messages := make([]*discordgo.Message, 0, 250)
+	for id := 250; id >= 1; id-- {
+		messages = append(messages, &discordgo.Message{
+			ID:        fmt.Sprintf("%03d", id),
+			GuildID:   "g1",
+			ChannelID: "c1",
+			Content:   fmt.Sprintf("msg-%03d", id),
+			Timestamp: time.Now().UTC(),
+			Author:    &discordgo.User{ID: "u1", Username: "user"},
+		})
+	}
+
+	client := &fakeClient{
+		guilds: []*discordgo.UserGuild{{ID: "g1", Name: "Guild"}},
+		guildByID: map[string]*discordgo.Guild{
+			"g1": {ID: "g1", Name: "Guild"},
+		},
+		channels: map[string][]*discordgo.Channel{
+			"g1": {{ID: "c1", GuildID: "g1", Name: "general", Type: discordgo.ChannelTypeGuildText}},
+		},
+		messages: map[string][]*discordgo.Message{
+			"c1": messages,
+		},
+		beforeErrors: map[string]map[string]error{
+			"c1": {"100": context.DeadlineExceeded},
+		},
+	}
+
+	svc := New(client, s, nil)
+	stats, err := svc.Sync(ctx, SyncOptions{Full: true, Concurrency: 1})
+	require.NoError(t, err)
+	require.Equal(t, 100, stats.Messages)
+
+	// The interrupted backfill must not have clobbered the head pointer with
+	// ids from the backfill region.
+	latest, err := s.GetSyncState(ctx, channelLatestScope("c1"))
+	require.NoError(t, err)
+	require.Equal(t, "250", latest)
+
+	backfill, err := s.GetSyncState(ctx, channelBackfillScope("c1"))
+	require.NoError(t, err)
+	require.Equal(t, "100", backfill)
+
+	complete, err := s.GetSyncState(ctx, channelHistoryCompleteScope("c1"))
+	require.NoError(t, err)
+	require.Empty(t, complete)
+
+	// The resumed pass should fetch only the remaining backfill span, not
+	// re-crawl 200..250 from a regressed head pointer.
+	delete(client.beforeErrors["c1"], "100")
+	stats, err = svc.Sync(ctx, SyncOptions{Full: true, Concurrency: 1})
+	require.NoError(t, err)
+	require.Equal(t, 99, stats.Messages)
+
+	latest, err = s.GetSyncState(ctx, channelLatestScope("c1"))
+	require.NoError(t, err)
+	require.Equal(t, "250", latest)
+
+	complete, err = s.GetSyncState(ctx, channelHistoryCompleteScope("c1"))
+	require.NoError(t, err)
+	require.Equal(t, "1", complete)
+}
+
 func TestSyncFullSeedsBackfillFromStoredMessages(t *testing.T) {
 	t.Parallel()
 

--- a/internal/syncer/syncer_history_test.go
+++ b/internal/syncer/syncer_history_test.go
@@ -169,6 +169,111 @@ func TestSyncFullBackfillDoesNotRegressLatestPointer(t *testing.T) {
 	require.Equal(t, "1", complete)
 }
 
+func TestSyncFullBackfillLargeResumeDoesNotRecrawlHeadSpan(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	s, err := store.Open(ctx, filepath.Join(t.TempDir(), "discrawl.db"))
+	require.NoError(t, err)
+	defer func() { _ = s.Close() }()
+
+	require.NoError(t, s.UpsertGuild(ctx, store.GuildRecord{ID: "g1", Name: "Guild", RawJSON: `{}`}))
+	require.NoError(t, s.UpsertChannel(ctx, store.ChannelRecord{ID: "c1", GuildID: "g1", Kind: "text", Name: "general", RawJSON: `{}`}))
+
+	const totalMessages = 1200
+	headID := syntheticSnowflakeID(totalMessages)
+	backfillStartID := syntheticSnowflakeID(1000)
+	interruptBeforeID := syntheticSnowflakeID(900)
+	for id := 1000; id <= totalMessages; id++ {
+		require.NoError(t, s.UpsertMessage(ctx, store.MessageRecord{
+			ID:                syntheticSnowflakeID(id),
+			GuildID:           "g1",
+			ChannelID:         "c1",
+			ChannelName:       "general",
+			AuthorID:          "u1",
+			AuthorName:        "user",
+			CreatedAt:         time.Now().UTC().Format(time.RFC3339Nano),
+			Content:           fmt.Sprintf("msg-%d", id),
+			NormalizedContent: fmt.Sprintf("msg-%d", id),
+			RawJSON:           `{}`,
+		}))
+	}
+	require.NoError(t, s.SetSyncState(ctx, channelLatestScope("c1"), headID))
+	require.NoError(t, s.SetSyncState(ctx, channelBackfillScope("c1"), backfillStartID))
+
+	messages := make([]*discordgo.Message, 0, totalMessages)
+	for id := totalMessages; id >= 1; id-- {
+		messages = append(messages, &discordgo.Message{
+			ID:        syntheticSnowflakeID(id),
+			GuildID:   "g1",
+			ChannelID: "c1",
+			Content:   fmt.Sprintf("msg-%d", id),
+			Timestamp: time.Now().UTC(),
+			Author:    &discordgo.User{ID: "u1", Username: "user"},
+		})
+	}
+
+	client := &fakeClient{
+		guilds: []*discordgo.UserGuild{{ID: "g1", Name: "Guild"}},
+		guildByID: map[string]*discordgo.Guild{
+			"g1": {ID: "g1", Name: "Guild"},
+		},
+		channels: map[string][]*discordgo.Channel{
+			"g1": {{ID: "c1", GuildID: "g1", Name: "general", Type: discordgo.ChannelTypeGuildText}},
+		},
+		messages: map[string][]*discordgo.Message{
+			"c1": messages,
+		},
+		beforeErrors: map[string]map[string]error{
+			"c1": {interruptBeforeID: context.DeadlineExceeded},
+		},
+	}
+
+	svc := New(client, s, nil)
+	stats, err := svc.Sync(ctx, SyncOptions{Full: true, Concurrency: 1})
+	require.NoError(t, err)
+	require.Equal(t, 100, stats.Messages)
+
+	latest, err := s.GetSyncState(ctx, channelLatestScope("c1"))
+	require.NoError(t, err)
+	require.Equal(t, headID, latest)
+	backfill, err := s.GetSyncState(ctx, channelBackfillScope("c1"))
+	require.NoError(t, err)
+	require.Equal(t, interruptBeforeID, backfill)
+
+	delete(client.beforeErrors["c1"], interruptBeforeID)
+	client.mu.Lock()
+	client.messageRequests = nil
+	client.mu.Unlock()
+
+	stats, err = svc.Sync(ctx, SyncOptions{Full: true, Concurrency: 1})
+	require.NoError(t, err)
+	require.Equal(t, 899, stats.Messages)
+
+	client.mu.Lock()
+	requests := append([]messageRequest(nil), client.messageRequests...)
+	client.mu.Unlock()
+	for _, req := range requests {
+		if req.afterID != "" {
+			require.Equal(t, headID, req.afterID)
+		}
+	}
+
+	latest, err = s.GetSyncState(ctx, channelLatestScope("c1"))
+	require.NoError(t, err)
+	require.Equal(t, headID, latest)
+	complete, err := s.GetSyncState(ctx, channelHistoryCompleteScope("c1"))
+	require.NoError(t, err)
+	require.Equal(t, "1", complete)
+	_, rows, err := s.ReadOnlyQuery(ctx, `select count(*) from messages where channel_id = 'c1'`)
+	require.NoError(t, err)
+	require.Equal(t, [][]string{{"1200"}}, rows)
+}
+
+func syntheticSnowflakeID(offset int) string {
+	return fmt.Sprintf("%018d", int64(100000000000000000+offset))
+}
+
 func TestSyncFullSeedsBackfillFromStoredMessages(t *testing.T) {
 	t.Parallel()
 

--- a/internal/syncer/syncer_tail_test.go
+++ b/internal/syncer/syncer_tail_test.go
@@ -108,6 +108,20 @@ func TestTailHandlerWritesEvents(t *testing.T) {
 	cursor, err := s.GetSyncState(context.Background(), "channel:c1:latest_message_id")
 	require.NoError(t, err)
 	require.Equal(t, "9", cursor)
+
+	older := *msg
+	older.ID = "8"
+	require.NoError(t, handler.OnMessageCreate(ctx, &older))
+	cursor, err = s.GetSyncState(context.Background(), "channel:c1:latest_message_id")
+	require.NoError(t, err)
+	require.Equal(t, "9", cursor)
+
+	newer := *msg
+	newer.ID = "10"
+	require.NoError(t, handler.OnMessageCreate(ctx, &newer))
+	cursor, err = s.GetSyncState(context.Background(), "channel:c1:latest_message_id")
+	require.NoError(t, err)
+	require.Equal(t, "10", cursor)
 }
 
 func TestHelpers(t *testing.T) {

--- a/internal/syncer/syncer_test.go
+++ b/internal/syncer/syncer_test.go
@@ -31,6 +31,7 @@ type fakeClient struct {
 	messages         map[string][]*discordgo.Message
 	messageErrors    map[string]error
 	messageCalls     map[string]int
+	messageRequests  []messageRequest
 	messageBlocks    map[string]chan struct{}
 	messageStarted   chan string
 	beforeErrors     map[string]map[string]error
@@ -45,6 +46,12 @@ type fakeClient struct {
 	mu               sync.Mutex
 	inFlight         int
 	maxInFlight      int
+}
+
+type messageRequest struct {
+	channelID string
+	beforeID  string
+	afterID   string
 }
 
 func (f *fakeClient) Self(context.Context) (*discordgo.User, error) {
@@ -122,6 +129,11 @@ func (f *fakeClient) ChannelMessages(ctx context.Context, channelID string, limi
 		f.messageCalls = make(map[string]int)
 	}
 	f.messageCalls[channelID]++
+	f.messageRequests = append(f.messageRequests, messageRequest{
+		channelID: channelID,
+		beforeID:  beforeID,
+		afterID:   afterID,
+	})
 	f.mu.Unlock()
 	if f.messageStarted != nil {
 		select {
@@ -203,7 +215,7 @@ func (f *fakeClient) ChannelMessage(_ context.Context, channelID, messageID stri
 func (f *fakeClient) Tail(ctx context.Context, handler discordclient.EventHandler) error {
 	f.tailCalls++
 	msg := &discordgo.Message{
-		ID:        "m3",
+		ID:        "3",
 		GuildID:   "g1",
 		ChannelID: "c1",
 		Content:   "tail event",

--- a/internal/syncer/tail.go
+++ b/internal/syncer/tail.go
@@ -62,7 +62,7 @@ func (t *tailHandler) OnMessageCreate(ctx context.Context, msg *discordgo.Messag
 	if err := t.store.SetSyncState(ctx, "tail:last_event", msg.ID); err != nil {
 		return err
 	}
-	return t.store.SetSyncState(ctx, channelLatestScope(msg.ChannelID), msg.ID)
+	return t.store.AdvanceChannelLatestMessageID(ctx, msg.ChannelID, msg.ID)
 }
 
 func (t *tailHandler) OnMessageUpdate(ctx context.Context, msg *discordgo.Message) error {


### PR DESCRIPTION
Fixes #85.

## Problem

`syncBackfillPages` persisted the newest id of each backfilled page to `channel:<id>:latest_message_id`. During a resumed `--full` sync the backfill region is by construction older than the stored head, so every page write regressed the pointer. When the per-channel timeout then deferred the channel, the next pass's forward sync re-crawled the entire span between the backfill cursor and the channel's true head (all duplicate `INSERT OR IGNORE` work) before backfill got whatever remained of the timeout budget — so resume cost grew roughly quadratically with channel size. On a ~200k-message channel, net-new rows per 5-minute pass collapsed from ~28k to ~500.

## Fix

`syncFullChannelHistory` already knows the current head (`state.Latest` maxed with the forward-sync result), so it now passes that into `syncBackfillPages` as a floor. The in-loop `channelLatestScope` checkpoint is only written when the backfill page's newest id actually advances past the floor — which only happens in the one case the write existed for: a first-run `--full` whose backfill starts at the channel head (no stored latest yet). With a stored head in place, backfill now only advances `channel:<id>:backfill_before_id`, and the pointer can never regress.

## Test

`TestSyncFullBackfillDoesNotRegressLatestPointer` reproduces the issue: a half-backfilled channel (latest=250, backfill cursor=200) whose backfill is interrupted by `context.DeadlineExceeded` mid-run. Without the fix the latest pointer regresses to 199 (the newest id in the backfilled page); with the fix it stays at 250, and the resumed pass fetches only the remaining 99 backfill messages instead of re-crawling the head span.

Verified: `go build ./...`, `go vet ./...`, `go test -count=1 ./...`, and `go test -race ./internal/syncer/` all pass; the new test fails against `main` with `expected: "250" / actual: "199"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)