### PR TITLE
feat: add archive coverage reporting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,9 @@
 *.out
 coverage.out
 coverage.*
+!docs/commands/coverage.md
+!internal/cli/coverage.go
+!internal/store/coverage.go
 *.coverprofile
 profile.cov
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Add read-only `publish --check` scope preflight with fail-closed metadata readiness, source hints, predicted channel/message counts, and concrete repair guidance.
 - Add shared channel resolution for `channels`, `search`, `messages`, and message sync with stable id precedence and actionable ambiguity candidates.
 - Add read-only `diagnostics` output for SQLite integrity, WAL size, archive freshness, and authoritative Discrawl writer-lock ownership.
+- Add read-only archive coverage reporting with per-guild/channel bounds, named-versus-synthetic channel counts, persisted wiretap skip counters, and watch-mode deltas via `wiretap --stats`.
 
 ## 0.11.3 - 2026-06-23
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Wiretap DMs stay local and are never exported to the Git-backed snapshot mirror.
 - imports classifiable Discord Desktop cache messages with `wiretap`, including proven DMs under `@me`
 - publishes and imports private Git-backed archive snapshots for org-wide read access
 - browses stored messages and local DMs in a terminal archive UI
-- exposes `metadata --json`, `status --json`, `diagnostics --json`, and `doctor --json` for local
+- exposes `metadata --json`, `status --json`, `diagnostics --json`, `coverage --json`, and `doctor --json` for local
   launchers, automation, and CI
 - reports Worker-fronted cloud archive status in read-only mode without
   touching local SQLite
@@ -319,6 +319,7 @@ discrawl wiretap --path "$HOME/Library/Application Support/discord"
 discrawl wiretap --dry-run
 discrawl wiretap --full-cache
 discrawl wiretap --watch-every 2m
+discrawl wiretap --watch-every 10s --stats --json
 ```
 
 Notes:
@@ -333,6 +334,11 @@ Notes:
 - use `--full-cache` or `desktop.full_cache = true` for exhaustive Chromium cache import when you want slower historical guild-cache archaeology
 - does not extract, store, or print Discord auth tokens
 - `--max-file-bytes` skips unusually large files; default is 64 MiB
+
+`--stats` adds a coverage snapshot after each import pass. With
+`--watch-every`, later snapshots include message/channel deltas from the
+previous pass. Discrawl persists only compact aggregate wiretap counters for
+this report; raw cache payloads and file paths are not added to coverage state.
 
 ### `search`
 
@@ -515,6 +521,25 @@ Shows local archive status.
 ```bash
 discrawl status
 ```
+
+### `coverage`
+
+Reports how much of the local archive is actually usable without running a
+sync or authenticating to Discord.
+
+```bash
+discrawl coverage
+discrawl coverage --guild 123456789012345678
+discrawl coverage --json
+```
+
+The report covers every guild by default and includes per-guild and
+per-channel message counts and time bounds, message-capable channel counts,
+history-complete markers, last bot/wiretap activity, and the most recent
+wiretap skipped-message/channel counters. "Synthetic" means Discrawl only has
+an id-derived placeholder such as `channel-123456` or `dm-123456`; "named"
+means it has a useful channel or conversation label. Soft-deleted messages are
+excluded.
 
 ### `diagnostics`
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -405,6 +405,7 @@ discrawl [global flags] <command> [args]
 - `members`
 - `channels`
 - `status`
+- `coverage`
 - `doctor`
 
 ### `init`
@@ -471,6 +472,7 @@ Expected flags:
 - `--watch-every <duration>`
 - `--max-file-bytes <bytes>`
 - `--full-cache`
+- `--stats`
 
 Requirements:
 
@@ -479,6 +481,8 @@ Requirements:
 - scan bounded local files only
 - default to route-bearing HTTP cache entries; exhaustive Chromium cache scans require explicit full-cache mode
 - store sanitized raw metadata, not full arbitrary cache blobs
+- persist only compact aggregate counters for coverage reporting; keep raw cache paths and payloads out of report state
+- with `--watch-every --stats`, include archive count deltas after the first pass
 
 ### `search`
 
@@ -535,6 +539,24 @@ Must show:
 - last sync time
 - last tail event time
 - embedding backlog
+
+### `coverage`
+
+Must show:
+
+- every guild by default, or one exact guild selected with `--guild`
+- total and per-guild message, channel, and message-capable channel counts
+- useful named versus id-placeholder synthetic channel counts
+- per-channel message counts and earliest/latest message timestamps
+- history-complete markers when present
+- last bot sync and wiretap import times
+- persisted skipped-message and skipped-channel counters from the latest successful wiretap pass
+
+Requirements:
+
+- read-only; never authenticate, sync, or update a share
+- human table and stable JSON output
+- exclude soft-deleted messages from coverage counts
 
 ### `doctor`
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -19,7 +19,7 @@ Mirror Discord guilds into local SQLite. Search server history without depending
 - **Just want to read a shared archive?** Use [`subscribe`](commands/subscribe.html) for Git snapshots, or [`subscribe-cloud`](commands/subscribe-cloud.html) for a Worker-fronted archive - no Discord token needed.
 - **Need DM search?** [`wiretap`](commands/wiretap.html) imports local Discord Desktop cache.
 - **Want semantic search?** Configure [Embeddings](guides/embeddings.html), then run [`embed`](commands/embed.html).
-- **Wiring an agent or launcher?** `discrawl metadata --json`, `discrawl status --json`, `discrawl diagnostics --json`, `discrawl remote status`, and `discrawl doctor --json` expose the read-only crawlkit control surface.
+- **Wiring an agent or launcher?** `discrawl metadata --json`, `discrawl status --json`, `discrawl diagnostics --json`, `discrawl coverage --json`, `discrawl remote status`, and `discrawl doctor --json` expose the read-only crawlkit control surface.
 
 ## At a glance
 

--- a/docs/commands/coverage.md
+++ b/docs/commands/coverage.md
@@ -1,0 +1,54 @@
+# `coverage`
+
+Reports how much of the local archive is usable without authenticating to
+Discord or running a sync.
+
+## Usage
+
+```bash
+discrawl coverage
+discrawl coverage --guild 123456789012345678
+discrawl coverage --json
+```
+
+## Reports
+
+- every guild by default, or one exact guild selected with `--guild`
+- message, channel, and message-capable channel totals
+- named versus synthetic channel counts
+- per-channel message counts and earliest/latest timestamps
+- history-complete markers when known
+- last bot sync and wiretap import times
+- skipped-message and skipped-channel counts from the latest successful wiretap pass
+
+The human output uses a table per guild. JSON returns the same guild/channel
+rows plus aggregate totals for agent and script use. Soft-deleted messages do
+not count toward coverage.
+
+"Synthetic" means Discrawl only has an id-derived placeholder such as
+`channel-123456` or `dm-123456`. "Named" means it has a useful channel or
+conversation label. The two counts partition all channel rows, regardless of
+whether the label came from bot sync or Discord Desktop cache metadata.
+
+Coverage is local and read-only. It does not authenticate, start a sync, wait
+for a writer lock, or update a configured share. Persisted wiretap coverage
+state contains compact counters and timestamps only; `wiretap:*` state remains
+excluded from Git snapshots.
+
+## Watch progress
+
+Use [`wiretap`](wiretap.html) with `--stats` to attach a coverage snapshot to
+each import pass:
+
+```bash
+discrawl wiretap --watch-every 10s --stats --json
+```
+
+The first sample has no delta. Later samples include changes in messages,
+channels, named channels, and synthetic channels since the previous pass.
+
+## See also
+
+- [`wiretap`](wiretap.html) - import local Discord Desktop cache data
+- [`status`](status.html) - high-level archive and share status
+- [`diagnostics`](diagnostics.html) - SQLite integrity, WAL, freshness, and writer-lock checks

--- a/docs/commands/status.md
+++ b/docs/commands/status.md
@@ -22,6 +22,7 @@ discrawl status
 
 ## See also
 
+- [`coverage`](coverage.html) - per-guild/channel archive readiness and wiretap skip counts
 - [`diagnostics`](diagnostics.html) - read-only SQLite, WAL, freshness, and writer-lock checks
 - [`doctor`](doctor.html) - liveness check (config, auth, DB, FTS wiring)
 - [`remote`](remote.html) - direct Cloudflare remote archive checks

--- a/docs/commands/wiretap.md
+++ b/docs/commands/wiretap.md
@@ -14,6 +14,7 @@ discrawl wiretap --path "$HOME/Library/Application Support/discord"
 discrawl wiretap --dry-run
 discrawl wiretap --full-cache
 discrawl wiretap --watch-every 2m
+discrawl wiretap --watch-every 10s --stats --json
 ```
 
 ## Flags
@@ -22,6 +23,7 @@ discrawl wiretap --watch-every 2m
 - `--dry-run` - report what would be imported without writing anything
 - `--full-cache` - exhaustive Chromium HTTP cache import for historical guild-cache archaeology (slower)
 - `--watch-every <duration>` - keep importing on a periodic loop
+- `--stats` - attach a full archive coverage snapshot; watched samples after the first include deltas
 - `--max-file-bytes <n>` - skip unusually large files (default 64 MiB)
 
 ## Notes
@@ -34,6 +36,7 @@ discrawl wiretap --watch-every 2m
 - imports what Discord Desktop has cached locally, not complete live DM history
 - scans local `.ldb`, `.log`, `.json`, and `.txt` artifacts for Discord message JSON, plus route-bearing Chromium HTTP cache entries by default
 - does not extract, store, or print Discord auth tokens
+- persists only compact aggregate import counters for [`coverage`](coverage.html); raw cache paths and payloads are not added to coverage state
 
 ## Default desktop paths
 
@@ -43,5 +46,6 @@ discrawl wiretap --watch-every 2m
 ## See also
 
 - [Wiretap guide](../guides/wiretap.html)
+- [`coverage`](coverage.html)
 - [`dms`](dms.html)
 - [`sync`](sync.html)

--- a/docs/guides/data-storage.md
+++ b/docs/guides/data-storage.md
@@ -58,6 +58,7 @@ See [`sql`](../commands/sql.html).
 ## See also
 
 - [`status`](../commands/status.html) - high-level archive status
+- [`coverage`](../commands/coverage.html) - per-guild/channel archive readiness and wiretap progress counters
 - [`diagnostics`](../commands/diagnostics.html) - SQLite integrity, WAL, freshness, and writer-lock state
 - [`channels`](../commands/channels.html) - channel directory
 - [`members`](../commands/members.html) - member directory

--- a/docs/guides/wiretap.md
+++ b/docs/guides/wiretap.md
@@ -44,9 +44,10 @@ discrawl wiretap --path "$HOME/Library/Application Support/discord"
 discrawl wiretap --dry-run
 discrawl wiretap --full-cache
 discrawl wiretap --watch-every 2m
+discrawl wiretap --watch-every 10s --stats --json
 ```
 
-`--watch-every` keeps the import running on a periodic loop. `--dry-run` reports what would be imported without writing anything.
+`--watch-every` keeps the import running on a periodic loop. `--dry-run` reports what would be imported without writing anything. `--stats` attaches a [`coverage`](../commands/coverage.html) snapshot to each pass and reports deltas after the first watched sample.
 
 ## Default desktop paths
 
@@ -57,5 +58,6 @@ discrawl wiretap --watch-every 2m
 ## See also
 
 - [`wiretap`](../commands/wiretap.html)
+- [`coverage`](../commands/coverage.html)
 - [`dms`](../commands/dms.html) - convenience layer over `@me`
 - [Sync sources](sync-sources.html)

--- a/internal/cli/admin_commands.go
+++ b/internal/cli/admin_commands.go
@@ -354,15 +354,21 @@ func (r *runtime) runWiretap(args []string) error {
 	fullCache := fs.Bool("full-cache", r.cfg.Desktop.FullCache, "")
 	dryRun := fs.Bool("dry-run", false, "")
 	watchEvery := fs.Duration("watch-every", 0, "")
+	showStats := fs.Bool("stats", false, "")
+	jsonOut := fs.Bool("json", false, "")
 	if err := fs.Parse(args); err != nil {
 		return usageErr(err)
 	}
 	if fs.NArg() != 0 {
 		return usageErr(errors.New("wiretap takes flags only"))
 	}
+	if *jsonOut {
+		r.json = true
+	}
 	if *maxFileBytes <= 0 {
 		return usageErr(errors.New("--max-file-bytes must be positive"))
 	}
+	var previousCoverage *store.CoverageReport
 	runOnce := func(ctx context.Context) error {
 		stats, err := discorddesktop.Import(ctx, r.store, discorddesktop.Options{
 			Path:         *path,
@@ -373,6 +379,19 @@ func (r *runtime) runWiretap(args []string) error {
 		})
 		if err != nil {
 			return err
+		}
+		if *showStats {
+			coverage, err := r.store.Coverage(ctx, "", r.nowUTC())
+			if err != nil {
+				return err
+			}
+			progress := wiretapProgress{Import: stats, Coverage: coverage}
+			if previousCoverage != nil {
+				delta := store.CoverageDeltaSince(coverage, *previousCoverage)
+				progress.Delta = &delta
+			}
+			previousCoverage = &coverage
+			return r.print(progress)
 		}
 		return r.print(stats)
 	}

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -285,6 +285,11 @@ func (r *runtime) dispatch(rest []string) error {
 		return r.withLocalStoreReadOnly(func() error { return r.runStatus(rest[1:]) })
 	case "diagnostics":
 		return r.withConfig(func() error { return r.runDiagnostics(rest[1:]) })
+	case "coverage":
+		if hasHelpFlag(rest[1:]) {
+			return printCommandUsage(r.stdout, []string{"coverage"})
+		}
+		return r.withLocalStoreReadOnly(func() error { return r.runCoverage(rest[1:]) })
 	case "report":
 		return r.withLocalStoreRead(true, func() error { return r.runReport(rest[1:]) })
 	case "publish":

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -616,6 +616,72 @@ func TestWiretapImportsDesktopDirectMessages(t *testing.T) {
 	require.Contains(t, out.String(), "secret DM launch plan")
 }
 
+func TestCoverageHumanJSONAndGuildFilter(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	cfg, cfgPath := writeTestConfig(t, dir)
+	s := seedCLIStore(t, cfg.DBPath)
+	require.NoError(t, s.UpsertChannel(ctx, store.ChannelRecord{ID: "c2", GuildID: "g1", Kind: "text", Name: "channel-c2", RawJSON: `{"source":"discord_desktop"}`}))
+	require.NoError(t, s.SetSyncState(ctx, "channel:c1:history_complete", "1"))
+	require.NoError(t, s.SetWiretapImportStats(ctx, store.WiretapImportStats{SkippedMessages: 3, SkippedChannels: 2, FinishedAt: time.Date(2026, 7, 1, 8, 0, 0, 0, time.UTC)}))
+	require.NoError(t, s.Close())
+
+	var out bytes.Buffer
+	require.NoError(t, Run(ctx, []string{"--config", cfgPath, "coverage"}, &out, &bytes.Buffer{}))
+	require.Contains(t, out.String(), "named_channels=1")
+	require.Contains(t, out.String(), "synthetic_channels=1")
+	require.Contains(t, out.String(), "wiretap_skipped_messages=3")
+	require.Contains(t, out.String(), "general")
+
+	out.Reset()
+	require.NoError(t, Run(ctx, []string{"--config", cfgPath, "coverage", "--guild", "g1", "--json"}, &out, &bytes.Buffer{}))
+	var report store.CoverageReport
+	require.NoError(t, json.Unmarshal(out.Bytes(), &report))
+	require.Equal(t, 1, report.Totals.GuildCount)
+	require.Equal(t, 2, report.Totals.ChannelCount)
+	require.Equal(t, 3, report.Wiretap.SkippedMessages)
+
+	err := Run(ctx, []string{"--config", cfgPath, "coverage", "--guild", "missing"}, &bytes.Buffer{}, &bytes.Buffer{})
+	require.ErrorContains(t, err, `guild "missing" not found`)
+}
+
+func TestCoverageMissingArchiveFailsWithoutCreatingDatabase(t *testing.T) {
+	dir := t.TempDir()
+	cfg, cfgPath := writeTestConfig(t, dir)
+	err := Run(context.Background(), []string{"--config", cfgPath, "coverage"}, &bytes.Buffer{}, &bytes.Buffer{})
+	require.Equal(t, 5, ExitCode(err))
+	require.ErrorContains(t, err, "coverage requires a local SQLite archive")
+	require.NoFileExists(t, cfg.DBPath)
+}
+
+func TestWiretapStatsIncludesCoverage(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.toml")
+	dbPath := filepath.Join(dir, "discrawl.db")
+	desktopPath := filepath.Join(dir, "discord")
+	require.NoError(t, os.MkdirAll(filepath.Join(desktopPath, "IndexedDB"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(desktopPath, "IndexedDB", "000001.log"), []byte(`{"id":"111111111111111111","type":1,"recipients":[{"id":"222222222222222222","username":"alice","global_name":"Alice"}]}
+{"id":"333333333333333333","channel_id":"111111111111111111","content":"coverage proof","timestamp":"2026-04-23T18:20:43Z","author":{"id":"222222222222222222","username":"alice"}}`), 0o600))
+	cfg := config.Default()
+	cfg.DBPath = dbPath
+	cfg.Desktop.Path = desktopPath
+	cfg.Discord.TokenSource = "none"
+	require.NoError(t, config.Write(cfgPath, cfg))
+
+	var out bytes.Buffer
+	require.NoError(t, Run(ctx, []string{"--config", cfgPath, "wiretap", "--stats", "--json"}, &out, &bytes.Buffer{}))
+	var progress struct {
+		Import   discorddesktop.Stats `json:"import"`
+		Coverage store.CoverageReport `json:"coverage"`
+		Delta    *store.CoverageDelta `json:"delta"`
+	}
+	require.NoError(t, json.Unmarshal(out.Bytes(), &progress))
+	require.Equal(t, 1, progress.Import.Messages)
+	require.Equal(t, 1, progress.Coverage.Totals.MessageCount)
+	require.Nil(t, progress.Delta)
+}
+
 func TestDiscordTUIRowsIncludePaneMetadata(t *testing.T) {
 	rows := discordTUIRows([]store.MessageRow{{
 		MessageID:       "m1",
@@ -3881,6 +3947,7 @@ func TestCommandUsageBranches(t *testing.T) {
 		{[]string{"--config", cfgPath, "wiretap", "extra"}, "wiretap takes flags only"},
 		{[]string{"--config", cfgPath, "wiretap", "--max-file-bytes", "0"}, "--max-file-bytes must be positive"},
 		{[]string{"--config", cfgPath, "wiretap", "--watch-every", "1ms"}, "--watch-every must be at least 1s"},
+		{[]string{"--config", cfgPath, "coverage", "extra"}, "coverage takes flags only"},
 		{[]string{"--config", cfgPath, "members"}, "members requires a subcommand"},
 		{[]string{"--config", cfgPath, "members", "search"}, "members search requires a query"},
 		{[]string{"--config", cfgPath, "members", "bogus"}, `unknown members subcommand "bogus"`},
@@ -3911,6 +3978,7 @@ func TestCommandHelpDoesNotOpenConfigOrStore(t *testing.T) {
 		{"--config", filepath.Join(t.TempDir(), "missing.toml"), "search", "--help"},
 		{"--config", filepath.Join(t.TempDir(), "missing.toml"), "messages", "--help"},
 		{"--config", filepath.Join(t.TempDir(), "missing.toml"), "sql", "--help"},
+		{"--config", filepath.Join(t.TempDir(), "missing.toml"), "coverage", "--help"},
 	} {
 		var stdout, stderr bytes.Buffer
 		require.NoError(t, Run(context.Background(), args, &stdout, &stderr), "args=%v", args)

--- a/internal/cli/control_commands.go
+++ b/internal/cli/control_commands.go
@@ -38,11 +38,12 @@ func (r *runtime) runMetadata(args []string) error {
 		DefaultLogs:     cfg.LogDir,
 		DefaultShare:    cfg.Share.RepoPath,
 	}
-	manifest.Capabilities = []string{"metadata", "status", "diagnostics", "doctor", "sync", "tap", "tui", "git-share", "cloud-remote", "cloud-publish", "sql", "embeddings"}
+	manifest.Capabilities = []string{"metadata", "status", "diagnostics", "coverage", "doctor", "sync", "tap", "tui", "git-share", "cloud-remote", "cloud-publish", "sql", "embeddings"}
 	manifest.Privacy = control.Privacy{ContainsPrivateMessages: true, ExportsSecrets: false, LocalOnlyScopes: []string{"discord", "desktop-cache", "sqlite", "git-share"}}
 	manifest.Commands = map[string]control.Command{
 		"status":          {Title: "Status", Argv: []string{"discrawl", "status", "--json"}, JSON: true},
 		"diagnostics":     {Title: "Diagnostics", Argv: []string{"discrawl", "diagnostics", "--json"}, JSON: true},
+		"coverage":        {Title: "Archive coverage", Argv: []string{"discrawl", "coverage", "--json"}, JSON: true},
 		"check-update":    {Title: "Check for updates", Argv: []string{"discrawl", "check-update", "--json"}, JSON: true},
 		"doctor":          {Title: "Doctor", Argv: []string{"discrawl", "doctor", "--json"}, JSON: true},
 		"sync":            {Title: "Sync", Argv: []string{"discrawl", "--json", "sync"}, JSON: true, Mutates: true},

--- a/internal/cli/coverage.go
+++ b/internal/cli/coverage.go
@@ -1,0 +1,41 @@
+package cli
+
+import (
+	"errors"
+	"flag"
+	"io"
+	"strings"
+
+	"github.com/openclaw/discrawl/internal/discorddesktop"
+	"github.com/openclaw/discrawl/internal/store"
+)
+
+type wiretapProgress struct {
+	Import   discorddesktop.Stats `json:"import"`
+	Coverage store.CoverageReport `json:"coverage"`
+	Delta    *store.CoverageDelta `json:"delta,omitempty"`
+}
+
+func (r *runtime) runCoverage(args []string) error {
+	fs := flag.NewFlagSet("coverage", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	guildID := fs.String("guild", "", "")
+	jsonOut := fs.Bool("json", false, "")
+	if err := fs.Parse(args); err != nil {
+		return usageErr(err)
+	}
+	if fs.NArg() != 0 {
+		return usageErr(errors.New("coverage takes flags only"))
+	}
+	if *jsonOut {
+		r.json = true
+	}
+	if r.store == nil {
+		return dbErr(errors.New("coverage requires a local SQLite archive"))
+	}
+	report, err := r.store.Coverage(r.ctx, strings.TrimSpace(*guildID), r.nowUTC())
+	if err != nil {
+		return err
+	}
+	return r.print(report)
+}

--- a/internal/cli/output.go
+++ b/internal/cli/output.go
@@ -125,6 +125,7 @@ Commands:
   channels
   status
   diagnostics
+  coverage
   remote
   whoami
   report
@@ -147,6 +148,11 @@ func printCommandUsage(w io.Writer, args []string) error {
 }
 
 var commandUsage = map[string]string{
+	"coverage": `Usage:
+  discrawl coverage [--guild ID] [--json]
+
+Reports archive coverage across every guild by default, including named versus synthetic channels, message bounds, history-complete markers, and persisted wiretap skip counts.
+`,
 	"diagnostics": `Usage:
   discrawl diagnostics [--json]
 
@@ -299,6 +305,18 @@ func printHuman(w io.Writer, value any) error {
 		_, err := fmt.Fprintf(w, "path=%s\nvisited=%d\nfiles=%d\nskipped=%d\nunchanged=%d\nfast_skipped=%d\nobjects=%d\nguilds=%d\nchannels=%d\nmessages=%d\ndm_messages=%d\ndm_channels=%d\nguild_messages=%d\nskipped_messages=%d\nskipped_channels=%d\ncheckpoints=%d\nfull_cache=%t\ndry_run=%t\n",
 			v.Path, v.FilesVisited, v.FilesScanned, v.FilesSkipped, v.FilesUnchanged, v.CacheFilesFastSkipped, v.JSONObjects, v.Guilds, v.Channels, v.Messages, v.DMMessages, v.DMChannels, v.GuildMessages, v.SkippedMessages, v.SkippedChannels, v.Checkpoints, v.FullCache, v.DryRun)
 		return err
+	case store.CoverageReport:
+		return printCoverageHuman(w, v)
+	case wiretapProgress:
+		if _, err := fmt.Fprintf(w, "import_messages=%d\nimport_channels=%d\nimport_skipped_messages=%d\nimport_skipped_channels=%d\n", v.Import.Messages, v.Import.Channels, v.Import.SkippedMessages, v.Import.SkippedChannels); err != nil {
+			return err
+		}
+		if v.Delta != nil {
+			if _, err := fmt.Fprintf(w, "delta_messages=%d\ndelta_channels=%d\ndelta_named_channels=%d\ndelta_synthetic_channels=%d\n", v.Delta.Messages, v.Delta.Channels, v.Delta.NamedChannels, v.Delta.SyntheticChannels); err != nil {
+				return err
+			}
+		}
+		return printCoverageHuman(w, v.Coverage)
 	case store.Status:
 		_, err := fmt.Fprintf(w, "db=%s\nguilds=%d\nchannels=%d\nthreads=%d\nmessages=%d\nmembers=%d\nembedding_backlog=%d\nlast_sync=%s\nlast_tail_event=%s\n",
 			v.DBPath, v.GuildCount, v.ChannelCount, v.ThreadCount, v.MessageCount, v.MemberCount, v.EmbeddingBacklog,
@@ -596,6 +614,53 @@ func printHuman(w io.Writer, value any) error {
 	default:
 		return errors.New("no human printer")
 	}
+}
+
+func printCoverageHuman(w io.Writer, report store.CoverageReport) error {
+	if _, err := fmt.Fprintf(w, "guilds=%d\nchannels=%d\nmessage_channels=%d\nnamed_channels=%d\nsynthetic_channels=%d\nmessages=%d\nhistory_complete_channels=%d\nlast_bot_sync=%s\nlast_wiretap_import=%s\nwiretap_skipped_messages=%d\nwiretap_skipped_channels=%d\n",
+		report.Totals.GuildCount,
+		report.Totals.ChannelCount,
+		report.Totals.MessageChannelCount,
+		report.Totals.NamedChannelCount,
+		report.Totals.SyntheticChannelCount,
+		report.Totals.MessageCount,
+		report.Totals.HistoryCompleteChannelCount,
+		formatTime(report.LastBotSyncAt),
+		formatTime(report.Wiretap.LastImportAt),
+		report.Wiretap.SkippedMessages,
+		report.Wiretap.SkippedChannels,
+	); err != nil {
+		return err
+	}
+	for _, guild := range report.Guilds {
+		if _, err := fmt.Fprintf(w, "\n%s (%s): messages=%d channels=%d named=%d synthetic=%d first=%s last=%s\n",
+			guild.Name, guild.ID, guild.MessageCount, guild.ChannelCount,
+			guild.NamedChannelCount, guild.SyntheticChannelCount,
+			formatTime(guild.EarliestMessageAt), formatTime(guild.LatestMessageAt),
+		); err != nil {
+			return err
+		}
+		tw := tabwriter.NewWriter(w, 2, 4, 2, ' ', 0)
+		_, _ = fmt.Fprintln(tw, "CHANNEL\tID\tKIND\tSOURCE\tMESSAGES\tFIRST\tLAST\tHISTORY")
+		for _, channel := range guild.Channels {
+			source := "named"
+			if channel.Synthetic {
+				source = "synthetic"
+			}
+			history := "unknown"
+			if channel.HistoryComplete != nil && *channel.HistoryComplete {
+				history = "complete"
+			}
+			_, _ = fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%d\t%s\t%s\t%s\n",
+				channel.Name, channel.ID, channel.Kind, source, channel.MessageCount,
+				formatTime(channel.EarliestMessageAt), formatTime(channel.LatestMessageAt), history,
+			)
+		}
+		if err := tw.Flush(); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func formatTime(t time.Time) string {

--- a/internal/discorddesktop/import.go
+++ b/internal/discorddesktop/import.go
@@ -167,6 +167,9 @@ func Import(ctx context.Context, st *store.Store, opts Options) (Stats, error) {
 			return stats, err
 		}
 		stats.Checkpoints = 1
+		if err := saveCoverageStats(ctx, st, stats); err != nil {
+			return stats, err
+		}
 		return stats, nil
 	}
 	stats, err := scanAndImport(ctx, st, opts, state)
@@ -174,7 +177,24 @@ func Import(ctx context.Context, st *store.Store, opts Options) (Stats, error) {
 		return stats, err
 	}
 	stats.DryRun = opts.DryRun
+	if !opts.DryRun {
+		if err := saveCoverageStats(ctx, st, stats); err != nil {
+			return stats, err
+		}
+	}
 	return stats, nil
+}
+
+func saveCoverageStats(ctx context.Context, st *store.Store, stats Stats) error {
+	return st.SetWiretapImportStats(ctx, store.WiretapImportStats{
+		FilesScanned:    stats.FilesScanned,
+		Messages:        stats.Messages,
+		Channels:        stats.Channels,
+		SkippedMessages: stats.SkippedMessages,
+		SkippedChannels: stats.SkippedChannels,
+		StartedAt:       stats.StartedAt,
+		FinishedAt:      stats.FinishedAt,
+	})
 }
 
 func loadScanState(ctx context.Context, st *store.Store, opts Options) (scanState, error) {

--- a/internal/discorddesktop/import_test.go
+++ b/internal/discorddesktop/import_test.go
@@ -92,6 +92,13 @@ binary-ish {"t":"MESSAGE_CREATE","token":"do-not-store","d":{"id":"3333333333333
 	require.Equal(t, 1, stats.FilesScanned)
 	require.Equal(t, 1, stats.Messages)
 	require.Equal(t, 1, stats.Channels)
+	coverage, err := st.Coverage(ctx, DirectMessageGuildID, time.Date(2026, 4, 23, 18, 31, 0, 0, time.UTC))
+	require.NoError(t, err)
+	require.Equal(t, 1, coverage.Wiretap.FilesScanned)
+	require.Equal(t, 1, coverage.Wiretap.Messages)
+	require.Zero(t, coverage.Wiretap.SkippedMessages)
+	require.Equal(t, stats.FinishedAt, coverage.Wiretap.LastImportAt)
+	require.Equal(t, 1, coverage.Totals.MessageChannelCount)
 
 	results, err := st.SearchMessages(ctx, store.SearchOptions{Query: "launch", Limit: 10})
 	require.NoError(t, err)
@@ -176,6 +183,9 @@ func TestImportDryRunDoesNotWrite(t *testing.T) {
 	results, err := st.SearchMessages(ctx, store.SearchOptions{Query: "dry", Limit: 10})
 	require.NoError(t, err)
 	require.Empty(t, results)
+	rawStats, err := st.GetSyncState(ctx, "wiretap:last_stats:v1")
+	require.NoError(t, err)
+	require.Empty(t, rawStats)
 }
 
 func TestImportMissingDesktopPathIsEmpty(t *testing.T) {

--- a/internal/store/coverage.go
+++ b/internal/store/coverage.go
@@ -110,10 +110,10 @@ func (s *Store) Coverage(ctx context.Context, guildID string, generatedAt time.T
 	if err != nil {
 		return CoverageReport{}, fmt.Errorf("list coverage guilds: %w", err)
 	}
+	defer func() { _ = rows.Close() }()
 	for rows.Next() {
 		var guild CoverageGuild
 		if err := rows.Scan(&guild.ID, &guild.Name); err != nil {
-			_ = rows.Close()
 			return CoverageReport{}, fmt.Errorf("scan coverage guild: %w", err)
 		}
 		guild.Channels = []CoverageChannel{}

--- a/internal/store/coverage.go
+++ b/internal/store/coverage.go
@@ -1,0 +1,284 @@
+package store
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+)
+
+const wiretapStatsScope = "wiretap:last_stats:v1"
+
+const coverageQueryTimeout = 2 * time.Minute
+
+var messageChannelKinds = map[string]struct{}{
+	"text": {}, "news": {}, "announcement": {}, "dm": {}, "group_dm": {},
+	"thread_public": {}, "thread_private": {}, "thread_news": {}, "thread_announcement": {},
+}
+
+type CoverageReport struct {
+	GeneratedAt   time.Time       `json:"generated_at"`
+	Guilds        []CoverageGuild `json:"guilds"`
+	Totals        CoverageTotals  `json:"totals"`
+	LastBotSyncAt time.Time       `json:"last_bot_sync_at,omitzero"`
+	Wiretap       WiretapCoverage `json:"wiretap"`
+}
+
+type CoverageGuild struct {
+	ID                          string            `json:"id"`
+	Name                        string            `json:"name"`
+	MessageCount                int               `json:"message_count"`
+	ChannelCount                int               `json:"channel_count"`
+	MessageChannelCount         int               `json:"message_channel_count"`
+	NamedChannelCount           int               `json:"named_channel_count"`
+	SyntheticChannelCount       int               `json:"synthetic_channel_count"`
+	HistoryCompleteChannelCount int               `json:"history_complete_channel_count"`
+	EarliestMessageAt           time.Time         `json:"earliest_message_at,omitzero"`
+	LatestMessageAt             time.Time         `json:"latest_message_at,omitzero"`
+	Channels                    []CoverageChannel `json:"channels"`
+}
+
+type CoverageChannel struct {
+	ID                string    `json:"id"`
+	Name              string    `json:"name"`
+	Kind              string    `json:"kind"`
+	Synthetic         bool      `json:"synthetic"`
+	MessageCapable    bool      `json:"message_capable"`
+	MessageCount      int       `json:"message_count"`
+	EarliestMessageAt time.Time `json:"earliest_message_at,omitzero"`
+	LatestMessageAt   time.Time `json:"latest_message_at,omitzero"`
+	HistoryComplete   *bool     `json:"history_complete,omitempty"`
+}
+
+type CoverageTotals struct {
+	GuildCount                  int `json:"guild_count"`
+	MessageCount                int `json:"message_count"`
+	ChannelCount                int `json:"channel_count"`
+	MessageChannelCount         int `json:"message_channel_count"`
+	NamedChannelCount           int `json:"named_channel_count"`
+	SyntheticChannelCount       int `json:"synthetic_channel_count"`
+	HistoryCompleteChannelCount int `json:"history_complete_channel_count"`
+}
+
+type WiretapImportStats struct {
+	FilesScanned    int       `json:"files_scanned"`
+	Messages        int       `json:"messages"`
+	Channels        int       `json:"channels"`
+	SkippedMessages int       `json:"skipped_messages"`
+	SkippedChannels int       `json:"skipped_channels"`
+	StartedAt       time.Time `json:"started_at"`
+	FinishedAt      time.Time `json:"finished_at"`
+}
+
+type WiretapCoverage struct {
+	LastImportAt    time.Time `json:"last_import_at,omitzero"`
+	FilesScanned    int       `json:"files_scanned"`
+	Messages        int       `json:"messages"`
+	Channels        int       `json:"channels"`
+	SkippedMessages int       `json:"skipped_messages"`
+	SkippedChannels int       `json:"skipped_channels"`
+}
+
+type CoverageDelta struct {
+	Messages          int `json:"messages"`
+	Channels          int `json:"channels"`
+	NamedChannels     int `json:"named_channels"`
+	SyntheticChannels int `json:"synthetic_channels"`
+}
+
+func (s *Store) SetWiretapImportStats(ctx context.Context, stats WiretapImportStats) error {
+	body, err := json.Marshal(stats)
+	if err != nil {
+		return fmt.Errorf("encode wiretap coverage stats: %w", err)
+	}
+	return s.SetSyncState(ctx, wiretapStatsScope, string(body))
+}
+
+func (s *Store) Coverage(ctx context.Context, guildID string, generatedAt time.Time) (CoverageReport, error) {
+	report := CoverageReport{GeneratedAt: generatedAt.UTC(), Guilds: []CoverageGuild{}}
+	queryCtx, cancel := context.WithTimeout(ctx, coverageQueryTimeout)
+	defer cancel()
+
+	rows, err := s.db.QueryContext(queryCtx, `
+		select id, name
+		from guilds
+		where ? = '' or id = ?
+		order by lower(name), id
+	`, guildID, guildID)
+	if err != nil {
+		return CoverageReport{}, fmt.Errorf("list coverage guilds: %w", err)
+	}
+	for rows.Next() {
+		var guild CoverageGuild
+		if err := rows.Scan(&guild.ID, &guild.Name); err != nil {
+			_ = rows.Close()
+			return CoverageReport{}, fmt.Errorf("scan coverage guild: %w", err)
+		}
+		guild.Channels = []CoverageChannel{}
+		report.Guilds = append(report.Guilds, guild)
+	}
+	if err := rows.Close(); err != nil {
+		return CoverageReport{}, fmt.Errorf("close coverage guild rows: %w", err)
+	}
+	if err := rows.Err(); err != nil {
+		return CoverageReport{}, fmt.Errorf("list coverage guilds: %w", err)
+	}
+	if guildID != "" && len(report.Guilds) == 0 {
+		return CoverageReport{}, fmt.Errorf("guild %q not found", guildID)
+	}
+
+	guilds := make(map[string]*CoverageGuild, len(report.Guilds))
+	for i := range report.Guilds {
+		guilds[report.Guilds[i].ID] = &report.Guilds[i]
+	}
+	channelRows, err := s.db.QueryContext(queryCtx, `
+		select
+			c.id, c.guild_id, c.name, c.kind,
+			case when exists (
+				select 1 from sync_state s
+				where s.scope = 'channel:' || c.id || ':history_complete'
+			) then 1 else 0 end,
+			count(m.id), coalesce(min(m.created_at), ''), coalesce(max(m.created_at), '')
+		from channels c
+		left join messages m on m.channel_id = c.id and m.deleted_at is null
+		where ? = '' or c.guild_id = ?
+		group by c.id, c.guild_id, c.name, c.kind
+		order by c.guild_id, count(m.id) desc, lower(c.name), c.id
+	`, guildID, guildID)
+	if err != nil {
+		return CoverageReport{}, fmt.Errorf("query channel coverage: %w", err)
+	}
+	defer func() { _ = channelRows.Close() }()
+	for channelRows.Next() {
+		var channel CoverageChannel
+		var rowGuildID, earliest, latest string
+		var historyComplete int
+		if err := channelRows.Scan(
+			&channel.ID, &rowGuildID, &channel.Name, &channel.Kind,
+			&historyComplete, &channel.MessageCount, &earliest, &latest,
+		); err != nil {
+			return CoverageReport{}, fmt.Errorf("scan channel coverage: %w", err)
+		}
+		channel.Synthetic = isSyntheticChannel(channel.ID, channel.Name)
+		_, channel.MessageCapable = messageChannelKinds[channel.Kind]
+		channel.EarliestMessageAt = parseTime(earliest)
+		channel.LatestMessageAt = parseTime(latest)
+		if historyComplete == 1 {
+			complete := true
+			channel.HistoryComplete = &complete
+		}
+		guild := guilds[rowGuildID]
+		if guild == nil {
+			continue
+		}
+		guild.Channels = append(guild.Channels, channel)
+		guild.ChannelCount++
+		guild.MessageCount += channel.MessageCount
+		if channel.MessageCapable {
+			guild.MessageChannelCount++
+		}
+		if channel.Synthetic {
+			guild.SyntheticChannelCount++
+		} else {
+			guild.NamedChannelCount++
+		}
+		if channel.HistoryComplete != nil {
+			guild.HistoryCompleteChannelCount++
+		}
+		guild.EarliestMessageAt = earlierNonZero(guild.EarliestMessageAt, channel.EarliestMessageAt)
+		guild.LatestMessageAt = later(guild.LatestMessageAt, channel.LatestMessageAt)
+	}
+	if err := channelRows.Err(); err != nil {
+		return CoverageReport{}, fmt.Errorf("query channel coverage: %w", err)
+	}
+
+	report.Totals.GuildCount = len(report.Guilds)
+	for i := range report.Guilds {
+		guild := &report.Guilds[i]
+		sort.SliceStable(guild.Channels, func(i, j int) bool {
+			if guild.Channels[i].MessageCount != guild.Channels[j].MessageCount {
+				return guild.Channels[i].MessageCount > guild.Channels[j].MessageCount
+			}
+			if guild.Channels[i].Name != guild.Channels[j].Name {
+				return strings.ToLower(guild.Channels[i].Name) < strings.ToLower(guild.Channels[j].Name)
+			}
+			return guild.Channels[i].ID < guild.Channels[j].ID
+		})
+		report.Totals.MessageCount += guild.MessageCount
+		report.Totals.ChannelCount += guild.ChannelCount
+		report.Totals.MessageChannelCount += guild.MessageChannelCount
+		report.Totals.NamedChannelCount += guild.NamedChannelCount
+		report.Totals.SyntheticChannelCount += guild.SyntheticChannelCount
+		report.Totals.HistoryCompleteChannelCount += guild.HistoryCompleteChannelCount
+	}
+	if err := s.loadCoverageState(ctx, &report); err != nil {
+		return CoverageReport{}, err
+	}
+	return report, nil
+}
+
+func (s *Store) loadCoverageState(ctx context.Context, report *CoverageReport) error {
+	lastBotSync, err := s.GetSyncState(ctx, "sync:last_success")
+	if err != nil {
+		return fmt.Errorf("read last bot sync: %w", err)
+	}
+	report.LastBotSyncAt = parseTime(lastBotSync)
+	lastImport, err := s.GetSyncState(ctx, "wiretap:last_import")
+	if err != nil {
+		return fmt.Errorf("read last wiretap import: %w", err)
+	}
+	report.Wiretap.LastImportAt = parseTime(lastImport)
+	rawStats, err := s.GetSyncState(ctx, wiretapStatsScope)
+	if err != nil {
+		return fmt.Errorf("read wiretap coverage stats: %w", err)
+	}
+	if strings.TrimSpace(rawStats) == "" {
+		return nil
+	}
+	var stats WiretapImportStats
+	if err := json.Unmarshal([]byte(rawStats), &stats); err != nil {
+		return fmt.Errorf("decode wiretap coverage stats: %w", err)
+	}
+	report.Wiretap.FilesScanned = stats.FilesScanned
+	report.Wiretap.Messages = stats.Messages
+	report.Wiretap.Channels = stats.Channels
+	report.Wiretap.SkippedMessages = stats.SkippedMessages
+	report.Wiretap.SkippedChannels = stats.SkippedChannels
+	if !stats.FinishedAt.IsZero() {
+		report.Wiretap.LastImportAt = stats.FinishedAt.UTC()
+	}
+	return nil
+}
+
+func CoverageDeltaSince(current, previous CoverageReport) CoverageDelta {
+	return CoverageDelta{
+		Messages:          current.Totals.MessageCount - previous.Totals.MessageCount,
+		Channels:          current.Totals.ChannelCount - previous.Totals.ChannelCount,
+		NamedChannels:     current.Totals.NamedChannelCount - previous.Totals.NamedChannelCount,
+		SyntheticChannels: current.Totals.SyntheticChannelCount - previous.Totals.SyntheticChannelCount,
+	}
+}
+
+func isSyntheticChannel(id, name string) bool {
+	suffix := id
+	if len(suffix) > 6 {
+		suffix = suffix[len(suffix)-6:]
+	}
+	return name == "channel-"+suffix || name == "dm-"+suffix
+}
+
+func earlierNonZero(a, b time.Time) time.Time {
+	if a.IsZero() || (!b.IsZero() && b.Before(a)) {
+		return b
+	}
+	return a
+}
+
+func later(a, b time.Time) time.Time {
+	if b.After(a) {
+		return b
+	}
+	return a
+}

--- a/internal/store/coverage_test.go
+++ b/internal/store/coverage_test.go
@@ -1,0 +1,80 @@
+package store
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCoverageReportsGuildChannelAndWiretapState(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	s, err := Open(ctx, filepath.Join(t.TempDir(), "discrawl.db"))
+	require.NoError(t, err)
+	defer func() { _ = s.Close() }()
+
+	require.NoError(t, s.UpsertGuild(ctx, GuildRecord{ID: "g1", Name: "Guild One", RawJSON: `{}`}))
+	require.NoError(t, s.UpsertGuild(ctx, GuildRecord{ID: "g2", Name: "Guild Two", RawJSON: `{}`}))
+	require.NoError(t, s.UpsertChannel(ctx, ChannelRecord{ID: "c1", GuildID: "g1", Kind: "text", Name: "general", RawJSON: `{}`}))
+	require.NoError(t, s.UpsertChannel(ctx, ChannelRecord{ID: "c2", GuildID: "g1", Kind: "text", Name: "channel-c2", RawJSON: `{"source":"discord_desktop"}`}))
+	require.NoError(t, s.UpsertChannel(ctx, ChannelRecord{ID: "v1", GuildID: "g1", Kind: "voice", Name: "Voice", RawJSON: `{}`}))
+	for _, message := range []MessageRecord{
+		{ID: "m1", GuildID: "g1", ChannelID: "c1", CreatedAt: "2026-06-01T10:00:00Z", Content: "one", NormalizedContent: "one", RawJSON: `{}`},
+		{ID: "m2", GuildID: "g1", ChannelID: "c1", CreatedAt: "2026-06-02T10:00:00Z", Content: "two", NormalizedContent: "two", RawJSON: `{}`},
+		{ID: "m3", GuildID: "g1", ChannelID: "c2", CreatedAt: "2026-06-03T10:00:00Z", Content: "three", NormalizedContent: "three", RawJSON: `{}`},
+	} {
+		require.NoError(t, s.UpsertMessage(ctx, message))
+	}
+	require.NoError(t, s.SetSyncState(ctx, "channel:c1:history_complete", "1"))
+	require.NoError(t, s.SetSyncState(ctx, "sync:last_success", "2026-06-04T10:00:00Z"))
+	require.NoError(t, s.SetSyncState(ctx, "wiretap:last_import", "2026-06-04T11:00:00Z"))
+	require.NoError(t, s.SetWiretapImportStats(ctx, WiretapImportStats{
+		FilesScanned: 4, Messages: 3, Channels: 2, SkippedMessages: 5, SkippedChannels: 6,
+		FinishedAt: time.Date(2026, 6, 4, 12, 0, 0, 0, time.UTC),
+	}))
+
+	generatedAt := time.Date(2026, 6, 5, 12, 0, 0, 0, time.UTC)
+	report, err := s.Coverage(ctx, "", generatedAt)
+	require.NoError(t, err)
+	require.Equal(t, generatedAt, report.GeneratedAt)
+	require.Equal(t, CoverageTotals{
+		GuildCount: 2, MessageCount: 3, ChannelCount: 3, MessageChannelCount: 2,
+		NamedChannelCount: 2, SyntheticChannelCount: 1, HistoryCompleteChannelCount: 1,
+	}, report.Totals)
+	require.Equal(t, time.Date(2026, 6, 4, 10, 0, 0, 0, time.UTC), report.LastBotSyncAt)
+	require.Equal(t, 5, report.Wiretap.SkippedMessages)
+	require.Equal(t, 6, report.Wiretap.SkippedChannels)
+	require.Equal(t, time.Date(2026, 6, 4, 12, 0, 0, 0, time.UTC), report.Wiretap.LastImportAt)
+	require.Len(t, report.Guilds, 2)
+	require.Equal(t, "g1", report.Guilds[0].ID)
+	require.Equal(t, 3, report.Guilds[0].MessageCount)
+	require.Equal(t, time.Date(2026, 6, 1, 10, 0, 0, 0, time.UTC), report.Guilds[0].EarliestMessageAt)
+	require.Equal(t, time.Date(2026, 6, 3, 10, 0, 0, 0, time.UTC), report.Guilds[0].LatestMessageAt)
+	require.Equal(t, "c1", report.Guilds[0].Channels[0].ID)
+	require.NotNil(t, report.Guilds[0].Channels[0].HistoryComplete)
+	require.True(t, *report.Guilds[0].Channels[0].HistoryComplete)
+	require.True(t, report.Guilds[0].Channels[1].Synthetic)
+
+	filtered, err := s.Coverage(ctx, "g2", generatedAt)
+	require.NoError(t, err)
+	require.Equal(t, CoverageTotals{GuildCount: 1}, filtered.Totals)
+	require.Equal(t, "g2", filtered.Guilds[0].ID)
+	_, err = s.Coverage(ctx, "missing", generatedAt)
+	require.ErrorContains(t, err, `guild "missing" not found`)
+}
+
+func TestCoverageDeltaSince(t *testing.T) {
+	previous := CoverageReport{Totals: CoverageTotals{MessageCount: 4, ChannelCount: 3, NamedChannelCount: 2, SyntheticChannelCount: 1}}
+	current := CoverageReport{Totals: CoverageTotals{MessageCount: 7, ChannelCount: 4, NamedChannelCount: 4, SyntheticChannelCount: 0}}
+	require.Equal(t, CoverageDelta{Messages: 3, Channels: 1, NamedChannels: 2, SyntheticChannels: -1}, CoverageDeltaSince(current, previous))
+}
+
+func TestSyntheticChannelClassificationUsesGeneratedPlaceholder(t *testing.T) {
+	require.True(t, isSyntheticChannel("123456123456", "channel-123456"))
+	require.True(t, isSyntheticChannel("123456123456", "dm-123456"))
+	require.False(t, isSyntheticChannel("123456123456", "general"))
+	require.False(t, isSyntheticChannel("123456123456", "channel-other"))
+}


### PR DESCRIPTION
## Summary

- add read-only `discrawl coverage` human/JSON reports across all guilds or one exact guild
- report per-guild/channel counts and bounds, named versus id-placeholder channels, history-complete markers, and bot/wiretap freshness
- persist compact aggregate wiretap counters and add `wiretap --stats` snapshots with watch-mode deltas
- document the stable contract and expose coverage in control metadata

## Safety

- coverage opens SQLite read-only, never authenticates or updates a share, and fails visibly when the archive or requested guild is missing
- persisted wiretap state contains counters and timestamps only; `wiretap:*` state remains excluded from Git snapshots
- dry-run imports do not persist coverage state

## Proof

- exact head `25ede6f2c75777cc337c21fa4e9d759b6e18e6e6`
- disposable synthetic Discord Desktop cache/archive: exact-guild JSON and human output; named/synthetic transition; per-channel bounds; missing-guild failure; persisted aggregate-only state
- read-only proof: SQLite SHA-256 unchanged before/after `coverage --guild ... --json`
- watched second pass: messages `+1`, named channels `+1`, synthetic channels `-1`

## Validation

- `GOWORK=off go test -count=1 ./...`
- `GOWORK=off go test -count=1 -race ./...`
- `GOWORK=off go vet ./...`
- `golangci-lint run ./...`
- Linux amd64 and Windows amd64 cross-builds
- docs site build
- autoreview clean after fixes for DM message-channel accounting, missing-archive handling, and query-row cleanup

Fixes #101
