### PR TITLE
Fix duplicate attachment sync upserts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Add shared channel resolution for `channels`, `search`, `messages`, and message sync with stable id precedence and actionable ambiguity candidates.
 - Add read-only `diagnostics` output for SQLite integrity, WAL size, archive freshness, and authoritative Discrawl writer-lock ownership.
 - Add read-only archive coverage reporting with per-guild/channel bounds, named-versus-synthetic channel counts, persisted wiretap skip counters, and watch-mode deltas via `wiretap --stats`.
+- Preserve fetched attachment media metadata when duplicate attachment snapshots refresh the singleton attachment row. Thanks @agent-eli.
 
 ## 0.11.3 - 2026-06-23
 

--- a/internal/store/attachments_test.go
+++ b/internal/store/attachments_test.go
@@ -90,6 +90,39 @@ func TestAttachmentMediaUpdatesAndFilters(t *testing.T) {
 	require.Empty(t, rows)
 }
 
+func TestAttachmentUpsertMovesDuplicateIDAndKeepsMedia(t *testing.T) {
+	ctx := context.Background()
+	s, err := Open(ctx, filepath.Join(t.TempDir(), "discrawl.db"))
+	require.NoError(t, err)
+	defer func() { _ = s.Close() }()
+
+	require.NoError(t, seedAttachmentForGuild(ctx, s, "g1", "c1", "m1", "a1"))
+	require.NoError(t, s.UpdateAttachmentMedia(ctx, AttachmentMediaUpdate{
+		AttachmentID:  "a1",
+		MediaPath:     "attachments/aa/hash-file.png",
+		ContentSHA256: "hash",
+		ContentSize:   4,
+		FetchedAt:     "2026-05-15T12:05:00Z",
+		FetchStatus:   "fetched",
+	}))
+	require.NoError(t, seedAttachmentForGuild(ctx, s, "g1", "c2", "m2", "a1"))
+
+	rows, err := s.ListAttachments(ctx, AttachmentListOptions{MessageID: "m1"})
+	require.NoError(t, err)
+	require.Empty(t, rows)
+
+	rows, err = s.ListAttachments(ctx, AttachmentListOptions{MessageID: "m2"})
+	require.NoError(t, err)
+	require.Len(t, rows, 1)
+	require.Equal(t, "a1", rows[0].AttachmentID)
+	require.Equal(t, "m2", rows[0].MessageID)
+	require.Equal(t, "c2", rows[0].ChannelID)
+	require.Equal(t, "attachments/aa/hash-file.png", rows[0].MediaPath)
+	require.Equal(t, "hash", rows[0].ContentSHA256)
+	require.Equal(t, int64(4), rows[0].ContentSize)
+	require.Equal(t, "fetched", rows[0].FetchStatus)
+}
+
 func seedAttachmentForGuild(ctx context.Context, s *Store, guildID, channelID, messageID, attachmentID string) error {
 	if err := s.UpsertGuild(ctx, GuildRecord{ID: guildID, Name: guildID, RawJSON: `{}`}); err != nil {
 		return err

--- a/internal/store/sqlc/queries.sql
+++ b/internal/store/sqlc/queries.sql
@@ -408,7 +408,7 @@ on conflict(attachment_id) do update set
 		else message_attachments.fetch_status
 	end,
 	fetch_error = case
-		when excluded.fetch_error <> '' then excluded.fetch_error
+		when excluded.fetch_status <> '' or excluded.fetch_error <> '' then excluded.fetch_error
 		else message_attachments.fetch_error
 	end,
 	updated_at = excluded.updated_at;

--- a/internal/store/sqlc/queries.sql
+++ b/internal/store/sqlc/queries.sql
@@ -396,12 +396,21 @@ on conflict(attachment_id) do update set
 	url = excluded.url,
 	proxy_url = excluded.proxy_url,
 	text_content = excluded.text_content,
-	media_path = excluded.media_path,
-	content_sha256 = excluded.content_sha256,
-	content_size = excluded.content_size,
-	fetched_at = excluded.fetched_at,
-	fetch_status = excluded.fetch_status,
-	fetch_error = excluded.fetch_error,
+	media_path = coalesce(excluded.media_path, message_attachments.media_path),
+	content_sha256 = coalesce(excluded.content_sha256, message_attachments.content_sha256),
+	content_size = case
+		when excluded.content_size > 0 then excluded.content_size
+		else message_attachments.content_size
+	end,
+	fetched_at = coalesce(excluded.fetched_at, message_attachments.fetched_at),
+	fetch_status = case
+		when excluded.fetch_status <> '' then excluded.fetch_status
+		else message_attachments.fetch_status
+	end,
+	fetch_error = case
+		when excluded.fetch_error <> '' then excluded.fetch_error
+		else message_attachments.fetch_error
+	end,
 	updated_at = excluded.updated_at;
 
 -- name: DeleteMentionEventsByMessage :exec

--- a/internal/store/store_write_test.go
+++ b/internal/store/store_write_test.go
@@ -99,6 +99,7 @@ func TestUpsertMessagesRefreshesDuplicateAttachmentID(t *testing.T) {
 			TextContent:  "cached text",
 			MediaPath:    "attachments/a1.txt",
 			FetchStatus:  "done",
+			FetchError:   "stale failure",
 		}},
 	}
 	second := MessageMutation{
@@ -127,9 +128,9 @@ func TestUpsertMessagesRefreshesDuplicateAttachmentID(t *testing.T) {
 	require.NoError(t, s.UpsertMessages(ctx, []MessageMutation{first}))
 	require.NoError(t, s.UpsertMessages(ctx, []MessageMutation{second}))
 
-	_, rows, err := s.ReadOnlyQuery(ctx, "select attachment_id, message_id, channel_id, filename, text_content, media_path from message_attachments")
+	_, rows, err := s.ReadOnlyQuery(ctx, "select attachment_id, message_id, channel_id, filename, text_content, media_path, fetch_status, fetch_error from message_attachments")
 	require.NoError(t, err)
-	require.Equal(t, [][]string{{"a1", "m2", "c2", "second.txt", "fresh text", "attachments/a1.txt"}}, rows)
+	require.Equal(t, [][]string{{"a1", "m2", "c2", "second.txt", "fresh text", "attachments/a1.txt", "done", ""}}, rows)
 }
 
 func TestUpsertMessagesNormalizesTimestampStrings(t *testing.T) {

--- a/internal/store/store_write_test.go
+++ b/internal/store/store_write_test.go
@@ -129,7 +129,7 @@ func TestUpsertMessagesRefreshesDuplicateAttachmentID(t *testing.T) {
 
 	_, rows, err := s.ReadOnlyQuery(ctx, "select attachment_id, message_id, channel_id, filename, text_content, media_path from message_attachments")
 	require.NoError(t, err)
-	require.Equal(t, [][]string{{"a1", "m2", "c2", "second.txt", "fresh text", ""}}, rows)
+	require.Equal(t, [][]string{{"a1", "m2", "c2", "second.txt", "fresh text", "attachments/a1.txt"}}, rows)
 }
 
 func TestUpsertMessagesNormalizesTimestampStrings(t *testing.T) {

--- a/internal/store/storedb/queries.sql.go
+++ b/internal/store/storedb/queries.sql.go
@@ -465,12 +465,21 @@ on conflict(attachment_id) do update set
 	url = excluded.url,
 	proxy_url = excluded.proxy_url,
 	text_content = excluded.text_content,
-	media_path = excluded.media_path,
-	content_sha256 = excluded.content_sha256,
-	content_size = excluded.content_size,
-	fetched_at = excluded.fetched_at,
-	fetch_status = excluded.fetch_status,
-	fetch_error = excluded.fetch_error,
+	media_path = coalesce(excluded.media_path, message_attachments.media_path),
+	content_sha256 = coalesce(excluded.content_sha256, message_attachments.content_sha256),
+	content_size = case
+		when excluded.content_size > 0 then excluded.content_size
+		else message_attachments.content_size
+	end,
+	fetched_at = coalesce(excluded.fetched_at, message_attachments.fetched_at),
+	fetch_status = case
+		when excluded.fetch_status <> '' then excluded.fetch_status
+		else message_attachments.fetch_status
+	end,
+	fetch_error = case
+		when excluded.fetch_error <> '' then excluded.fetch_error
+		else message_attachments.fetch_error
+	end,
 	updated_at = excluded.updated_at
 `
 

--- a/internal/store/storedb/queries.sql.go
+++ b/internal/store/storedb/queries.sql.go
@@ -477,7 +477,7 @@ on conflict(attachment_id) do update set
 		else message_attachments.fetch_status
 	end,
 	fetch_error = case
-		when excluded.fetch_error <> '' then excluded.fetch_error
+		when excluded.fetch_status <> '' or excluded.fetch_error <> '' then excluded.fetch_error
 		else message_attachments.fetch_error
 	end,
 	updated_at = excluded.updated_at


### PR DESCRIPTION
## Summary

- upsert `message_attachments` on duplicate `attachment_id` instead of failing sync
- preserve previously fetched media cache fields when a duplicate attachment row moves to another message
- let an explicit new fetch status clear stale fetch-error text while metadata-less archive refreshes keep cached status/error
- add regression coverage for duplicate attachment IDs across messages

## Verification

- `GOWORK=off go test -count=1 ./...`
- rebuilt the exact PR head and ran `wiretap` twice against an explicit disposable synthetic Discord Desktop cache/archive
- verified the singleton attachment moved to the newer message and channel, source filename/size refreshed, cached media path/hash/size/status remained intact, and the old message owned zero attachment rows
- autoreview clean after fixing its stale-fetch-error finding

## Maintainer notes

- rebased onto current `main`; retained Eli Vance as author of the implementation commit
- added the `0.11.4 - Unreleased` changelog credit for `@agent-eli`
