### PR TITLE
feat: add publish scope preflight

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.11.4 - Unreleased
+
+### Changes
+
+- Add read-only `publish --check` scope preflight with fail-closed metadata readiness, source hints, predicted channel/message counts, and concrete repair guidance.
+
 ## 0.11.3 - 2026-06-23
 
 ### Fixes

--- a/docs/commands/publish.md
+++ b/docs/commands/publish.md
@@ -12,6 +12,7 @@ discrawl publish --tag backup-2026-06-19 --push
 discrawl publish --with-embeddings --push
 discrawl publish --no-media --push
 discrawl publish --public-only --include-channels 1458141495701012561 --push
+discrawl publish --public-only --check --json
 ```
 
 ## Flags
@@ -23,6 +24,7 @@ discrawl publish --public-only --include-channels 1458141495701012561 --push
 - `--tag <name>` - create an immutable snapshot tag; requires a commit
 - `--no-commit` - write/export files without creating a Git commit
 - `--push` - push the snapshot commit after writing it
+- `--check` - inspect filter readiness and predicted scope without writing files or contacting the remote
 - `--readme <path>` - update the activity block in this README file too
 - `--public-only` - export only channels visible to the guild `@everyone` role
 - `--include-channels <ids>` - comma-separated channel ids to export; forum parents include their allowed public threads
@@ -33,6 +35,16 @@ discrawl publish --public-only --include-channels 1458141495701012561 --push
 Filters narrow only the published snapshot. The local SQLite archive can still
 be synced from a richer bot-visible dataset. Git-only readers see the filtered
 snapshot; the publisher keeps the complete local DB.
+
+Run `publish --check` before a filtered publish when you need a read-only
+preflight. It uses the same channel permission/filter logic as export and
+reports candidate versus allowed channel/message counts, per-guild metadata
+readiness, source hints, and whether an empty result means incomplete metadata
+or a genuinely empty scope. If `--public-only` lacks usable `@everyone` role
+metadata, the check fails closed and recommends `discrawl sync --source
+discord`. A not-ready check exits non-zero after printing its report. `--check`
+does not initialize or modify the snapshot repository and does not contact its
+remote.
 
 Filter rules:
 

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -286,6 +286,9 @@ func (r *runtime) dispatch(rest []string) error {
 	case "report":
 		return r.withLocalStoreRead(true, func() error { return r.runReport(rest[1:]) })
 	case "publish":
+		if boolFlagEnabled(rest[1:], "--check") || boolFlagEnabled(rest[1:], "-check") {
+			return r.withLocalStoreReadOnly(func() error { return r.runPublish(rest[1:]) })
+		}
 		return r.withServicesAutoLocked(false, false, true, func() error { return r.runPublish(rest[1:]) })
 	case "cloud":
 		return r.runCloud(rest[1:])

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -1782,6 +1782,71 @@ func TestShareCommandsPublishSubscribeAndUpdate(t *testing.T) {
 	require.Contains(t, out.String(), "automatic updates work")
 }
 
+func TestPublishCheckIsReadOnlyAndUsesPublishFilters(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.toml")
+	cfg := config.Default()
+	cfg.DBPath = filepath.Join(dir, "publisher.db")
+	cfg.Share.Remote = "https://invalid.example/archive.git"
+	cfg.Share.RepoPath = filepath.Join(dir, "must-not-exist")
+	require.NoError(t, config.Write(cfgPath, cfg))
+	publisher := seedCLIStore(t, cfg.DBPath)
+	require.NoError(t, publisher.UpsertGuild(ctx, store.GuildRecord{
+		ID:      "g1",
+		Name:    "Guild",
+		RawJSON: `{"roles":[{"id":"g1","permissions":"1024"}]}`,
+	}))
+	require.NoError(t, publisher.Close())
+
+	var out bytes.Buffer
+	require.NoError(t, Run(ctx, []string{
+		"--config", cfgPath,
+		"publish",
+		"--public-only",
+		"--check",
+		"--json",
+	}, &out, &bytes.Buffer{}))
+	var report share.PublishScopePreflight
+	require.NoError(t, json.Unmarshal(out.Bytes(), &report))
+	require.True(t, report.Ready)
+	require.Equal(t, share.PublishScopeCount{Candidate: 1, Allowed: 1}, report.Channels)
+	require.Equal(t, share.PublishScopeCount{Candidate: 1, Allowed: 1}, report.Messages)
+	require.NoDirExists(t, cfg.Share.RepoPath)
+
+	err := Run(ctx, []string{"--config", cfgPath, "publish", "--check", "--push"}, &bytes.Buffer{}, &bytes.Buffer{})
+	require.Equal(t, 2, ExitCode(err))
+	require.ErrorContains(t, err, "publish --check cannot be combined with --push")
+
+	publisher, err = store.Open(ctx, cfg.DBPath)
+	require.NoError(t, err)
+	require.NoError(t, publisher.UpsertGuild(ctx, store.GuildRecord{ID: "g1", Name: "Guild", RawJSON: `{}`}))
+	require.NoError(t, publisher.Close())
+	out.Reset()
+	err = Run(ctx, []string{"--config", cfgPath, "publish", "--public-only", "--check", "--json"}, &out, &bytes.Buffer{})
+	require.Equal(t, 1, ExitCode(err))
+	require.ErrorContains(t, err, "publish scope is not ready")
+	require.NoError(t, json.Unmarshal(out.Bytes(), &report))
+	require.False(t, report.Ready)
+	require.Equal(t, "discrawl sync --source discord", report.RepairCommand)
+	require.NoDirExists(t, cfg.Share.RepoPath)
+}
+
+func TestPublishCheckRejectsMissingLocalStoreWithoutCreatingArchive(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.toml")
+	cfg := config.Default()
+	cfg.DBPath = filepath.Join(dir, "missing.db")
+	require.NoError(t, config.Write(cfgPath, cfg))
+
+	for _, checkFlag := range []string{"--check", "-check"} {
+		err := Run(ctx, []string{"--config", cfgPath, "publish", checkFlag}, &bytes.Buffer{}, &bytes.Buffer{})
+		require.ErrorContains(t, err, "publish --check requires a local SQLite archive")
+		require.NoFileExists(t, cfg.DBPath)
+	}
+}
+
 func TestFilteredPublishRemovesGeneratedReadme(t *testing.T) {
 	ctx := context.Background()
 	dir := t.TempDir()

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -150,6 +150,14 @@ func TestOutputBranches(t *testing.T) {
 		},
 		syncer.SyncStats{Guilds: 1, Channels: 2, Threads: 3, Members: 4, Messages: 5},
 		discorddesktop.Stats{Path: "/tmp/discord", FilesVisited: 1, FullCache: true, DryRun: true},
+		share.PublishScopePreflight{
+			Ready: false, PublicOnly: true,
+			Channels:      share.PublishScopeCount{Candidate: 2, Allowed: 1, Excluded: 1},
+			Messages:      share.PublishScopeCount{Candidate: 3, Allowed: 1, Excluded: 2},
+			Empty:         true,
+			EmptyReason:   "metadata_incomplete",
+			RepairCommand: "discrawl sync --source discord",
+		},
 		store.EmbeddingDrainStats{
 			Processed:        3,
 			Succeeded:        2,

--- a/internal/cli/output.go
+++ b/internal/cli/output.go
@@ -14,6 +14,7 @@ import (
 	"github.com/openclaw/discrawl/internal/discorddesktop"
 	"github.com/openclaw/discrawl/internal/media"
 	"github.com/openclaw/discrawl/internal/report"
+	"github.com/openclaw/discrawl/internal/share"
 	"github.com/openclaw/discrawl/internal/store"
 	"github.com/openclaw/discrawl/internal/syncer"
 )
@@ -231,6 +232,12 @@ Reads the configured Cloudflare-backed remote archive without opening the local 
 
 Publishes the local non-DM SQLite archive into a Cloudflare-backed remote archive.
 `,
+	"publish": `Usage:
+  discrawl publish [flags]
+  discrawl publish --check [--public-only] [--include-channels IDS] [--exclude-channels IDS] [--json]
+
+Use --check for a read-only, no-network scope preflight. Other publish flags write the configured snapshot repository.
+`,
 	"subscribe-cloud": `Usage:
   discrawl subscribe-cloud --endpoint URL --archive ARCHIVE [--token-env ENV]
 
@@ -283,6 +290,22 @@ func printHuman(w io.Writer, value any) error {
 		_, err := fmt.Fprintf(w, "db=%s\nguilds=%d\nchannels=%d\nthreads=%d\nmessages=%d\nmembers=%d\nembedding_backlog=%d\nlast_sync=%s\nlast_tail_event=%s\n",
 			v.DBPath, v.GuildCount, v.ChannelCount, v.ThreadCount, v.MessageCount, v.MemberCount, v.EmbeddingBacklog,
 			formatTime(v.LastSyncAt), formatTime(v.LastTailEventAt))
+		return err
+	case share.PublishScopePreflight:
+		_, err := fmt.Fprintf(w, "ready=%t\npublic_only=%t\nchannels_candidate=%d\nchannels_allowed=%d\nchannels_excluded=%d\nmessages_candidate=%d\nmessages_allowed=%d\nmessages_excluded=%d\nempty=%t\n",
+			v.Ready, v.PublicOnly,
+			v.Channels.Candidate, v.Channels.Allowed, v.Channels.Excluded,
+			v.Messages.Candidate, v.Messages.Allowed, v.Messages.Excluded,
+			v.Empty)
+		if err != nil {
+			return err
+		}
+		if v.EmptyReason != "" {
+			_, err = fmt.Fprintf(w, "empty_reason=%s\n", v.EmptyReason)
+		}
+		if err == nil && v.RepairCommand != "" {
+			_, err = fmt.Fprintf(w, "repair_command=%s\n", v.RepairCommand)
+		}
 		return err
 	case store.EmbeddingDrainStats:
 		_, err := fmt.Fprintf(w, "processed=%d\nsucceeded=%d\nfailed=%d\nskipped=%d\nremaining_backlog=%d\nprovider=%s\nmodel=%s\ninput_version=%s\n",

--- a/internal/cli/share_commands.go
+++ b/internal/cli/share_commands.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"errors"
 	"flag"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -25,6 +26,8 @@ func (r *runtime) runPublish(args []string) error {
 	readmePath := fs.String("readme", "", "")
 	noCommit := fs.Bool("no-commit", false, "")
 	push := fs.Bool("push", false, "")
+	check := fs.Bool("check", false, "")
+	jsonOut := fs.Bool("json", false, "")
 	withEmbeddings := fs.Bool("with-embeddings", false, "")
 	noMedia := fs.Bool("no-media", !r.cfg.ShareMediaEnabled(), "")
 	publicOnly := fs.Bool("public-only", r.cfg.Share.Filter.PublicOnly, "")
@@ -35,6 +38,35 @@ func (r *runtime) runPublish(args []string) error {
 	}
 	if fs.NArg() != 0 {
 		return usageErr(errors.New("publish takes no positional arguments"))
+	}
+	filter := share.FilterOptions{
+		PublicOnly:        *publicOnly,
+		IncludeChannelIDs: csvList(*includeChannels),
+		ExcludeChannelIDs: csvList(*excludeChannels),
+	}
+	if *check {
+		for _, name := range []string{"repo", "remote", "branch", "message", "tag", "readme", "no-commit", "push", "with-embeddings", "no-media"} {
+			if flagPassed(fs, name) {
+				return usageErr(fmt.Errorf("publish --check cannot be combined with --%s", name))
+			}
+		}
+		if r.store == nil {
+			return dbErr(errors.New("publish --check requires a local SQLite archive"))
+		}
+		if *jsonOut {
+			r.json = true
+		}
+		report, err := share.PreflightPublishScope(r.ctx, r.store, filter)
+		if err != nil {
+			return err
+		}
+		if err := r.print(report); err != nil {
+			return err
+		}
+		if !report.Ready {
+			return errors.New("publish scope is not ready; run the reported repair command and check again")
+		}
+		return nil
 	}
 	if *noCommit && strings.TrimSpace(*tag) != "" {
 		return usageErr(errors.New("publish --tag requires a commit"))
@@ -47,11 +79,7 @@ func (r *runtime) runPublish(args []string) error {
 	if err := share.ValidateTag(r.ctx, opts); err != nil {
 		return err
 	}
-	opts.Filter = share.FilterOptions{
-		PublicOnly:        *publicOnly,
-		IncludeChannelIDs: csvList(*includeChannels),
-		ExcludeChannelIDs: csvList(*excludeChannels),
-	}
+	opts.Filter = filter
 	if *readmePath != "" && opts.Filter.Active() {
 		return usageErr(errors.New("publish --readme is not supported with share filters; filtered report stats would otherwise leak the full archive"))
 	}

--- a/internal/share/share.go
+++ b/internal/share/share.go
@@ -143,91 +143,15 @@ func PreflightPublishScope(ctx context.Context, s *store.Store, opts FilterOptio
 		ExcludeChannelIDs: slices.Sorted(maps.Keys(stringSet(opts.ExcludeChannelIDs))),
 		Guilds:            []PublishScopeGuild{},
 	}
-	guilds := map[string]*PublishScopeGuild{}
-	rows, err := s.DB().QueryContext(ctx, `select id, name, raw_json from guilds where id != ? order by id`, directMessageGuildID)
+	guilds, err := loadPublishScopeGuilds(ctx, s.DB())
 	if err != nil {
-		return PublishScopePreflight{}, fmt.Errorf("query guild publish preflight: %w", err)
-	}
-	for rows.Next() {
-		var id, name, raw string
-		if err := rows.Scan(&id, &name, &raw); err != nil {
-			_ = rows.Close()
-			return PublishScopePreflight{}, fmt.Errorf("scan guild publish preflight: %w", err)
-		}
-		_, metadataReady := everyoneGuildPermissions(raw, id)
-		guilds[id] = &PublishScopeGuild{
-			GuildID:       id,
-			GuildName:     name,
-			SourceHint:    publishSourceHint(raw, metadataReady),
-			MetadataReady: metadataReady,
-		}
-	}
-	if err := rows.Close(); err != nil {
 		return PublishScopePreflight{}, err
 	}
-	if err := rows.Err(); err != nil {
-		return PublishScopePreflight{}, err
-	}
-
-	channelGuilds := map[string]string{}
-	rows, err = s.DB().QueryContext(ctx, `select id, guild_id from channels where guild_id != ?`, directMessageGuildID)
+	channelGuilds, err := countPublishScopeChannels(ctx, s.DB(), candidateFilter, selectedFilter, guilds, &report)
 	if err != nil {
-		return PublishScopePreflight{}, fmt.Errorf("query channel publish preflight: %w", err)
-	}
-	for rows.Next() {
-		var channelID, guildID string
-		if err := rows.Scan(&channelID, &guildID); err != nil {
-			_ = rows.Close()
-			return PublishScopePreflight{}, fmt.Errorf("scan channel publish preflight: %w", err)
-		}
-		channelGuilds[channelID] = guildID
-		if !candidateFilter.allowChannelID(channelID) {
-			continue
-		}
-		report.Channels.Candidate++
-		guild := ensurePublishScopeGuild(guilds, guildID)
-		guild.CandidateChannels++
-		if selectedFilter.allowChannelID(channelID) {
-			report.Channels.Allowed++
-			guild.AllowedChannels++
-		}
-	}
-	if err := rows.Close(); err != nil {
 		return PublishScopePreflight{}, err
 	}
-	if err := rows.Err(); err != nil {
-		return PublishScopePreflight{}, err
-	}
-
-	rows, err = s.DB().QueryContext(ctx, `select id, guild_id, channel_id from messages where guild_id != ?`, directMessageGuildID)
-	if err != nil {
-		return PublishScopePreflight{}, fmt.Errorf("query message publish preflight: %w", err)
-	}
-	for rows.Next() {
-		var messageID, messageGuildID, channelID string
-		if err := rows.Scan(&messageID, &messageGuildID, &channelID); err != nil {
-			_ = rows.Close()
-			return PublishScopePreflight{}, fmt.Errorf("scan message publish preflight: %w", err)
-		}
-		if !candidateFilter.allowChannelID(channelID) {
-			continue
-		}
-		guildID := messageGuildID
-		if channelGuildID, ok := channelGuilds[channelID]; ok {
-			guildID = channelGuildID
-		}
-		report.Messages.Candidate++
-		guild := ensurePublishScopeGuild(guilds, guildID)
-		guild.CandidateMessages++
-		if selectedFilter.allowedMessageIDs[messageID] || selectedFilter.allowChannelID(channelID) {
-			report.Messages.Allowed++
-			guild.AllowedMessages++
-		}
-	}
-	if err := rows.Close(); err != nil {
-		return PublishScopePreflight{}, err
-	}
-	if err := rows.Err(); err != nil {
+	if err := countPublishScopeMessages(ctx, s.DB(), candidateFilter, selectedFilter, guilds, channelGuilds, &report); err != nil {
 		return PublishScopePreflight{}, err
 	}
 
@@ -258,6 +182,98 @@ func PreflightPublishScope(ctx context.Context, s *store.Store, opts FilterOptio
 		}
 	}
 	return report, nil
+}
+
+func loadPublishScopeGuilds(ctx context.Context, db *sql.DB) (map[string]*PublishScopeGuild, error) {
+	rows, err := db.QueryContext(ctx, `select id, name, raw_json from guilds where id != ? order by id`, directMessageGuildID)
+	if err != nil {
+		return nil, fmt.Errorf("query guild publish preflight: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	guilds := map[string]*PublishScopeGuild{}
+	for rows.Next() {
+		var id, name, raw string
+		if err := rows.Scan(&id, &name, &raw); err != nil {
+			return nil, fmt.Errorf("scan guild publish preflight: %w", err)
+		}
+		_, metadataReady := everyoneGuildPermissions(raw, id)
+		guilds[id] = &PublishScopeGuild{
+			GuildID:       id,
+			GuildName:     name,
+			SourceHint:    publishSourceHint(raw, metadataReady),
+			MetadataReady: metadataReady,
+		}
+	}
+	return guilds, rows.Err()
+}
+
+func countPublishScopeChannels(
+	ctx context.Context,
+	db *sql.DB,
+	candidateFilter, selectedFilter *snapshotFilter,
+	guilds map[string]*PublishScopeGuild,
+	report *PublishScopePreflight,
+) (map[string]string, error) {
+	rows, err := db.QueryContext(ctx, `select id, guild_id from channels where guild_id != ?`, directMessageGuildID)
+	if err != nil {
+		return nil, fmt.Errorf("query channel publish preflight: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	channelGuilds := map[string]string{}
+	for rows.Next() {
+		var channelID, guildID string
+		if err := rows.Scan(&channelID, &guildID); err != nil {
+			return nil, fmt.Errorf("scan channel publish preflight: %w", err)
+		}
+		channelGuilds[channelID] = guildID
+		if !candidateFilter.allowChannelID(channelID) {
+			continue
+		}
+		report.Channels.Candidate++
+		guild := ensurePublishScopeGuild(guilds, guildID)
+		guild.CandidateChannels++
+		if selectedFilter.allowChannelID(channelID) {
+			report.Channels.Allowed++
+			guild.AllowedChannels++
+		}
+	}
+	return channelGuilds, rows.Err()
+}
+
+func countPublishScopeMessages(
+	ctx context.Context,
+	db *sql.DB,
+	candidateFilter, selectedFilter *snapshotFilter,
+	guilds map[string]*PublishScopeGuild,
+	channelGuilds map[string]string,
+	report *PublishScopePreflight,
+) error {
+	rows, err := db.QueryContext(ctx, `select id, guild_id, channel_id from messages where guild_id != ?`, directMessageGuildID)
+	if err != nil {
+		return fmt.Errorf("query message publish preflight: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	for rows.Next() {
+		var messageID, messageGuildID, channelID string
+		if err := rows.Scan(&messageID, &messageGuildID, &channelID); err != nil {
+			return fmt.Errorf("scan message publish preflight: %w", err)
+		}
+		if !candidateFilter.allowChannelID(channelID) {
+			continue
+		}
+		guildID := messageGuildID
+		if channelGuildID, ok := channelGuilds[channelID]; ok {
+			guildID = channelGuildID
+		}
+		report.Messages.Candidate++
+		guild := ensurePublishScopeGuild(guilds, guildID)
+		guild.CandidateMessages++
+		if selectedFilter.allowedMessageIDs[messageID] || selectedFilter.allowChannelID(channelID) {
+			report.Messages.Allowed++
+			guild.AllowedMessages++
+		}
+	}
+	return rows.Err()
 }
 
 func ensurePublishScopeGuild(guilds map[string]*PublishScopeGuild, guildID string) *PublishScopeGuild {

--- a/internal/share/share.go
+++ b/internal/share/share.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"hash/fnv"
 	"io"
+	"maps"
 	"os"
 	"path"
 	"path/filepath"
@@ -86,6 +87,199 @@ type FilterOptions struct {
 
 func (o FilterOptions) Active() bool {
 	return o.PublicOnly || len(stringSet(o.IncludeChannelIDs)) > 0 || len(stringSet(o.ExcludeChannelIDs)) > 0
+}
+
+type PublishScopeCount struct {
+	Candidate int `json:"candidate"`
+	Allowed   int `json:"allowed"`
+	Excluded  int `json:"excluded"`
+}
+
+type PublishScopeGuild struct {
+	GuildID           string `json:"guild_id"`
+	GuildName         string `json:"guild_name,omitempty"`
+	SourceHint        string `json:"source_hint"`
+	MetadataReady     bool   `json:"metadata_ready"`
+	CandidateChannels int    `json:"candidate_channels"`
+	AllowedChannels   int    `json:"allowed_channels"`
+	CandidateMessages int    `json:"candidate_messages"`
+	AllowedMessages   int    `json:"allowed_messages"`
+}
+
+type PublishScopePreflight struct {
+	Ready             bool                `json:"ready"`
+	PublicOnly        bool                `json:"public_only"`
+	IncludeChannelIDs []string            `json:"include_channel_ids,omitempty"`
+	ExcludeChannelIDs []string            `json:"exclude_channel_ids,omitempty"`
+	Guilds            []PublishScopeGuild `json:"guilds"`
+	Channels          PublishScopeCount   `json:"channels"`
+	Messages          PublishScopeCount   `json:"messages"`
+	Empty             bool                `json:"empty"`
+	EmptyReason       string              `json:"empty_reason,omitempty"`
+	Warnings          []string            `json:"warnings,omitempty"`
+	RepairCommand     string              `json:"repair_command,omitempty"`
+}
+
+// PreflightPublishScope evaluates the same filters used by Export without
+// touching the snapshot repository or any configured remote.
+func PreflightPublishScope(ctx context.Context, s *store.Store, opts FilterOptions) (PublishScopePreflight, error) {
+	candidateOpts := FilterOptions{
+		IncludeChannelIDs: opts.IncludeChannelIDs,
+		ExcludeChannelIDs: opts.ExcludeChannelIDs,
+	}
+	candidateFilter, err := newSnapshotFilter(ctx, s.DB(), candidateOpts)
+	if err != nil {
+		return PublishScopePreflight{}, err
+	}
+	selectedFilter, err := newSnapshotFilter(ctx, s.DB(), opts)
+	if err != nil {
+		return PublishScopePreflight{}, err
+	}
+
+	report := PublishScopePreflight{
+		Ready:             true,
+		PublicOnly:        opts.PublicOnly,
+		IncludeChannelIDs: slices.Sorted(maps.Keys(stringSet(opts.IncludeChannelIDs))),
+		ExcludeChannelIDs: slices.Sorted(maps.Keys(stringSet(opts.ExcludeChannelIDs))),
+		Guilds:            []PublishScopeGuild{},
+	}
+	guilds := map[string]*PublishScopeGuild{}
+	rows, err := s.DB().QueryContext(ctx, `select id, name, raw_json from guilds where id != ? order by id`, directMessageGuildID)
+	if err != nil {
+		return PublishScopePreflight{}, fmt.Errorf("query guild publish preflight: %w", err)
+	}
+	for rows.Next() {
+		var id, name, raw string
+		if err := rows.Scan(&id, &name, &raw); err != nil {
+			_ = rows.Close()
+			return PublishScopePreflight{}, fmt.Errorf("scan guild publish preflight: %w", err)
+		}
+		_, metadataReady := everyoneGuildPermissions(raw, id)
+		guilds[id] = &PublishScopeGuild{
+			GuildID:       id,
+			GuildName:     name,
+			SourceHint:    publishSourceHint(raw, metadataReady),
+			MetadataReady: metadataReady,
+		}
+	}
+	if err := rows.Close(); err != nil {
+		return PublishScopePreflight{}, err
+	}
+	if err := rows.Err(); err != nil {
+		return PublishScopePreflight{}, err
+	}
+
+	channelGuilds := map[string]string{}
+	rows, err = s.DB().QueryContext(ctx, `select id, guild_id from channels where guild_id != ?`, directMessageGuildID)
+	if err != nil {
+		return PublishScopePreflight{}, fmt.Errorf("query channel publish preflight: %w", err)
+	}
+	for rows.Next() {
+		var channelID, guildID string
+		if err := rows.Scan(&channelID, &guildID); err != nil {
+			_ = rows.Close()
+			return PublishScopePreflight{}, fmt.Errorf("scan channel publish preflight: %w", err)
+		}
+		channelGuilds[channelID] = guildID
+		if !candidateFilter.allowChannelID(channelID) {
+			continue
+		}
+		report.Channels.Candidate++
+		guild := ensurePublishScopeGuild(guilds, guildID)
+		guild.CandidateChannels++
+		if selectedFilter.allowChannelID(channelID) {
+			report.Channels.Allowed++
+			guild.AllowedChannels++
+		}
+	}
+	if err := rows.Close(); err != nil {
+		return PublishScopePreflight{}, err
+	}
+	if err := rows.Err(); err != nil {
+		return PublishScopePreflight{}, err
+	}
+
+	rows, err = s.DB().QueryContext(ctx, `select id, guild_id, channel_id from messages where guild_id != ?`, directMessageGuildID)
+	if err != nil {
+		return PublishScopePreflight{}, fmt.Errorf("query message publish preflight: %w", err)
+	}
+	for rows.Next() {
+		var messageID, messageGuildID, channelID string
+		if err := rows.Scan(&messageID, &messageGuildID, &channelID); err != nil {
+			_ = rows.Close()
+			return PublishScopePreflight{}, fmt.Errorf("scan message publish preflight: %w", err)
+		}
+		if !candidateFilter.allowChannelID(channelID) {
+			continue
+		}
+		guildID := messageGuildID
+		if channelGuildID, ok := channelGuilds[channelID]; ok {
+			guildID = channelGuildID
+		}
+		report.Messages.Candidate++
+		guild := ensurePublishScopeGuild(guilds, guildID)
+		guild.CandidateMessages++
+		if selectedFilter.allowedMessageIDs[messageID] || selectedFilter.allowChannelID(channelID) {
+			report.Messages.Allowed++
+			guild.AllowedMessages++
+		}
+	}
+	if err := rows.Close(); err != nil {
+		return PublishScopePreflight{}, err
+	}
+	if err := rows.Err(); err != nil {
+		return PublishScopePreflight{}, err
+	}
+
+	report.Channels.Excluded = report.Channels.Candidate - report.Channels.Allowed
+	report.Messages.Excluded = report.Messages.Candidate - report.Messages.Allowed
+	for _, guild := range guilds {
+		if opts.PublicOnly && (guild.CandidateChannels > 0 || guild.CandidateMessages > 0) && !guild.MetadataReady {
+			report.Ready = false
+			report.Warnings = append(report.Warnings,
+				fmt.Sprintf("guild %s lacks usable @everyone role metadata; public-only selection fails closed", guild.GuildID))
+		}
+		report.Guilds = append(report.Guilds, *guild)
+	}
+	sort.Slice(report.Guilds, func(i, j int) bool { return report.Guilds[i].GuildID < report.Guilds[j].GuildID })
+	sort.Strings(report.Warnings)
+	if !report.Ready {
+		report.RepairCommand = "discrawl sync --source discord"
+	}
+	report.Empty = report.Messages.Allowed == 0
+	if report.Empty {
+		switch {
+		case report.Messages.Candidate == 0:
+			report.EmptyReason = "no_matching_messages"
+		case !report.Ready:
+			report.EmptyReason = "metadata_incomplete"
+		default:
+			report.EmptyReason = "filters_match_no_publishable_messages"
+		}
+	}
+	return report, nil
+}
+
+func ensurePublishScopeGuild(guilds map[string]*PublishScopeGuild, guildID string) *PublishScopeGuild {
+	if guild := guilds[guildID]; guild != nil {
+		return guild
+	}
+	guild := &PublishScopeGuild{GuildID: guildID, SourceHint: "unknown"}
+	guilds[guildID] = guild
+	return guild
+}
+
+func publishSourceHint(raw string, metadataReady bool) string {
+	var payload struct {
+		Source string `json:"source"`
+	}
+	if decodeJSONUseNumber(raw, &payload) == nil && strings.EqualFold(strings.TrimSpace(payload.Source), "discord_desktop") {
+		return "discord_desktop"
+	}
+	if metadataReady {
+		return "discord_metadata"
+	}
+	return "unknown"
 }
 
 type ImportProgress struct {

--- a/internal/share/share_test.go
+++ b/internal/share/share_test.go
@@ -677,6 +677,74 @@ func TestPublicPermissionHelpers(t *testing.T) {
 	require.False(t, isRoleOverwrite(struct{}{}))
 }
 
+func TestPreflightPublishScopeDistinguishesMissingMetadataFromEmptyScope(t *testing.T) {
+	ctx := context.Background()
+	s, err := store.Open(ctx, filepath.Join(t.TempDir(), "discrawl.db"))
+	require.NoError(t, err)
+	defer func() { _ = s.Close() }()
+
+	require.NoError(t, s.UpsertGuild(ctx, store.GuildRecord{
+		ID:      "g-ready",
+		Name:    "Ready",
+		RawJSON: `{"roles":[{"id":"g-ready","permissions":"1024"}]}`,
+	}))
+	require.NoError(t, s.UpsertGuild(ctx, store.GuildRecord{
+		ID:      "g-cache",
+		Name:    "Cache only",
+		RawJSON: `{"source":"discord_desktop"}`,
+	}))
+	upsertSnapshotFilterChannel(t, ctx, s, store.ChannelRecord{ID: "c-public", GuildID: "g-ready", Kind: "text", Name: "public", RawJSON: `{}`})
+	upsertSnapshotFilterChannel(t, ctx, s, store.ChannelRecord{ID: "c-private", GuildID: "g-ready", Kind: "text", Name: "private", RawJSON: `{"permission_overwrites":[{"id":"g-ready","type":0,"deny":"1024"}]}`})
+	upsertSnapshotFilterChannel(t, ctx, s, store.ChannelRecord{ID: "c-cache", GuildID: "g-cache", Kind: "text", Name: "cache", RawJSON: `{"source":"discord_desktop"}`})
+	upsertSnapshotFilterMessage(t, ctx, s, "m-public", "c-public", "u1", "public")
+	upsertSnapshotFilterMessage(t, ctx, s, "m-private", "c-private", "u2", "private")
+	upsertSnapshotFilterMessage(t, ctx, s, "m-cache", "c-cache", "u3", "cache")
+
+	report, err := PreflightPublishScope(ctx, s, FilterOptions{PublicOnly: true})
+	require.NoError(t, err)
+	require.False(t, report.Ready)
+	require.Equal(t, PublishScopeCount{Candidate: 3, Allowed: 1, Excluded: 2}, report.Channels)
+	require.Equal(t, PublishScopeCount{Candidate: 3, Allowed: 1, Excluded: 2}, report.Messages)
+	require.False(t, report.Empty)
+	require.Equal(t, "discrawl sync --source discord", report.RepairCommand)
+	require.Len(t, report.Guilds, 2)
+	guilds := map[string]PublishScopeGuild{}
+	for _, guild := range report.Guilds {
+		guilds[guild.GuildID] = guild
+	}
+	require.True(t, guilds["g-ready"].MetadataReady)
+	require.Equal(t, "discord_metadata", guilds["g-ready"].SourceHint)
+	require.False(t, guilds["g-cache"].MetadataReady)
+	require.Equal(t, "discord_desktop", guilds["g-cache"].SourceHint)
+
+	report, err = PreflightPublishScope(ctx, s, FilterOptions{PublicOnly: true, IncludeChannelIDs: []string{"missing"}})
+	require.NoError(t, err)
+	require.True(t, report.Ready)
+	require.True(t, report.Empty)
+	require.Equal(t, "no_matching_messages", report.EmptyReason)
+	require.Empty(t, report.RepairCommand)
+
+	upsertSnapshotFilterChannel(t, ctx, s, store.ChannelRecord{ID: "c-orphan", GuildID: "g-missing", Kind: "text", Name: "orphan", RawJSON: `{}`})
+	now := time.Now().UTC().Format(time.RFC3339Nano)
+	require.NoError(t, s.UpsertMessages(ctx, []store.MessageMutation{{
+		Record: store.MessageRecord{
+			ID: "m-orphan", GuildID: "g-missing", ChannelID: "c-orphan", ChannelName: "orphan",
+			AuthorID: "u4", AuthorName: "orphan", CreatedAt: now, Content: "orphan", NormalizedContent: "orphan", RawJSON: `{}`,
+		},
+		EventType: "upsert", PayloadJSON: `{"id":"m-orphan"}`, Options: store.WriteOptions{AppendEvent: true},
+	}}))
+	report, err = PreflightPublishScope(ctx, s, FilterOptions{PublicOnly: true, IncludeChannelIDs: []string{"c-orphan"}})
+	require.NoError(t, err)
+	require.False(t, report.Ready)
+	require.Equal(t, "metadata_incomplete", report.EmptyReason)
+	guilds = map[string]PublishScopeGuild{}
+	for _, guild := range report.Guilds {
+		guilds[guild.GuildID] = guild
+	}
+	require.Equal(t, "unknown", guilds["g-missing"].SourceHint)
+	require.Equal(t, 1, guilds["g-missing"].CandidateMessages)
+}
+
 func TestPublicSnapshotFilterHonorsCategoryAndThreadPermissions(t *testing.T) {
 	ctx := context.Background()
 	s, err := store.Open(ctx, filepath.Join(t.TempDir(), "discrawl.db"))

--- a/internal/share/share_test.go
+++ b/internal/share/share_test.go
@@ -724,6 +724,12 @@ func TestPreflightPublishScopeDistinguishesMissingMetadataFromEmptyScope(t *test
 	require.Equal(t, "no_matching_messages", report.EmptyReason)
 	require.Empty(t, report.RepairCommand)
 
+	report, err = PreflightPublishScope(ctx, s, FilterOptions{PublicOnly: true, IncludeChannelIDs: []string{"c-private"}})
+	require.NoError(t, err)
+	require.True(t, report.Ready)
+	require.True(t, report.Empty)
+	require.Equal(t, "filters_match_no_publishable_messages", report.EmptyReason)
+
 	upsertSnapshotFilterChannel(t, ctx, s, store.ChannelRecord{ID: "c-orphan", GuildID: "g-missing", Kind: "text", Name: "orphan", RawJSON: `{}`})
 	now := time.Now().UTC().Format(time.RFC3339Nano)
 	require.NoError(t, s.UpsertMessages(ctx, []store.MessageMutation{{


### PR DESCRIPTION
## Summary

- add a strictly read-only, no-network `publish --check` preflight
- report candidate/allowed channel and message counts, metadata readiness, bounded source hints, empty-scope reasons, and repair guidance
- fail closed and exit non-zero when `--public-only` lacks usable role metadata
- reject write-oriented publish flags before opening or creating any archive/repository state

Fixes #103.

## Root cause

The exporter already filtered public snapshots safely, but operators had no non-mutating way to distinguish an intentionally empty scope from incomplete Discord permission metadata. The new preflight reuses the exporter filter contract and accounts for missing guild/channel provenance explicitly.

## Proof

- `GOWORK=off go test -count=1 ./...`
- `GOWORK=off go vet ./...`
- `GOWORK=off go mod verify`
- `gofumpt -l .`
- `git diff --check`
- exact candidate binary against an isolated synthetic Discord Desktop cache and disposable SQLite archive:
  - incomplete role metadata: `ready=false`, source hint `discord_desktop`, candidate scope retained, allowed scope zero, repair command reported, exit 1
  - unmatched include filter: `ready=true`, empty reason `no_matching_messages`
  - anti-cheat mutation: candidate message count changed from 1 to 2
  - snapshot repository remained absent; invalid remote was never contacted
  - `--check --push` rejected before mutation
- autoreview: clean after accepted missing-archive, single-dash routing, exit-status, and orphan-metadata fixes

## Risk

Medium. New CLI/report surface and read-only database queries; no schema or snapshot format changes. Existing publish behavior is unchanged without `--check`.
