### PR TITLE
Expose the changelog in the docs site

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
     paths:
+      - "CHANGELOG.md"
       - "docs/**"
       - "scripts/build-docs-site.mjs"
       - ".github/workflows/pages.yml"

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,0 +1,1 @@
+../CHANGELOG.md

--- a/docs/README.md
+++ b/docs/README.md
@@ -38,7 +38,7 @@ readable message/thread detail on the right.
 
 ## Sections
 
-- **[Start](install.html)** - install, configure, set up the Discord bot, security notes, contact
+- **[Start](install.html)** - install, configure, set up the Discord bot, security notes, release history, contact
 - **[Guides](guides/)** - sync sources, wiretap internals, search modes, embeddings, Git snapshots, data layout
 - **[Commands](commands/)** - one page per CLI command
 

--- a/scripts/build-docs-site.mjs
+++ b/scripts/build-docs-site.mjs
@@ -10,7 +10,7 @@ const siteUrl = "https://discrawl.sh";
 const brewInstall = "brew install openclaw/tap/discrawl";
 
 const sections = [
-  ["Start", ["README.md", "install.md", "configuration.md", "bot-setup.md", "security.md", "contact.md"]],
+  ["Start", ["README.md", "install.md", "configuration.md", "bot-setup.md", "security.md", "CHANGELOG.md", "contact.md"]],
   ["Guides", rels("guides")],
   ["Commands", rels("commands")],
 ];


### PR DESCRIPTION
## Summary

- add `docs/CHANGELOG.md` as a symlink to the root changelog
- include the changelog in the docs site Start navigation
- mention release history from the docs home page section list
- add root `CHANGELOG.md` to the Pages workflow path filter so changelog-only edits rebuild the published docs site

## Rationale

Finding the changelog from the documentation site currently takes multiple steps for a user. The release history is useful when someone wants to understand what changed, whether their installed version has a feature, or how recent behavior differs from older releases.

This makes the changelog a first-class docs page without duplicating the source file, so the site stays easy to navigate while the root `CHANGELOG.md` remains the canonical source. Since the generated site now depends on the root changelog, the Pages workflow also needs to watch `CHANGELOG.md`; otherwise release-note-only updates could leave the published docs stale.

## Validation

- `node scripts/build-docs-site.mjs`
- `git diff --check -- .github/workflows/pages.yml docs/CHANGELOG.md docs/README.md scripts/build-docs-site.mjs`
- opened `http://127.0.0.1:4173/CHANGELOG.html` in the in-app browser

Terminal proof from the generated site:

```text
built docs site: dist/docs-site

--- rendered file proof ---
6:  <title>Changelog - Discrawl</title>
219:      <nav><section><h2>start</h2><a class="nav-link" href="index.html">Discrawl</a><a class="nav-link" href="install.html">Install</a><a class="nav-link" href="configuration.html">Configuration</a><a class="nav-link" href="bot-setup.html">Discord bot setup</a><a class="nav-link" href="security.html">Security</a><a class="nav-link active" href="CHANGELOG.html">Changelog</a><a class="nav-link" href="contact.html">Contact</a></section>
237:        <article class="doc"><h1 id="changelog">Changelog</h1>

--- home proof ---
219:      <nav><section><h2>start</h2><a class="nav-link active" href="index.html">Discrawl</a><a class="nav-link" href="install.html">Install</a><a class="nav-link" href="configuration.html">Configuration</a><a class="nav-link" href="bot-setup.html">Discord bot setup</a><a class="nav-link" href="security.html">Security</a><a class="nav-link" href="CHANGELOG.html">Changelog</a><a class="nav-link" href="contact.html">Contact</a></section>
280:<li><strong><a href="install.html">Start</a></strong> - install, configure, set up the Discord bot, security notes, release history, contact</li>
```

Rendered-page proof from the in-app browser:

```json
{
  "activeHref": "CHANGELOG.html",
  "activeNav": "Changelog",
  "firstChangelogItem": "Keep incremental share imports compatible with crawlkit's safe changed-tail replacement plan instead of falling back to a full archive rebuild.",
  "heading": "Changelog",
  "startNav": [
    "Discrawl",
    "Install",
    "Configuration",
    "Discord bot setup",
    "Security",
    "Changelog",
    "Contact"
  ],
  "title": "Changelog - Discrawl",
  "url": "http://127.0.0.1:4173/CHANGELOG.html"
}
```
