### PR TITLE
[codex] Close tail client on repair-loop exits

### DIFF
--- a/internal/syncer/tail.go
+++ b/internal/syncer/tail.go
@@ -3,6 +3,7 @@ package syncer
 import (
 	"context"
 	"fmt"
+	"sync"
 	"time"
 
 	"github.com/bwmarrin/discordgo"
@@ -22,6 +23,13 @@ func (s *Syncer) RunTail(ctx context.Context, guildIDs []string, repairEvery tim
 	}
 	tailCtx, cancelTail := context.WithCancel(ctx)
 	defer cancelTail()
+	var closeOnce sync.Once
+	closeClient := func() {
+		if closeable, ok := s.client.(closeableClient); ok {
+			_ = closeable.Close()
+		}
+	}
+	defer closeOnce.Do(closeClient)
 	errCh := make(chan error, 2)
 	go func() {
 		errCh <- s.client.Tail(tailCtx, handler)
@@ -32,9 +40,7 @@ func (s *Syncer) RunTail(ctx context.Context, guildIDs []string, repairEvery tim
 		select {
 		case <-ctx.Done():
 			cancelTail()
-			if closeable, ok := s.client.(closeableClient); ok {
-				_ = closeable.Close()
-			}
+			closeOnce.Do(closeClient)
 			<-errCh
 			return nil
 		case err := <-errCh:


### PR DESCRIPTION
## Summary
- close repair-loop tail clients on every RunTail exit path
- keep the existing cancellation close path to unblock Tail, guarded with sync.Once
- fixes the race where Tail could return through errCh after cancellation and skip Close

## Validation
- GOWORK=off go test -count=20 -race ./internal/syncer -run TestRunTailWithRepairLoopJoinsTailOnCancellation
- GOWORK=off go test -count=1 -race ./internal/syncer
- GOWORK=off go test -count=1 ./...

Context: main CI failed after the actions/cache dependency merge on the existing race-detector test TestRunTailWithRepairLoopJoinsTailOnCancellation.