### PR TITLE
ci(deps): bump trufflehog to 3.95.6

### DIFF
--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -49,7 +49,7 @@ jobs:
 
       - name: TruffleHog OSS
         id: trufflehog
-        uses: trufflesecurity/trufflehog@v3.95.5
+        uses: trufflesecurity/trufflehog@v3.95.6
         with:
           path: ./
           base: ${{ steps.scan_range.outputs.base }}


### PR DESCRIPTION
## Summary

- update the TruffleHog secret-scan action from 3.95.5 to 3.95.6
- pick up scanner correctness fixes, including long-line coverage and fewer false verified findings

## Verification

- `actionlint`
- `GOWORK=off go test -count=1 ./...`
- repo-local Codex autoreview: clean
- runtime code unchanged; the PR secret-scan job is the end-to-end workflow proof
