### PR TITLE
feat: add safe channel resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Changes
 
 - Add read-only `publish --check` scope preflight with fail-closed metadata readiness, source hints, predicted channel/message counts, and concrete repair guidance.
+- Add shared channel resolution for `channels`, `search`, `messages`, and message sync with stable id precedence and actionable ambiguity candidates.
 
 ## 0.11.3 - 2026-06-23
 

--- a/README.md
+++ b/README.md
@@ -360,6 +360,11 @@ Modes:
 
 FTS uses SQLite FTS5 with the default `unicode61` tokenizer. User query terms are parameterized and quoted before `MATCH`, so tokens like `AND`, `OR`, `NOT`, `NEAR`, and `*` are searched as input terms instead of FTS operators. Punctuation still follows FTS5 tokenization rules.
 
+Local `search --channel` and `messages --channel` resolve exactly one channel:
+exact id first, then exact name, then a unique partial name. Ambiguous names
+fail with candidate guild/channel ids. Run `discrawl channels resolve help
+--json`, then reuse the numeric id for stable scripts and agent workflows.
+
 Semantic and hybrid search require `[search.embeddings]` plus local `message_embeddings` rows for the configured provider, model, and input version. Run `discrawl sync --with-embeddings` to enqueue changed messages, then `discrawl embed` to generate vectors. The input version is currently `message_normalized_v1`, so vectors are tied to normalized message text rather than raw Discord payloads.
 
 ### `messages`
@@ -379,7 +384,7 @@ discrawl --json messages --channel maintainers --days 3
 
 Notes:
 
-- `--channel` accepts a channel id, exact name, `#name`, or partial name match
+- `--channel` resolves one channel by exact id, exact name, or unique partial name
 - `--hours` is shorthand for "since now minus N hours"
 - `--days` is shorthand for "since now minus N days"
 - `--last` returns the newest `N` matching messages, then prints them oldest-to-newest

--- a/docs/commands/channels.md
+++ b/docs/commands/channels.md
@@ -7,17 +7,23 @@ Browse the offline channel directory.
 ```bash
 discrawl channels list
 discrawl channels show 123456789012345678
+discrawl channels resolve help --json
+discrawl channels resolve help --guild 123456789012345678 --json
 ```
 
 ## Subcommands
 
 - `list` - dump every channel and thread in the local archive
 - `show <id>` - show metadata for one channel/thread
+- `resolve <id|name|#name>` - resolve one stable channel id; optionally restrict with `--guild` or `--guilds`
 
 ## Notes
 
 - threads are stored as channels because that matches the Discord model
 - archived threads are part of the sync surface and appear here too
+- resolution prefers an exact id, then an exact case-insensitive name, then a unique partial name
+- ambiguous names fail and report every candidate guild/channel id; retry with the numeric id
+- numeric channel ids are the safest stable input for repeated scripts and agent workflows
 
 ## See also
 

--- a/docs/commands/messages.md
+++ b/docs/commands/messages.md
@@ -17,7 +17,7 @@ discrawl --json messages --channel maintainers --days 3
 
 ## Flags
 
-- `--channel <id|name|#name>` - id, exact name, `#name`, or partial name match
+- `--channel <id|name|#name>` - resolve one exact id, exact name, or unique partial name
 - `--guild <id>` / `--guilds <id,id>` / `--dm` - restrict the guild scope (`--dm` is shorthand for `--guild @me`)
 - `--author <name>` - restrict to one author
 - `--hours <n>` - shorthand for "since now minus N hours"
@@ -35,6 +35,7 @@ discrawl --json messages --channel maintainers --days 3
 - if `tail` is already running, plain `messages` reads the local archive without waiting; `messages --sync` fails fast instead of waiting behind the tail lock
 - `--dm` skips Git snapshot auto-update because DMs are never imported from the shared mirror
 - use either `--last` for the newest matching rows or `--all` for an uncapped oldest-to-newest slice
+- ambiguous channel names fail with candidate guild/channel ids; resolve once with `discrawl channels resolve <name> --json` and reuse the numeric id
 
 ## See also
 

--- a/docs/commands/search.md
+++ b/docs/commands/search.md
@@ -27,7 +27,7 @@ discrawl --json search "websocket closed"
 - `--mode <fts|semantic|hybrid>` - search mode
 - `--guild <id>` / `--guilds <id,id>` - restrict the guild scope
 - `--dm` - shorthand for `--guild @me`
-- `--channel <id|name|#name>` - restrict to one channel (id, exact name, `#name`, or partial match)
+- `--channel <id|name|#name>` - resolve and restrict to one channel (exact id, exact name, or unique partial name)
 - `--author <name>` - restrict to one author
 - `--limit <n>` - cap result count
 - `--include-empty` - include rows with no searchable content (attachment text/filenames, embeds, and replies still count as content)
@@ -35,6 +35,10 @@ discrawl --json search "websocket closed"
 ## FTS behavior
 
 User query terms are parameterized and quoted before `MATCH`, so tokens like `AND`, `OR`, `NOT`, `NEAR`, and `*` are searched as input terms instead of FTS operators. Punctuation still follows FTS5 tokenization rules.
+
+Ambiguous channel names fail with candidate guild/channel ids instead of
+silently searching multiple channels. Use `discrawl channels resolve <name>
+--json`, then keep the numeric id for repeatable workflows.
 
 ## Semantic prerequisites
 

--- a/internal/cli/channel_resolution.go
+++ b/internal/cli/channel_resolution.go
@@ -1,0 +1,175 @@
+package cli
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+
+	"github.com/openclaw/discrawl/internal/store"
+)
+
+func (r *runtime) runChannelsResolve(args []string) error {
+	fs := flag.NewFlagSet("channels resolve", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	guild := fs.String("guild", "", "")
+	guilds := fs.String("guilds", "", "")
+	jsonOut := fs.Bool("json", false, "")
+	if err := fs.Parse(permuteChannelResolveFlags(args)); err != nil {
+		return usageErr(err)
+	}
+	if fs.NArg() != 1 {
+		return usageErr(errors.New("channels resolve requires one channel id or name"))
+	}
+	if *jsonOut {
+		r.json = true
+	}
+	guildIDs := csvList(strings.Join([]string{*guild, *guilds}, ","))
+	resolution, resolveErr := r.resolveLocalChannel(fs.Arg(0), guildIDs)
+	if err := r.print(resolution); err != nil {
+		return err
+	}
+	return resolveErr
+}
+
+func permuteChannelResolveFlags(args []string) []string {
+	flags := make([]string, 0, len(args))
+	positionals := make([]string, 0, len(args))
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
+		if arg == "--json" || strings.HasPrefix(arg, "--json=") || strings.HasPrefix(arg, "--guild=") || strings.HasPrefix(arg, "--guilds=") {
+			flags = append(flags, arg)
+			continue
+		}
+		if (arg == "--guild" || arg == "--guilds") && i+1 < len(args) {
+			flags = append(flags, arg, args[i+1])
+			i++
+			continue
+		}
+		positionals = append(positionals, arg)
+	}
+	return append(flags, positionals...)
+}
+
+type channelResolutionCandidate struct {
+	ChannelID string `json:"channel_id"`
+	GuildID   string `json:"guild_id"`
+	Name      string `json:"name"`
+	Kind      string `json:"kind,omitempty"`
+}
+
+type channelResolution struct {
+	Query      string                       `json:"query"`
+	Status     string                       `json:"status"`
+	Match      string                       `json:"match,omitempty"`
+	Selected   *channelResolutionCandidate  `json:"selected,omitempty"`
+	Candidates []channelResolutionCandidate `json:"candidates,omitempty"`
+}
+
+type channelResolutionError struct {
+	resolution channelResolution
+}
+
+func (e *channelResolutionError) Error() string {
+	switch e.resolution.Status {
+	case "ambiguous":
+		candidates := make([]string, 0, len(e.resolution.Candidates))
+		for _, candidate := range e.resolution.Candidates {
+			candidates = append(candidates, fmt.Sprintf("guild=%s channel=%s name=#%s", candidate.GuildID, candidate.ChannelID, candidate.Name))
+		}
+		return fmt.Sprintf("channel %q is ambiguous; retry with a channel id; candidates: %s", e.resolution.Query, strings.Join(candidates, ", "))
+	default:
+		return fmt.Sprintf("cannot resolve channel %q; run discrawl channels resolve %q --json or pass a channel id", e.resolution.Query, e.resolution.Query)
+	}
+}
+
+func (r *runtime) resolveLocalChannel(query string, guildIDs []string) (channelResolution, error) {
+	rows, err := r.store.Channels(r.ctx, "")
+	if err != nil {
+		return channelResolution{}, err
+	}
+	return resolveChannelRows(rows, query, guildIDs)
+}
+
+func resolveChannelRows(rows []store.ChannelRow, query string, guildIDs []string) (channelResolution, error) {
+	query = normalizeChannelQuery(query)
+	resolution := channelResolution{Query: query, Status: "not_found"}
+	allowedGuilds := map[string]struct{}{}
+	for _, guildID := range guildIDs {
+		allowedGuilds[guildID] = struct{}{}
+	}
+	filtered := make([]store.ChannelRow, 0, len(rows))
+	for _, row := range rows {
+		if len(allowedGuilds) > 0 {
+			if _, ok := allowedGuilds[row.GuildID]; !ok {
+				continue
+			}
+		}
+		filtered = append(filtered, row)
+	}
+
+	match := func(kind string, predicate func(store.ChannelRow) bool) (channelResolution, bool) {
+		candidates := make([]channelResolutionCandidate, 0)
+		for _, row := range filtered {
+			if predicate(row) {
+				candidates = append(candidates, channelCandidate(row))
+			}
+		}
+		sort.Slice(candidates, func(i, j int) bool {
+			if candidates[i].GuildID != candidates[j].GuildID {
+				return candidates[i].GuildID < candidates[j].GuildID
+			}
+			if candidates[i].Name != candidates[j].Name {
+				return candidates[i].Name < candidates[j].Name
+			}
+			return candidates[i].ChannelID < candidates[j].ChannelID
+		})
+		switch len(candidates) {
+		case 0:
+			return channelResolution{}, false
+		case 1:
+			resolution.Status = "resolved"
+			resolution.Match = kind
+			resolution.Selected = &candidates[0]
+			return resolution, true
+		default:
+			resolution.Status = "ambiguous"
+			resolution.Match = kind
+			resolution.Candidates = candidates
+			return resolution, true
+		}
+	}
+
+	if resolved, ok := match("id", func(row store.ChannelRow) bool { return row.ID == query }); ok {
+		return finishChannelResolution(resolved)
+	}
+	if resolved, ok := match("exact_name", func(row store.ChannelRow) bool { return strings.EqualFold(row.Name, query) }); ok {
+		return finishChannelResolution(resolved)
+	}
+	lowered := strings.ToLower(query)
+	if query != "" {
+		if resolved, ok := match("partial_name", func(row store.ChannelRow) bool {
+			return strings.Contains(strings.ToLower(row.Name), lowered)
+		}); ok {
+			return finishChannelResolution(resolved)
+		}
+	}
+	return resolution, &channelResolutionError{resolution: resolution}
+}
+
+func normalizeChannelQuery(query string) string {
+	return strings.TrimSpace(strings.TrimPrefix(strings.TrimSpace(query), "#"))
+}
+
+func finishChannelResolution(resolution channelResolution) (channelResolution, error) {
+	if resolution.Status == "resolved" {
+		return resolution, nil
+	}
+	return resolution, &channelResolutionError{resolution: resolution}
+}
+
+func channelCandidate(row store.ChannelRow) channelResolutionCandidate {
+	return channelResolutionCandidate{ChannelID: row.ID, GuildID: row.GuildID, Name: row.Name, Kind: row.Kind}
+}

--- a/internal/cli/channel_resolution_test.go
+++ b/internal/cli/channel_resolution_test.go
@@ -1,0 +1,129 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/openclaw/discrawl/internal/config"
+	"github.com/openclaw/discrawl/internal/store"
+)
+
+func TestResolveChannelRowsUsesStablePrecedenceAndScope(t *testing.T) {
+	rows := []store.ChannelRow{
+		{ID: "c1", GuildID: "g1", Name: "help", Kind: "text"},
+		{ID: "c2", GuildID: "g2", Name: "Help", Kind: "text"},
+		{ID: "c3", GuildID: "g1", Name: "helpers", Kind: "text"},
+		{ID: "help", GuildID: "g3", Name: "random", Kind: "text"},
+	}
+
+	resolution, err := resolveChannelRows(rows, "help", nil)
+	require.NoError(t, err)
+	require.Equal(t, "id", resolution.Match)
+	require.Equal(t, "help", resolution.Selected.ChannelID)
+
+	resolution, err = resolveChannelRows(rows[:3], "#help", nil)
+	require.Error(t, err)
+	require.Equal(t, "ambiguous", resolution.Status)
+	require.Equal(t, "exact_name", resolution.Match)
+	require.Equal(t, []string{"c1", "c2"}, []string{resolution.Candidates[0].ChannelID, resolution.Candidates[1].ChannelID})
+	require.ErrorContains(t, err, "guild=g1 channel=c1")
+	require.ErrorContains(t, err, "guild=g2 channel=c2")
+
+	resolution, err = resolveChannelRows(rows[:3], "help", []string{"g1"})
+	require.NoError(t, err)
+	require.Equal(t, "c1", resolution.Selected.ChannelID)
+
+	resolution, err = resolveChannelRows(rows[:3], "pers", nil)
+	require.NoError(t, err)
+	require.Equal(t, "partial_name", resolution.Match)
+	require.Equal(t, "c3", resolution.Selected.ChannelID)
+
+	resolution, err = resolveChannelRows(rows, "missing", nil)
+	require.Error(t, err)
+	require.Equal(t, "not_found", resolution.Status)
+}
+
+func TestChannelResolverDrivesLocalQueriesAndReportsAmbiguity(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "discrawl.db")
+	cfgPath := filepath.Join(dir, "config.toml")
+	cfg := config.Default()
+	cfg.DBPath = dbPath
+	require.NoError(t, config.Write(cfgPath, cfg))
+	s, err := store.Open(ctx, dbPath)
+	require.NoError(t, err)
+	defer func() { _ = s.Close() }()
+	for _, guild := range []store.GuildRecord{{ID: "g1", Name: "One", RawJSON: `{}`}, {ID: "g2", Name: "Two", RawJSON: `{}`}} {
+		require.NoError(t, s.UpsertGuild(ctx, guild))
+	}
+	for _, channel := range []store.ChannelRecord{
+		{ID: "c1", GuildID: "g1", Name: "help", Kind: "text", RawJSON: `{}`},
+		{ID: "c2", GuildID: "g2", Name: "help", Kind: "text", RawJSON: `{}`},
+	} {
+		require.NoError(t, s.UpsertChannel(ctx, channel))
+	}
+	now := time.Now().UTC().Format(time.RFC3339Nano)
+	for _, message := range []store.MessageRecord{
+		{ID: "m1", GuildID: "g1", ChannelID: "c1", ChannelName: "help", AuthorID: "u1", AuthorName: "One", CreatedAt: now, Content: "needle one", NormalizedContent: "needle one", RawJSON: `{}`},
+		{ID: "m2", GuildID: "g2", ChannelID: "c2", ChannelName: "help", AuthorID: "u2", AuthorName: "Two", CreatedAt: now, Content: "needle two", NormalizedContent: "needle two", RawJSON: `{}`},
+		{ID: "m3", GuildID: "g1", ChannelID: "700000000000000099", ChannelName: "", AuthorID: "u1", AuthorName: "One", CreatedAt: now, Content: "orphan marker", NormalizedContent: "orphan marker", RawJSON: `{}`},
+	} {
+		require.NoError(t, s.UpsertMessage(ctx, message))
+	}
+
+	var out bytes.Buffer
+	rt := &runtime{ctx: ctx, cfg: cfg, store: s, stdout: &out, stderr: &bytes.Buffer{}, logger: discardLogger()}
+	err = rt.runChannelsResolve([]string{"help", "--json"})
+	require.Error(t, err)
+	require.ErrorContains(t, err, "channel=c1")
+	require.ErrorContains(t, err, "channel=c2")
+	var resolution channelResolution
+	require.NoError(t, json.Unmarshal(out.Bytes(), &resolution))
+	require.Equal(t, "ambiguous", resolution.Status)
+
+	out.Reset()
+	require.NoError(t, rt.runChannelsResolve([]string{"help", "--json", "--guild", "g1"}))
+	require.NoError(t, json.Unmarshal(out.Bytes(), &resolution))
+	require.Equal(t, "c1", resolution.Selected.ChannelID)
+
+	err = rt.runSearch([]string{"--channel", "help", "needle"})
+	require.ErrorContains(t, err, "channel=c1")
+	out.Reset()
+	require.NoError(t, rt.runSearch([]string{"--channel", "help", "--guild", "g1", "needle"}))
+	var searchRows []store.SearchResult
+	require.NoError(t, json.Unmarshal(out.Bytes(), &searchRows))
+	require.Len(t, searchRows, 1)
+	require.Equal(t, "c1", searchRows[0].ChannelID)
+
+	err = rt.runMessages([]string{"--channel", "help", "--all"})
+	require.ErrorContains(t, err, "channel=c2")
+	out.Reset()
+	require.NoError(t, rt.runMessages([]string{"--channel", "c2", "--all"}))
+	var messageRows []store.MessageRow
+	require.NoError(t, json.Unmarshal(out.Bytes(), &messageRows))
+	require.Len(t, messageRows, 1)
+	require.Equal(t, "c2", messageRows[0].ChannelID)
+
+	out.Reset()
+	require.NoError(t, rt.runSearch([]string{"--channel", "700000000000000099", "orphan"}))
+	require.NoError(t, json.Unmarshal(out.Bytes(), &searchRows))
+	require.Len(t, searchRows, 1)
+	require.Equal(t, "700000000000000099", searchRows[0].ChannelID)
+	out.Reset()
+	require.NoError(t, rt.runMessages([]string{"--channel", "700000000000000099", "--all"}))
+	require.NoError(t, json.Unmarshal(out.Bytes(), &messageRows))
+	require.Len(t, messageRows, 1)
+	require.Equal(t, "700000000000000099", messageRows[0].ChannelID)
+
+	err = Run(ctx, []string{"--config", cfgPath, "search", "--channel", "help", "marker"}, &bytes.Buffer{}, &bytes.Buffer{})
+	require.ErrorContains(t, err, "channel=c1")
+	err = Run(ctx, []string{"--config", cfgPath, "messages", "--channel", "help", "--all"}, &bytes.Buffer{}, &bytes.Buffer{})
+	require.ErrorContains(t, err, "channel=c2")
+}

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -222,7 +222,7 @@ func (r *runtime) dispatch(rest []string) error {
 	case "tap", "cache-import":
 		return r.withLocalStoreLocked(false, func() error { return r.runWiretap(rest[1:]) })
 	case "search":
-		if hasHelpArg(rest[1:]) {
+		if hasHelpFlag(rest[1:]) {
 			return printCommandUsage(r.stdout, []string{"search"})
 		}
 		if r.configuredForCloudReadOnly() {
@@ -236,7 +236,7 @@ func (r *runtime) dispatch(rest []string) error {
 		}
 		return r.withLocalStoreReadOnly(func() error { return r.runTUI(rest[1:]) })
 	case "messages":
-		if hasHelpArg(rest[1:]) {
+		if hasHelpFlag(rest[1:]) {
 			return printCommandUsage(r.stdout, []string{"messages"})
 		}
 		if r.configuredForCloudReadOnly() {

--- a/internal/cli/messages.go
+++ b/internal/cli/messages.go
@@ -128,16 +128,22 @@ func (r *runtime) runMessages(args []string) error {
 		}
 		return r.print(rows)
 	}
-	rows, err := r.store.ListMessages(r.ctx, store.MessageListOptions{
-		GuildIDs:     guildIDs,
-		Channel:      *channel,
-		Author:       *author,
-		Since:        sinceTime,
-		Before:       beforeTime,
-		Limit:        *limit,
-		Last:         *last,
-		IncludeEmpty: *includeEmpty,
-	})
+	if strings.TrimSpace(opts.Channel) != "" {
+		channelQuery := normalizeChannelQuery(opts.Channel)
+		if isDiscordID(channelQuery) {
+			opts.Channel = channelQuery
+		} else {
+			resolution, err := r.resolveLocalChannel(channelQuery, guildIDs)
+			if err != nil {
+				if resolution.Status != "not_found" || !*syncNow {
+					return err
+				}
+			} else {
+				opts.Channel = resolution.Selected.ChannelID
+			}
+		}
+	}
+	rows, err := r.store.ListMessages(r.ctx, opts)
 	if err != nil {
 		return err
 	}

--- a/internal/cli/output.go
+++ b/internal/cli/output.go
@@ -208,6 +208,13 @@ Flags:
   --guild ID                  Restrict to one guild id.
   --guilds ID,ID              Restrict to guild ids.
 `,
+	"channels": `Usage:
+  discrawl channels list
+  discrawl channels show CHANNEL_ID
+  discrawl channels resolve [--guild ID | --guilds ID,ID] [--json] ID_OR_NAME
+
+Resolution prefers an exact channel id, then an exact name, then a unique partial name. Ambiguous names fail with candidate guild/channel ids.
+`,
 	"sql": `Usage:
   discrawl sql [--unsafe --confirm] <query>
   discrawl sql [--unsafe --confirm] -
@@ -307,6 +314,25 @@ func printHuman(w io.Writer, value any) error {
 			_, err = fmt.Fprintf(w, "repair_command=%s\n", v.RepairCommand)
 		}
 		return err
+	case channelResolution:
+		if _, err := fmt.Fprintf(w, "status=%s\nquery=%s\n", v.Status, v.Query); err != nil {
+			return err
+		}
+		if v.Match != "" {
+			if _, err := fmt.Fprintf(w, "match=%s\n", v.Match); err != nil {
+				return err
+			}
+		}
+		if v.Selected != nil {
+			_, err := fmt.Fprintf(w, "channel_id=%s\nguild_id=%s\nname=%s\nkind=%s\n", v.Selected.ChannelID, v.Selected.GuildID, v.Selected.Name, v.Selected.Kind)
+			return err
+		}
+		for _, candidate := range v.Candidates {
+			if _, err := fmt.Fprintf(w, "candidate=%s guild=%s name=%s kind=%s\n", candidate.ChannelID, candidate.GuildID, candidate.Name, candidate.Kind); err != nil {
+				return err
+			}
+		}
+		return nil
 	case store.EmbeddingDrainStats:
 		_, err := fmt.Fprintf(w, "processed=%d\nsucceeded=%d\nfailed=%d\nskipped=%d\nremaining_backlog=%d\nprovider=%s\nmodel=%s\ninput_version=%s\n",
 			v.Processed, v.Succeeded, v.Failed, v.Skipped, v.RemainingBacklog, v.Provider, v.Model, v.InputVersion)

--- a/internal/cli/query_commands.go
+++ b/internal/cli/query_commands.go
@@ -51,6 +51,18 @@ func (r *runtime) runSearch(args []string) error {
 		}
 		return r.print(results)
 	}
+	if strings.TrimSpace(opts.Channel) != "" {
+		channelQuery := normalizeChannelQuery(opts.Channel)
+		if isDiscordID(channelQuery) {
+			opts.Channel = channelQuery
+		} else {
+			resolution, err := r.resolveLocalChannel(channelQuery, guildIDs)
+			if err != nil {
+				return err
+			}
+			opts.Channel = resolution.Selected.ChannelID
+		}
+	}
 	switch normalizedMode {
 	case "", "fts":
 		results, err := r.store.SearchMessages(r.ctx, opts)
@@ -338,16 +350,20 @@ func (r *runtime) runChannels(args []string) error {
 	if len(args) == 0 {
 		return usageErr(errors.New("channels requires a subcommand"))
 	}
-	rows, err := r.store.Channels(r.ctx, "")
-	if err != nil {
-		return err
-	}
 	switch args[0] {
 	case "list":
+		rows, err := r.store.Channels(r.ctx, "")
+		if err != nil {
+			return err
+		}
 		return r.print(rows)
 	case "show":
 		if len(args) < 2 {
 			return usageErr(errors.New("channels show requires a channel id"))
+		}
+		rows, err := r.store.Channels(r.ctx, "")
+		if err != nil {
+			return err
 		}
 		filtered := make([]store.ChannelRow, 0, 1)
 		for _, row := range rows {
@@ -356,6 +372,8 @@ func (r *runtime) runChannels(args []string) error {
 			}
 		}
 		return r.print(filtered)
+	case "resolve":
+		return r.runChannelsResolve(args[1:])
 	default:
 		return usageErr(fmt.Errorf("unknown channels subcommand %q", args[0]))
 	}

--- a/internal/cli/query_sync.go
+++ b/internal/cli/query_sync.go
@@ -2,8 +2,6 @@ package cli
 
 import (
 	"errors"
-	"fmt"
-	"slices"
 	"strings"
 
 	"github.com/openclaw/discrawl/internal/syncer"
@@ -44,36 +42,18 @@ func (r *runtime) messageSyncOptions(channel, guild, guilds string) (syncer.Sync
 	if err != nil {
 		return opts, err
 	}
-	needle := strings.ToLower(channelFilter)
-	allowedGuilds := map[string]struct{}{}
-	for _, guildID := range requestedGuilds {
-		allowedGuilds[guildID] = struct{}{}
-	}
-	for _, row := range rows {
-		if len(allowedGuilds) > 0 {
-			if _, ok := allowedGuilds[row.GuildID]; !ok {
-				continue
-			}
+	resolution, err := resolveChannelRows(rows, channelFilter, requestedGuilds)
+	if err != nil {
+		if resolution.Status == "not_found" && len(requestedGuilds) > 0 {
+			return opts, nil
 		}
-		if !channelMatches(row.ID, row.Name, channelFilter, needle) {
-			continue
-		}
-		opts.ChannelIDs = append(opts.ChannelIDs, row.ID)
-		if len(requestedGuilds) == 0 && !slices.Contains(opts.GuildIDs, row.GuildID) {
-			opts.GuildIDs = append(opts.GuildIDs, row.GuildID)
-		}
+		return opts, err
 	}
-	if len(opts.ChannelIDs) > 0 {
-		return opts, nil
+	opts.ChannelIDs = []string{resolution.Selected.ChannelID}
+	if len(requestedGuilds) == 0 {
+		opts.GuildIDs = []string{resolution.Selected.GuildID}
 	}
-	if len(opts.GuildIDs) > 0 {
-		return opts, nil
-	}
-	return opts, fmt.Errorf("cannot resolve channel %q; pass a channel id or --guild", channel)
-}
-
-func channelMatches(id, name, raw, lowered string) bool {
-	return id == raw || name == raw || strings.Contains(strings.ToLower(name), lowered)
+	return opts, nil
 }
 
 func isDiscordID(raw string) bool {
@@ -119,6 +99,15 @@ func boolFlagEnabled(args []string, name string) bool {
 func hasHelpArg(args []string) bool {
 	for _, arg := range args {
 		if arg == "help" || arg == "--help" || arg == "-h" {
+			return true
+		}
+	}
+	return false
+}
+
+func hasHelpFlag(args []string) bool {
+	for _, arg := range args {
+		if arg == "--help" || arg == "-h" {
 			return true
 		}
 	}


### PR DESCRIPTION
## Summary

- add `channels resolve` with JSON output, guild scoping, and deterministic id/name/partial precedence
- make local `search`, `messages`, and message-sync use one resolver instead of broad partial-name matching
- fail ambiguous names with actionable guild/channel candidates while preserving direct numeric-id queries for partial archives
- stop treating bare `help` channel/query values as command-help requests
- document numeric ids as the stable repeated-workflow input

Fixes #104.

## Root cause

Local query paths passed raw channel text into independent partial-match logic. Duplicate names could silently broaden a query, sync could select multiple channels, and dispatch intercepted `help` before it reached the channel filter.

## Proof

- `GOWORK=off go test -count=1 ./...`
- `GOWORK=off go vet ./...`
- `GOWORK=off go mod verify`
- `GOWORK=off golangci-lint run` (0 issues)
- `gofumpt -l .`
- exact candidate binary against an isolated synthetic Discord Desktop cache with duplicate `#help` channels in two synthetic guilds:
  - unscoped resolution returned both guild/channel ids and exited 1
  - guild scope selected one exact-name candidate
  - numeric id selected directly
  - unique partial selected one channel
  - ambiguous local search/messages exited 1 with both candidates
  - numeric search/messages returned only the selected synthetic marker
- focused partial-archive regression: numeric id queries still return messages when the channel-directory row is absent
- autoreview: clean after accepting the partial-archive numeric-id finding

## Risk

Medium. Local name filters now reject ambiguous matches instead of silently querying multiple channels. Remote-cloud filtering remains unchanged. No schema, archive, or protocol changes.
