### PR TITLE
feat: add archive diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Add read-only `publish --check` scope preflight with fail-closed metadata readiness, source hints, predicted channel/message counts, and concrete repair guidance.
 - Add shared channel resolution for `channels`, `search`, `messages`, and message sync with stable id precedence and actionable ambiguity candidates.
+- Add read-only `diagnostics` output for SQLite integrity, WAL size, archive freshness, and authoritative Discrawl writer-lock ownership.
 
 ## 0.11.3 - 2026-06-23
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Wiretap DMs stay local and are never exported to the Git-backed snapshot mirror.
 - imports classifiable Discord Desktop cache messages with `wiretap`, including proven DMs under `@me`
 - publishes and imports private Git-backed archive snapshots for org-wide read access
 - browses stored messages and local DMs in a terminal archive UI
-- exposes `metadata --json`, `status --json`, and `doctor --json` for local
+- exposes `metadata --json`, `status --json`, `diagnostics --json`, and `doctor --json` for local
   launchers, automation, and CI
 - reports Worker-fronted cloud archive status in read-only mode without
   touching local SQLite
@@ -515,6 +515,21 @@ Shows local archive status.
 ```bash
 discrawl status
 ```
+
+### `diagnostics`
+
+Inspects the local archive without authenticating to Discord or running a sync.
+It reports the active database path, SQLite integrity and journal mode, WAL
+presence/size, last sync/tail timestamps, and the sync-lock owner when a
+Discrawl writer is active.
+
+```bash
+discrawl diagnostics
+discrawl diagnostics --json
+```
+
+The lock probe verifies the operating-system file lock. Leftover lock metadata
+is reported as stale rather than mistaken for an active writer.
 
 ### Git-backed sharing
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -19,7 +19,7 @@ Mirror Discord guilds into local SQLite. Search server history without depending
 - **Just want to read a shared archive?** Use [`subscribe`](commands/subscribe.html) for Git snapshots, or [`subscribe-cloud`](commands/subscribe-cloud.html) for a Worker-fronted archive - no Discord token needed.
 - **Need DM search?** [`wiretap`](commands/wiretap.html) imports local Discord Desktop cache.
 - **Want semantic search?** Configure [Embeddings](guides/embeddings.html), then run [`embed`](commands/embed.html).
-- **Wiring an agent or launcher?** `discrawl metadata --json`, `discrawl status --json`, `discrawl remote status`, and `discrawl doctor --json` expose the read-only crawlkit control surface.
+- **Wiring an agent or launcher?** `discrawl metadata --json`, `discrawl status --json`, `discrawl diagnostics --json`, `discrawl remote status`, and `discrawl doctor --json` expose the read-only crawlkit control surface.
 
 ## At a glance
 

--- a/docs/commands/diagnostics.md
+++ b/docs/commands/diagnostics.md
@@ -1,0 +1,42 @@
+# `diagnostics`
+
+Reports local archive health and active Discrawl writer state without running a
+sync or authenticating to Discord.
+
+## Usage
+
+```bash
+discrawl diagnostics
+discrawl diagnostics --json
+```
+
+## Reports
+
+- expanded SQLite database path, presence, and size
+- SQLite journal mode, schema version, and read-only `PRAGMA quick_check` result
+- WAL path, presence, and size
+- last completed sync and last tail event when recorded
+- sync-lock path and whether its operating-system file lock is held
+- active writer PID, operation, phase, and timestamps from Discrawl lock metadata
+- whether the archive passed integrity checks and is safe for read-only inspection
+
+An active writer can be `sync`, `tail`, `wiretap`, an import, or another
+Discrawl operation. The operation and phase come from the same lock metadata
+used by Discrawl's writer serialization. `diagnostics` does not scan unrelated
+operating-system processes.
+
+Lock files can remain after a writer exits. Discrawl verifies the file lock and
+reports leftover owner data as `stale_metadata`, so an old PID or lock file is
+not mistaken for an active writer. On platforms without a supported file-lock
+probe, the JSON output uses `detection: "unsupported"` instead of guessing.
+
+Missing or unreadable databases are returned as structured warning reports.
+The command does not create a missing database or lock file.
+SQLite integrity is checked independently of Discrawl's schema version, so a
+healthy older or newer archive can still report `integrity: "ok"`; freshness
+fields carry a separate compatibility error when this binary cannot read them.
+
+## See also
+
+- [`status`](status.html) - archive counts and high-level freshness
+- [`doctor`](doctor.html) - config, Discord auth, DB schema, and FTS readiness

--- a/docs/commands/doctor.md
+++ b/docs/commands/doctor.md
@@ -33,3 +33,4 @@ discrawl doctor
 - [Bot setup](../bot-setup.html)
 - [Configuration](../configuration.html)
 - [`status`](status.html)
+- [`diagnostics`](diagnostics.html) - local archive integrity and writer state without Discord auth

--- a/docs/commands/status.md
+++ b/docs/commands/status.md
@@ -22,6 +22,7 @@ discrawl status
 
 ## See also
 
+- [`diagnostics`](diagnostics.html) - read-only SQLite, WAL, freshness, and writer-lock checks
 - [`doctor`](doctor.html) - liveness check (config, auth, DB, FTS wiring)
 - [`remote`](remote.html) - direct Cloudflare remote archive checks
 - [`report`](report.html) - Markdown activity block for the shared backup README

--- a/docs/guides/data-storage.md
+++ b/docs/guides/data-storage.md
@@ -58,6 +58,7 @@ See [`sql`](../commands/sql.html).
 ## See also
 
 - [`status`](../commands/status.html) - high-level archive status
+- [`diagnostics`](../commands/diagnostics.html) - SQLite integrity, WAL, freshness, and writer-lock state
 - [`channels`](../commands/channels.html) - channel directory
 - [`members`](../commands/members.html) - member directory
 - [Security](../security.html)

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -283,6 +283,8 @@ func (r *runtime) dispatch(rest []string) error {
 			return r.withConfig(func() error { return r.runStatus(rest[1:]) })
 		}
 		return r.withLocalStoreReadOnly(func() error { return r.runStatus(rest[1:]) })
+	case "diagnostics":
+		return r.withConfig(func() error { return r.runDiagnostics(rest[1:]) })
 	case "report":
 		return r.withLocalStoreRead(true, func() error { return r.runReport(rest[1:]) })
 	case "publish":

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -437,6 +437,106 @@ func TestControlStatusIncludesShareAndFileSizes(t *testing.T) {
 	require.Contains(t, out.Summary, "5 messages")
 }
 
+func TestDiagnosticsReportsSQLiteAndActiveWriter(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	cfg, cfgPath := writeTestConfig(t, dir)
+	s := seedCLIStore(t, cfg.DBPath)
+	defer func() { _ = s.Close() }()
+
+	lockPath := filepath.Join(dir, ".discrawl-sync.lock")
+	now := time.Date(2026, 7, 1, 12, 0, 0, 0, time.UTC)
+	release, err := acquireSyncLockWithMetadata(ctx, lockPath, syncLockMetadataBody("wiretap", "importing", now, now.Add(time.Minute), testSyncLockToken()))
+	require.NoError(t, err)
+
+	var out bytes.Buffer
+	require.NoError(t, Run(ctx, []string{"--config", cfgPath, "diagnostics", "--json"}, &out, &bytes.Buffer{}))
+	var report diagnosticsReport
+	require.NoError(t, json.Unmarshal(out.Bytes(), &report))
+	require.Equal(t, "ok", report.Status)
+	require.Equal(t, cfg.DBPath, report.Database.Path)
+	require.True(t, report.Database.Exists)
+	require.Positive(t, report.Database.Bytes)
+	require.Equal(t, "wal", report.Database.JournalMode)
+	require.Equal(t, "ok", report.Database.Integrity)
+	require.Equal(t, cfg.DBPath+"-wal", report.Database.WAL.Path)
+	require.True(t, report.SafeForReadOnlyInspection)
+	require.True(t, report.SyncLock.Held)
+	require.Equal(t, "active_writer", report.SyncLock.State)
+	require.Equal(t, "file_lock", report.SyncLock.Detection)
+	require.NotNil(t, report.SyncLock.Owner)
+	require.Equal(t, os.Getpid(), report.SyncLock.Owner.PID)
+	require.True(t, report.SyncLock.Owner.Alive)
+	require.Equal(t, "wiretap", report.SyncLock.Owner.Operation)
+	require.Equal(t, "importing", report.SyncLock.Owner.Phase)
+	require.Equal(t, now.Format(time.RFC3339Nano), report.SyncLock.Owner.StartedAt)
+	require.Equal(t, now.Add(time.Minute).Format(time.RFC3339Nano), report.SyncLock.Owner.UpdatedAt)
+
+	require.NoError(t, release())
+	out.Reset()
+	require.NoError(t, Run(ctx, []string{"--config", cfgPath, "diagnostics"}, &out, &bytes.Buffer{}))
+	require.Contains(t, out.String(), "sync_lock_held=false")
+	require.Contains(t, out.String(), "sync_lock_state=stale_metadata")
+}
+
+func TestDiagnosticsMissingDatabaseIsVisibleAndNonMutating(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	cfg, cfgPath := writeTestConfig(t, dir)
+	lockPath := filepath.Join(dir, ".discrawl-sync.lock")
+
+	var out bytes.Buffer
+	require.NoError(t, Run(ctx, []string{"--config", cfgPath, "--json", "diagnostics"}, &out, &bytes.Buffer{}))
+	var report diagnosticsReport
+	require.NoError(t, json.Unmarshal(out.Bytes(), &report))
+	require.Equal(t, "warning", report.Status)
+	require.False(t, report.Database.Exists)
+	require.Equal(t, "not_available", report.Database.Integrity)
+	require.False(t, report.SafeForReadOnlyInspection)
+	require.False(t, report.SyncLock.Held)
+	require.Equal(t, "unlocked", report.SyncLock.State)
+	require.NoFileExists(t, cfg.DBPath)
+	require.NoFileExists(t, lockPath)
+	require.NoFileExists(t, syncLockMetadataPath(lockPath))
+}
+
+func TestDiagnosticsReportsUnreadableDatabase(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	cfg, cfgPath := writeTestConfig(t, dir)
+	require.NoError(t, os.WriteFile(cfg.DBPath, []byte("not sqlite"), 0o600))
+
+	var out bytes.Buffer
+	require.NoError(t, Run(ctx, []string{"--config", cfgPath, "diagnostics", "--json"}, &out, &bytes.Buffer{}))
+	var report diagnosticsReport
+	require.NoError(t, json.Unmarshal(out.Bytes(), &report))
+	require.Equal(t, "warning", report.Status)
+	require.True(t, report.Database.Exists)
+	require.Equal(t, "unavailable", report.Database.Integrity)
+	require.NotEmpty(t, report.Database.OpenError)
+	require.False(t, report.SafeForReadOnlyInspection)
+}
+
+func TestDiagnosticsChecksIntegrityAcrossSchemaMismatch(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	cfg, cfgPath := writeTestConfig(t, dir)
+	s := seedCLIStore(t, cfg.DBPath)
+	_, err := s.Exec(ctx, "pragma user_version = 999")
+	require.NoError(t, err)
+	require.NoError(t, s.Close())
+
+	var out bytes.Buffer
+	require.NoError(t, Run(ctx, []string{"--config", cfgPath, "diagnostics", "--json"}, &out, &bytes.Buffer{}))
+	var report diagnosticsReport
+	require.NoError(t, json.Unmarshal(out.Bytes(), &report))
+	require.Equal(t, "warning", report.Status)
+	require.Equal(t, 999, report.Database.SchemaVersion)
+	require.Equal(t, "ok", report.Database.Integrity)
+	require.True(t, report.SafeForReadOnlyInspection)
+	require.Contains(t, report.Freshness.Error, "database schema version mismatch")
+}
+
 func TestFormattingAndTUISourceBranches(t *testing.T) {
 	require.Equal(t, "-", formatDaysSilent(-1))
 	require.Equal(t, "4", formatDaysSilent(4))

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -443,6 +443,8 @@ func TestDiagnosticsReportsSQLiteAndActiveWriter(t *testing.T) {
 	cfg, cfgPath := writeTestConfig(t, dir)
 	s := seedCLIStore(t, cfg.DBPath)
 	defer func() { _ = s.Close() }()
+	require.NoError(t, s.SetSyncState(ctx, "sync:last_success", "2026-07-01T11:59:00Z"))
+	require.NoError(t, s.SetSyncState(ctx, "tail:last_event", "synthetic-message"))
 
 	lockPath := filepath.Join(dir, ".discrawl-sync.lock")
 	now := time.Date(2026, 7, 1, 12, 0, 0, 0, time.UTC)
@@ -471,12 +473,16 @@ func TestDiagnosticsReportsSQLiteAndActiveWriter(t *testing.T) {
 	require.Equal(t, "importing", report.SyncLock.Owner.Phase)
 	require.Equal(t, now.Format(time.RFC3339Nano), report.SyncLock.Owner.StartedAt)
 	require.Equal(t, now.Add(time.Minute).Format(time.RFC3339Nano), report.SyncLock.Owner.UpdatedAt)
+	require.NotEmpty(t, report.Freshness.LastSyncAt)
+	require.NotEmpty(t, report.Freshness.LastTailEventAt)
 
 	require.NoError(t, release())
 	out.Reset()
 	require.NoError(t, Run(ctx, []string{"--config", cfgPath, "diagnostics"}, &out, &bytes.Buffer{}))
 	require.Contains(t, out.String(), "sync_lock_held=false")
 	require.Contains(t, out.String(), "sync_lock_state=stale_metadata")
+	require.Contains(t, out.String(), "last_sync_at=")
+	require.Contains(t, out.String(), "last_tail_event_at=")
 }
 
 func TestDiagnosticsMissingDatabaseIsVisibleAndNonMutating(t *testing.T) {

--- a/internal/cli/control_commands.go
+++ b/internal/cli/control_commands.go
@@ -38,10 +38,11 @@ func (r *runtime) runMetadata(args []string) error {
 		DefaultLogs:     cfg.LogDir,
 		DefaultShare:    cfg.Share.RepoPath,
 	}
-	manifest.Capabilities = []string{"metadata", "status", "doctor", "sync", "tap", "tui", "git-share", "cloud-remote", "cloud-publish", "sql", "embeddings"}
+	manifest.Capabilities = []string{"metadata", "status", "diagnostics", "doctor", "sync", "tap", "tui", "git-share", "cloud-remote", "cloud-publish", "sql", "embeddings"}
 	manifest.Privacy = control.Privacy{ContainsPrivateMessages: true, ExportsSecrets: false, LocalOnlyScopes: []string{"discord", "desktop-cache", "sqlite", "git-share"}}
 	manifest.Commands = map[string]control.Command{
 		"status":          {Title: "Status", Argv: []string{"discrawl", "status", "--json"}, JSON: true},
+		"diagnostics":     {Title: "Diagnostics", Argv: []string{"discrawl", "diagnostics", "--json"}, JSON: true},
 		"check-update":    {Title: "Check for updates", Argv: []string{"discrawl", "check-update", "--json"}, JSON: true},
 		"doctor":          {Title: "Doctor", Argv: []string{"discrawl", "doctor", "--json"}, JSON: true},
 		"sync":            {Title: "Sync", Argv: []string{"discrawl", "--json", "sync"}, JSON: true, Mutates: true},

--- a/internal/cli/diagnostics.go
+++ b/internal/cli/diagnostics.go
@@ -106,14 +106,15 @@ func (r *runtime) runDiagnostics(args []string) error {
 	if !known {
 		report.SyncLock.Detection = "unsupported"
 	}
-	if lockErr != nil {
+	switch {
+	case lockErr != nil:
 		report.SyncLock.Error = lockErr.Error()
 		report.Warnings = append(report.Warnings, "sync lock state could not be determined")
-	} else if !known {
+	case !known:
 		report.Warnings = append(report.Warnings, "sync lock state detection is unsupported on this platform")
-	} else if held {
+	case held:
 		report.SyncLock.State = "active_writer"
-	} else {
+	default:
 		report.SyncLock.State = "unlocked"
 	}
 	if owner, ok := readSyncLockOwner(lockPath); ok {

--- a/internal/cli/diagnostics.go
+++ b/internal/cli/diagnostics.go
@@ -1,0 +1,188 @@
+package cli
+
+import (
+	"errors"
+	"flag"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/openclaw/discrawl/internal/config"
+	"github.com/openclaw/discrawl/internal/store"
+)
+
+type diagnosticsReport struct {
+	Status                    string               `json:"status"`
+	Database                  diagnosticsDatabase  `json:"database"`
+	SyncLock                  diagnosticsSyncLock  `json:"sync_lock"`
+	Freshness                 diagnosticsFreshness `json:"freshness"`
+	SafeForReadOnlyInspection bool                 `json:"safe_for_read_only_inspection"`
+	Warnings                  []string             `json:"warnings,omitempty"`
+}
+
+type diagnosticsDatabase struct {
+	Path          string          `json:"path"`
+	Exists        bool            `json:"exists"`
+	Bytes         int64           `json:"bytes"`
+	JournalMode   string          `json:"journal_mode,omitempty"`
+	SchemaVersion int             `json:"schema_version"`
+	Integrity     string          `json:"integrity"`
+	OpenError     string          `json:"open_error,omitempty"`
+	WAL           diagnosticsFile `json:"wal"`
+}
+
+type diagnosticsFile struct {
+	Path   string `json:"path"`
+	Exists bool   `json:"exists"`
+	Bytes  int64  `json:"bytes"`
+}
+
+type diagnosticsSyncLock struct {
+	Path         string                    `json:"path"`
+	MetadataPath string                    `json:"metadata_path"`
+	Held         bool                      `json:"held"`
+	State        string                    `json:"state"`
+	Detection    string                    `json:"detection"`
+	Owner        *diagnosticsSyncLockOwner `json:"owner,omitempty"`
+	Error        string                    `json:"error,omitempty"`
+}
+
+type diagnosticsSyncLockOwner struct {
+	PID       int    `json:"pid"`
+	Alive     bool   `json:"alive"`
+	Operation string `json:"operation,omitempty"`
+	Phase     string `json:"phase,omitempty"`
+	StartedAt string `json:"started_at,omitempty"`
+	UpdatedAt string `json:"updated_at,omitempty"`
+}
+
+type diagnosticsFreshness struct {
+	LastSyncAt      string `json:"last_sync_at,omitempty"`
+	LastTailEventAt string `json:"last_tail_event_at,omitempty"`
+	Error           string `json:"error,omitempty"`
+}
+
+func (r *runtime) runDiagnostics(args []string) error {
+	fs := flag.NewFlagSet("diagnostics", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	jsonOut := fs.Bool("json", false, "")
+	if err := fs.Parse(args); err != nil {
+		return usageErr(err)
+	}
+	if fs.NArg() != 0 {
+		return usageErr(errors.New("diagnostics takes no arguments"))
+	}
+	if *jsonOut {
+		r.json = true
+	}
+
+	dbPath, err := config.ExpandPath(r.cfg.DBPath)
+	if err != nil {
+		return configErr(err)
+	}
+	lockPath := filepath.Join(filepath.Dir(dbPath), ".discrawl-sync.lock")
+	report := diagnosticsReport{
+		Status: "warning",
+		Database: diagnosticsDatabase{
+			Path:      dbPath,
+			Integrity: "not_checked",
+			WAL:       statDiagnosticsFile(dbPath + "-wal"),
+		},
+		SyncLock: diagnosticsSyncLock{
+			Path:         lockPath,
+			MetadataPath: syncLockMetadataPath(lockPath),
+			State:        "unknown",
+			Detection:    "file_lock",
+		},
+	}
+	dbFile := statDiagnosticsFile(dbPath)
+	report.Database.Exists = dbFile.Exists
+	report.Database.Bytes = dbFile.Bytes
+
+	held, known, lockErr := syncLockState(lockPath)
+	report.SyncLock.Held = held
+	if !known {
+		report.SyncLock.Detection = "unsupported"
+	}
+	if lockErr != nil {
+		report.SyncLock.Error = lockErr.Error()
+		report.Warnings = append(report.Warnings, "sync lock state could not be determined")
+	} else if !known {
+		report.Warnings = append(report.Warnings, "sync lock state detection is unsupported on this platform")
+	} else if held {
+		report.SyncLock.State = "active_writer"
+	} else {
+		report.SyncLock.State = "unlocked"
+	}
+	if owner, ok := readSyncLockOwner(lockPath); ok {
+		report.SyncLock.Owner = &diagnosticsSyncLockOwner{
+			PID:       owner.PID,
+			Alive:     syncLockPIDAlive(owner.PID),
+			Operation: owner.Operation,
+			Phase:     owner.Phase,
+			StartedAt: owner.StartedAt,
+			UpdatedAt: owner.UpdatedAt,
+		}
+		if lockErr == nil && known && !held {
+			report.SyncLock.State = "stale_metadata"
+		}
+	}
+
+	if !report.Database.Exists {
+		report.Database.Integrity = "not_available"
+		report.Warnings = append(report.Warnings, "database does not exist")
+		return r.print(report)
+	}
+
+	health, inspectErr := store.InspectSQLite(r.ctx, dbPath)
+	if inspectErr != nil {
+		report.Database.Integrity = "unavailable"
+		report.Database.OpenError = inspectErr.Error()
+		report.Warnings = append(report.Warnings, "database could not be opened read-only")
+		return r.print(report)
+	}
+	report.Database.JournalMode = strings.ToLower(strings.TrimSpace(health.JournalMode))
+	report.Database.SchemaVersion = health.SchemaVersion
+	if health.IntegrityOK {
+		report.Database.Integrity = "ok"
+	} else {
+		report.Database.Integrity = "failed"
+		report.Warnings = append(report.Warnings, "SQLite quick_check reported integrity errors")
+	}
+	db, openErr := store.OpenReadOnly(r.ctx, dbPath)
+	if openErr != nil {
+		report.Freshness.Error = openErr.Error()
+		report.Warnings = append(report.Warnings, "archive freshness could not be read with this Discrawl version")
+	} else {
+		defer func() { _ = db.Close() }()
+		if status, statusErr := db.Status(r.ctx, dbPath, r.cfg.EffectiveDefaultGuildID()); statusErr != nil {
+			report.Freshness.Error = statusErr.Error()
+			report.Warnings = append(report.Warnings, "archive freshness could not be read")
+		} else {
+			if !status.LastSyncAt.IsZero() {
+				report.Freshness.LastSyncAt = status.LastSyncAt.UTC().Format(time.RFC3339)
+			}
+			if !status.LastTailEventAt.IsZero() {
+				report.Freshness.LastTailEventAt = status.LastTailEventAt.UTC().Format(time.RFC3339)
+			}
+		}
+	}
+	report.SafeForReadOnlyInspection = report.Database.Integrity == "ok"
+	if report.SafeForReadOnlyInspection && len(report.Warnings) == 0 {
+		report.Status = "ok"
+	}
+	return r.print(report)
+}
+
+func statDiagnosticsFile(path string) diagnosticsFile {
+	out := diagnosticsFile{Path: path}
+	info, err := os.Stat(path)
+	if err != nil {
+		return out
+	}
+	out.Exists = true
+	out.Bytes = info.Size()
+	return out
+}

--- a/internal/cli/diagnostics_unix_test.go
+++ b/internal/cli/diagnostics_unix_test.go
@@ -1,0 +1,36 @@
+//go:build unix
+
+package cli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/openclaw/discrawl/internal/config"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDiagnosticsKeepsUnknownStateWhenLockProbeFails(t *testing.T) {
+	dir := t.TempDir()
+	cfg := config.Default()
+	cfg.DBPath = filepath.Join(dir, "missing.db")
+	cfgPath := filepath.Join(dir, "config.toml")
+	require.NoError(t, config.Write(cfgPath, cfg))
+	lockPath := filepath.Join(dir, ".discrawl-sync.lock")
+	require.NoError(t, os.WriteFile(lockPath, []byte("locked"), 0o600))
+	writeSyncLockMetadata(t, lockPath, "wiretap", os.Getpid())
+	require.NoError(t, os.Chmod(lockPath, 0))
+	t.Cleanup(func() { _ = os.Chmod(lockPath, 0o600) })
+
+	var out bytes.Buffer
+	require.NoError(t, Run(context.Background(), []string{"--config", cfgPath, "diagnostics", "--json"}, &out, &bytes.Buffer{}))
+	var report diagnosticsReport
+	require.NoError(t, json.Unmarshal(out.Bytes(), &report))
+	require.Equal(t, "unknown", report.SyncLock.State)
+	require.NotEmpty(t, report.SyncLock.Error)
+	require.NotNil(t, report.SyncLock.Owner)
+}

--- a/internal/cli/output.go
+++ b/internal/cli/output.go
@@ -124,6 +124,7 @@ Commands:
   members
   channels
   status
+  diagnostics
   remote
   whoami
   report
@@ -146,6 +147,11 @@ func printCommandUsage(w io.Writer, args []string) error {
 }
 
 var commandUsage = map[string]string{
+	"diagnostics": `Usage:
+  discrawl diagnostics [--json]
+
+Reports read-only SQLite integrity, WAL, freshness, and Discrawl sync-lock state.
+`,
 	"check-update": `Usage:
   discrawl check-update [--json] [--force]
 
@@ -297,6 +303,32 @@ func printHuman(w io.Writer, value any) error {
 		_, err := fmt.Fprintf(w, "db=%s\nguilds=%d\nchannels=%d\nthreads=%d\nmessages=%d\nmembers=%d\nembedding_backlog=%d\nlast_sync=%s\nlast_tail_event=%s\n",
 			v.DBPath, v.GuildCount, v.ChannelCount, v.ThreadCount, v.MessageCount, v.MemberCount, v.EmbeddingBacklog,
 			formatTime(v.LastSyncAt), formatTime(v.LastTailEventAt))
+		return err
+	case diagnosticsReport:
+		_, err := fmt.Fprintf(w, "status=%s\ndb=%s\ndb_exists=%t\ndb_bytes=%d\njournal_mode=%s\nschema_version=%d\nwal=%s\nwal_exists=%t\nwal_bytes=%d\nintegrity=%s\nsync_lock=%s\nsync_lock_held=%t\nsync_lock_state=%s\nsafe_for_read_only_inspection=%t\n",
+			v.Status, v.Database.Path, v.Database.Exists, v.Database.Bytes, v.Database.JournalMode,
+			v.Database.SchemaVersion,
+			v.Database.WAL.Path, v.Database.WAL.Exists, v.Database.WAL.Bytes, v.Database.Integrity,
+			v.SyncLock.Path, v.SyncLock.Held, v.SyncLock.State, v.SafeForReadOnlyInspection)
+		if err != nil {
+			return err
+		}
+		if v.SyncLock.Owner != nil {
+			_, err = fmt.Fprintf(w, "writer_pid=%d\nwriter_alive=%t\nwriter_operation=%s\nwriter_phase=%s\nwriter_started_at=%s\nwriter_updated_at=%s\n",
+				v.SyncLock.Owner.PID, v.SyncLock.Owner.Alive, v.SyncLock.Owner.Operation,
+				v.SyncLock.Owner.Phase, v.SyncLock.Owner.StartedAt, v.SyncLock.Owner.UpdatedAt)
+		}
+		if err == nil && v.Freshness.LastSyncAt != "" {
+			_, err = fmt.Fprintf(w, "last_sync_at=%s\n", v.Freshness.LastSyncAt)
+		}
+		if err == nil && v.Freshness.LastTailEventAt != "" {
+			_, err = fmt.Fprintf(w, "last_tail_event_at=%s\n", v.Freshness.LastTailEventAt)
+		}
+		for _, warning := range v.Warnings {
+			if err == nil {
+				_, err = fmt.Fprintf(w, "warning=%s\n", warning)
+			}
+		}
 		return err
 	case share.PublishScopePreflight:
 		_, err := fmt.Fprintf(w, "ready=%t\npublic_only=%t\nchannels_candidate=%d\nchannels_allowed=%d\nchannels_excluded=%d\nmessages_candidate=%d\nmessages_allowed=%d\nmessages_excluded=%d\nempty=%t\n",

--- a/internal/cli/sync_lock.go
+++ b/internal/cli/sync_lock.go
@@ -183,6 +183,9 @@ func (r *runtime) syncLockPath() (string, error) {
 type syncLockOwner struct {
 	PID       int
 	Operation string
+	Phase     string
+	StartedAt string
+	UpdatedAt string
 	Token     string
 }
 
@@ -241,7 +244,14 @@ func readSyncLockOwnerFile(path string) (syncLockOwner, bool) {
 	if err != nil {
 		return syncLockOwner{}, false
 	}
-	return syncLockOwner{PID: pid, Operation: fields["operation"], Token: fields["token"]}, true
+	return syncLockOwner{
+		PID:       pid,
+		Operation: fields["operation"],
+		Phase:     fields["phase"],
+		StartedAt: fields["started_at"],
+		UpdatedAt: fields["updated_at"],
+		Token:     fields["token"],
+	}, true
 }
 
 func writeSyncLockMetadataRecord(file *os.File, path string, metadata []byte) error {

--- a/internal/cli/sync_lock_state_other.go
+++ b/internal/cli/sync_lock_state_other.go
@@ -1,0 +1,7 @@
+//go:build !unix && !windows
+
+package cli
+
+func syncLockState(string) (held bool, known bool, err error) {
+	return false, false, nil
+}

--- a/internal/cli/sync_lock_state_unix.go
+++ b/internal/cli/sync_lock_state_unix.go
@@ -1,0 +1,31 @@
+//go:build unix
+
+package cli
+
+import (
+	"errors"
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+func syncLockState(path string) (held bool, known bool, err error) {
+	file, err := os.Open(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return false, true, nil
+		}
+		return false, true, err
+	}
+	defer func() { _ = file.Close() }()
+	if err := unix.Flock(int(file.Fd()), unix.LOCK_EX|unix.LOCK_NB); err != nil {
+		if errors.Is(err, unix.EWOULDBLOCK) || errors.Is(err, unix.EAGAIN) {
+			return true, true, nil
+		}
+		return false, true, err
+	}
+	if err := unix.Flock(int(file.Fd()), unix.LOCK_UN); err != nil {
+		return false, true, err
+	}
+	return false, true, nil
+}

--- a/internal/cli/sync_lock_state_windows.go
+++ b/internal/cli/sync_lock_state_windows.go
@@ -1,0 +1,33 @@
+//go:build windows
+
+package cli
+
+import (
+	"errors"
+	"os"
+
+	"golang.org/x/sys/windows"
+)
+
+func syncLockState(path string) (held bool, known bool, err error) {
+	file, err := os.OpenFile(path, os.O_RDWR, 0)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return false, true, nil
+		}
+		return false, true, err
+	}
+	defer func() { _ = file.Close() }()
+	handle := windows.Handle(file.Fd())
+	overlapped := syncLockWindowsOverlapped()
+	if err := windows.LockFileEx(handle, windows.LOCKFILE_EXCLUSIVE_LOCK|windows.LOCKFILE_FAIL_IMMEDIATELY, 0, 1, 0, overlapped); err != nil {
+		if errors.Is(err, windows.ERROR_LOCK_VIOLATION) {
+			return true, true, nil
+		}
+		return false, true, err
+	}
+	if err := windows.UnlockFileEx(handle, 0, 1, 0, overlapped); err != nil {
+		return false, true, err
+	}
+	return false, true, nil
+}

--- a/internal/store/diagnostics.go
+++ b/internal/store/diagnostics.go
@@ -1,0 +1,58 @@
+package store
+
+import (
+	"context"
+	"errors"
+
+	crawlstore "github.com/openclaw/crawlkit/store"
+)
+
+type SQLiteHealth struct {
+	JournalMode   string
+	SchemaVersion int
+	IntegrityOK   bool
+}
+
+func InspectSQLite(ctx context.Context, path string) (SQLiteHealth, error) {
+	base, err := crawlstore.OpenReadOnly(ctx, path)
+	if err != nil {
+		return SQLiteHealth{}, err
+	}
+	defer func() { _ = base.Close() }()
+	db := base.DB()
+	queryCtx, cancel := withQueryTimeout(ctx)
+	defer cancel()
+
+	var health SQLiteHealth
+	if err := db.QueryRowContext(queryCtx, "pragma journal_mode").Scan(&health.JournalMode); err != nil {
+		return SQLiteHealth{}, err
+	}
+	if err := db.QueryRowContext(queryCtx, "pragma user_version").Scan(&health.SchemaVersion); err != nil {
+		return SQLiteHealth{}, err
+	}
+	rows, err := db.QueryContext(queryCtx, "pragma quick_check")
+	if err != nil {
+		return SQLiteHealth{}, err
+	}
+	defer func() { _ = rows.Close() }()
+	rowCount := 0
+	issueCount := 0
+	for rows.Next() {
+		var result string
+		if err := rows.Scan(&result); err != nil {
+			return SQLiteHealth{}, err
+		}
+		rowCount++
+		if result != "ok" {
+			issueCount++
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return SQLiteHealth{}, err
+	}
+	if rowCount == 0 {
+		return SQLiteHealth{}, errors.New("SQLite quick_check returned no result")
+	}
+	health.IntegrityOK = rowCount == 1 && issueCount == 0
+	return health, nil
+}

--- a/internal/store/diagnostics_test.go
+++ b/internal/store/diagnostics_test.go
@@ -1,0 +1,39 @@
+package store
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestInspectSQLiteIgnoresApplicationSchemaVersion(t *testing.T) {
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "archive.db")
+	s, err := Open(ctx, dbPath)
+	require.NoError(t, err)
+	_, err = s.Exec(ctx, "pragma user_version = 999")
+	require.NoError(t, err)
+	require.NoError(t, s.Close())
+
+	health, err := InspectSQLite(ctx, dbPath)
+	require.NoError(t, err)
+	require.Equal(t, "wal", health.JournalMode)
+	require.Equal(t, 999, health.SchemaVersion)
+	require.True(t, health.IntegrityOK)
+}
+
+func TestInspectSQLiteReportsOpenAndQueryErrors(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+
+	_, err := InspectSQLite(ctx, filepath.Join(dir, "missing.db"))
+	require.Error(t, err)
+
+	invalidPath := filepath.Join(dir, "invalid.db")
+	require.NoError(t, os.WriteFile(invalidPath, []byte("not sqlite"), 0o600))
+	_, err = InspectSQLite(ctx, invalidPath)
+	require.Error(t, err)
+}


### PR DESCRIPTION
## Summary

- add `discrawl diagnostics` human and JSON output for database/WAL paths, sizes, SQLite journal/schema/integrity state, and archive freshness
- report authoritative Discrawl writer-lock state and safe owner metadata while treating leftover metadata as stale
- keep raw SQLite health independent from Discrawl schema compatibility, and keep missing-archive inspection non-mutating

## Verification

- `GOWORK=off go test -count=1 ./...`
- `go vet ./...`
- Windows cross-compile: `GOOS=windows GOARCH=amd64 go test -c ./internal/cli`
- `node scripts/build-docs-site.mjs`
- source-blind behavior contract against the exact built binary on a disposable synthetic archive: valid, active-writer, stale-metadata, schema-mismatch, and missing-archive paths passed
- autoreview clean after fixing lock-probe ambiguity and schema-coupled integrity checks

Closes #102.
