### PR TITLE
build(deps): bump crawlkit to 0.12.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 - Refresh Discord member roles daily for published archives, and make `sync --with-members` bypass cached freshness when a refresh is required. Thanks @hannesrudolph.
 - Keep incremental share imports compatible with crawlkit's safe changed-tail replacement plan instead of falling back to a full archive rebuild.
+- Accept absolute Windows SQLite paths through the shared crawlkit store opener.
 
 ## 0.11.0 - 2026-06-11
 

--- a/go.mod
+++ b/go.mod
@@ -44,7 +44,7 @@ require (
 	github.com/muesli/cancelreader v0.2.2 // indirect
 	github.com/muesli/termenv v0.16.0 // indirect
 	github.com/ncruces/go-strftime v1.0.0 // indirect
-	github.com/openclaw/crawlkit v0.12.1
+	github.com/openclaw/crawlkit v0.12.2
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect

--- a/go.sum
+++ b/go.sum
@@ -71,8 +71,8 @@ github.com/muesli/termenv v0.16.0 h1:S5AlUN9dENB57rsbnkPyfdGuWIlkmzJjbFf0Tf5FWUc
 github.com/muesli/termenv v0.16.0/go.mod h1:ZRfOIKPFDYQoDFF4Olj7/QJbW60Ol/kL1pU3VfY/Cnk=
 github.com/ncruces/go-strftime v1.0.0 h1:HMFp8mLCTPp341M/ZnA4qaf7ZlsbTc+miZjCLOFAw7w=
 github.com/ncruces/go-strftime v1.0.0/go.mod h1:Fwc5htZGVVkseilnfgOVb9mKy6w1naJmn9CehxcKcls=
-github.com/openclaw/crawlkit v0.12.1 h1:62EfPfHRTtb06RHOQfGIjBBvt0jQqNZCRywOvS8Ps4w=
-github.com/openclaw/crawlkit v0.12.1/go.mod h1:+Z9vrCgH8BJ/+3MMoMfnDyhXC9ON7bEDduGvp5TmmuM=
+github.com/openclaw/crawlkit v0.12.2 h1:KivYMOHfemLG9LrfKKI8A/FTDJpdFJyeOreCGbKCsXA=
+github.com/openclaw/crawlkit v0.12.2/go.mod h1:+Z9vrCgH8BJ/+3MMoMfnDyhXC9ON7bEDduGvp5TmmuM=
 github.com/pelletier/go-toml/v2 v2.3.1 h1:MYEvvGnQjeNkRF1qUuGolNtNExTDwct51yp7olPtrEc=
 github.com/pelletier/go-toml/v2 v2.3.1/go.mod h1:2gIqNv+qfxSVS7cM2xJQKtLSTLUE9V8t9Stt+h56mCY=
 github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=


### PR DESCRIPTION
## Summary

- update crawlkit from 0.12.1 to 0.12.2
- pick up its Windows absolute SQLite path fix
- document the compatibility fix in the unreleased changelog

## Verification

- `GOWORK=off go test -count=1 ./... -coverprofile=/tmp/discrawl-coverage.out`
- `GOWORK=off go test -count=1 -race ./...`
- `GOWORK=off go vet ./...`
- staticcheck, deadcode, gofumpt, gosec, govulncheck
- GoReleaser snapshot and Docker build/smoke
- exact built CLI: `doctor --json`, `status --json`, and archive-backed search; output suppressed
- repo-local Codex autoreview: clean
