### PR TITLE
Add durable failure diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Add read-only `diagnostics` output for SQLite integrity, WAL size, archive freshness, and authoritative Discrawl writer-lock ownership.
 - Add read-only archive coverage reporting with per-guild/channel bounds, named-versus-synthetic channel counts, persisted wiretap skip counters, and watch-mode deltas via `wiretap --stats`.
 - Preserve fetched attachment media metadata when duplicate attachment snapshots refresh the singleton attachment row. Thanks @agent-eli.
+- Add a local-only failure ledger with row-level write context, retry/resolution tracking, JSON queries, and known-failure coverage counts.
 
 ## 0.11.3 - 2026-06-23
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Wiretap DMs stay local and are never exported to the Git-backed snapshot mirror.
 - imports classifiable Discord Desktop cache messages with `wiretap`, including proven DMs under `@me`
 - publishes and imports private Git-backed archive snapshots for org-wide read access
 - browses stored messages and local DMs in a terminal archive UI
-- exposes `metadata --json`, `status --json`, `diagnostics --json`, `coverage --json`, and `doctor --json` for local
+- exposes `metadata --json`, `status --json`, `diagnostics --json`, `coverage --json`, `failures --json`, and `doctor --json` for local
   launchers, automation, and CI
 - reports Worker-fronted cloud archive status in read-only mode without
   touching local SQLite
@@ -536,10 +536,26 @@ discrawl coverage --json
 The report covers every guild by default and includes per-guild and
 per-channel message counts and time bounds, message-capable channel counts,
 history-complete markers, last bot/wiretap activity, and the most recent
-wiretap skipped-message/channel counters. "Synthetic" means Discrawl only has
+wiretap skipped-message/channel counters. Unresolved known failures are counted
+per guild/channel so a failed attempt is distinguishable from unattempted data. "Synthetic" means Discrawl only has
 an id-derived placeholder such as `channel-123456` or `dm-123456`; "named"
 means it has a useful channel or conversation label. Soft-deleted messages are
 excluded.
+
+### `failures`
+
+Lists unresolved local sync, wiretap import, media, embedding, and row-write
+failures with the available guild/channel/message/attachment identifiers.
+
+```bash
+discrawl failures
+discrawl failures --source wiretap --json
+discrawl failures --all --limit 200
+```
+
+Repeated failures increment `retry_count`; successful later ingestion marks
+matching rows resolved. Resolved history is retained for 90 days. The ledger is
+local-only and excluded from Git snapshots.
 
 ### `diagnostics`
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -19,7 +19,7 @@ Mirror Discord guilds into local SQLite. Search server history without depending
 - **Just want to read a shared archive?** Use [`subscribe`](commands/subscribe.html) for Git snapshots, or [`subscribe-cloud`](commands/subscribe-cloud.html) for a Worker-fronted archive - no Discord token needed.
 - **Need DM search?** [`wiretap`](commands/wiretap.html) imports local Discord Desktop cache.
 - **Want semantic search?** Configure [Embeddings](guides/embeddings.html), then run [`embed`](commands/embed.html).
-- **Wiring an agent or launcher?** `discrawl metadata --json`, `discrawl status --json`, `discrawl diagnostics --json`, `discrawl coverage --json`, `discrawl remote status`, and `discrawl doctor --json` expose the read-only crawlkit control surface.
+- **Wiring an agent or launcher?** `discrawl metadata --json`, `discrawl status --json`, `discrawl diagnostics --json`, `discrawl coverage --json`, `discrawl failures --json`, `discrawl remote status`, and `discrawl doctor --json` expose the read-only crawlkit control surface.
 
 ## At a glance
 

--- a/docs/commands/coverage.md
+++ b/docs/commands/coverage.md
@@ -20,6 +20,7 @@ discrawl coverage --json
 - history-complete markers when known
 - last bot sync and wiretap import times
 - skipped-message and skipped-channel counts from the latest successful wiretap pass
+- unresolved known-failure counts per guild/channel, plus unscoped failures
 
 The human output uses a table per guild. JSON returns the same guild/channel
 rows plus aggregate totals for agent and script use. Soft-deleted messages do
@@ -34,6 +35,10 @@ Coverage is local and read-only. It does not authenticate, start a sync, wait
 for a writer lock, or update a configured share. Persisted wiretap coverage
 state contains compact counters and timestamps only; `wiretap:*` state remains
 excluded from Git snapshots.
+
+Known failures mean Discrawl attempted work and retained the failure. Missing
+rows without a known failure may still be unattempted. Use
+[`failures`](failures.html) for row identifiers, retry counts, and errors.
 
 ## Watch progress
 
@@ -52,3 +57,4 @@ channels, named channels, and synthetic channels since the previous pass.
 - [`wiretap`](wiretap.html) - import local Discord Desktop cache data
 - [`status`](status.html) - high-level archive and share status
 - [`diagnostics`](diagnostics.html) - SQLite integrity, WAL, freshness, and writer-lock checks
+- [`failures`](failures.html) - unresolved and recently resolved ingestion failures

--- a/docs/commands/failures.md
+++ b/docs/commands/failures.md
@@ -1,0 +1,40 @@
+# `failures`
+
+Queries the local operational failure ledger without authenticating to Discord
+or running a sync.
+
+## Usage
+
+```bash
+discrawl failures
+discrawl failures --source discord --guild 123456789012345678
+discrawl failures --all --limit 200
+discrawl failures --json
+```
+
+By default, the command returns up to 100 unresolved rows. Filters accept an
+exact source, guild id, or channel id. `--all` also returns resolved history;
+the maximum limit is 1000.
+
+Each row includes the operation and source, available guild/channel/message or
+attachment identifiers, a bounded error class/message, first and last seen
+times, retry count, and resolved time. Repeated failures update the same row.
+A successful later channel, message, attachment, or embedding operation marks
+the matching failure resolved.
+
+Resolved history is retained for 90 days; unresolved rows are not aged out.
+The ledger is local-only and excluded from Git snapshot exports/imports. Error
+text is bounded and common bearer/query/JSON secret forms are redacted.
+
+## Sources
+
+- `discord` - bot sync and Gateway tail operations
+- `wiretap` - Discord Desktop cache imports
+- `media` - attachment fetches and cache writes
+- `embeddings` - embedding provider and local vector writes
+
+## See also
+
+- [`coverage`](coverage.html) - known-failure counts beside archive coverage
+- [`diagnostics`](diagnostics.html) - SQLite integrity, WAL, freshness, and writer-lock checks
+- [Data layout](../guides/data-storage.html) - local storage and snapshot boundaries

--- a/docs/guides/data-storage.md
+++ b/docs/guides/data-storage.md
@@ -19,6 +19,7 @@ path if you want to move an existing archive to the platform-native location.
 - append-only message event records
 - FTS5 index rows
 - optional local embedding queue metadata and vectors
+- local-only sync/import/media/embedding failure history
 
 Messages imported from Discord Desktop use the same message, attachment, mention, and FTS paths as bot-synced messages.
 
@@ -44,6 +45,14 @@ The schema is multi-guild ready even when the common UX stays single-guild simpl
 
 SQLite schema migrations are versioned with `PRAGMA user_version`. Startup fails fast when a local DB schema is newer than the supported binary - that means you have a binary older than the database.
 
+## Failure history
+
+`failure_ledger` records bounded error text and available Discord row
+identifiers. Unresolved failures are retained; resolved failures age out after
+90 days. The table is intentionally absent from Git snapshot exports and
+imports, so one machine's operational diagnostics never become published
+archive content. Query it through [`failures`](../commands/failures.html).
+
 ## Querying directly
 
 Anything you want, with read-only SQL:
@@ -60,6 +69,7 @@ See [`sql`](../commands/sql.html).
 - [`status`](../commands/status.html) - high-level archive status
 - [`coverage`](../commands/coverage.html) - per-guild/channel archive readiness and wiretap progress counters
 - [`diagnostics`](../commands/diagnostics.html) - SQLite integrity, WAL, freshness, and writer-lock state
+- [`failures`](../commands/failures.html) - local ingestion and write failure history
 - [`channels`](../commands/channels.html) - channel directory
 - [`members`](../commands/members.html) - member directory
 - [Security](../security.html)

--- a/docs/security.md
+++ b/docs/security.md
@@ -37,8 +37,13 @@ CI runs secret scanning with `gitleaks` against git history and the working tree
 - append-only message event records
 - FTS index rows
 - optional local embedding queue metadata and vectors
+- local-only failure history with bounded, redacted error text
 
 Attachment binaries are not stored in SQLite. Only attachment metadata, optional extracted text, and media cache bookkeeping are stored there. Cached files live under `cache_dir/media`. Failed CDN downloads are recorded with their HTTP status, such as `404`, instead of being retried silently forever.
+
+The operational failure ledger is excluded from Git snapshot exports and
+imports. It may contain local row identifiers and sanitized error context, so
+inspect `discrawl failures --json` before sharing its output.
 
 Set `sync.attachment_text = false` if you want to keep attachment metadata and filenames but disable attachment body fetches for text indexing.
 

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -290,6 +290,11 @@ func (r *runtime) dispatch(rest []string) error {
 			return printCommandUsage(r.stdout, []string{"coverage"})
 		}
 		return r.withLocalStoreReadOnly(func() error { return r.runCoverage(rest[1:]) })
+	case "failures":
+		if hasHelpFlag(rest[1:]) {
+			return printCommandUsage(r.stdout, []string{"failures"})
+		}
+		return r.withLocalStoreReadOnly(func() error { return r.runFailures(rest[1:]) })
 	case "report":
 		return r.withLocalStoreRead(true, func() error { return r.runReport(rest[1:]) })
 	case "publish":

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -688,6 +688,15 @@ func TestFailuresHumanJSONAndResolvedHistory(t *testing.T) {
 	require.False(t, report.Failures[0].ResolvedAt.IsZero())
 }
 
+func TestFailuresMissingArchiveFailsWithoutCreatingDatabase(t *testing.T) {
+	dir := t.TempDir()
+	cfg, cfgPath := writeTestConfig(t, dir)
+	err := Run(context.Background(), []string{"--config", cfgPath, "failures"}, &bytes.Buffer{}, &bytes.Buffer{})
+	require.Equal(t, 5, ExitCode(err))
+	require.ErrorContains(t, err, "failures requires a local SQLite archive")
+	require.NoFileExists(t, cfg.DBPath)
+}
+
 func TestWiretapStatsIncludesCoverage(t *testing.T) {
 	ctx := context.Background()
 	dir := t.TempDir()

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -654,6 +654,40 @@ func TestCoverageMissingArchiveFailsWithoutCreatingDatabase(t *testing.T) {
 	require.NoFileExists(t, cfg.DBPath)
 }
 
+func TestFailuresHumanJSONAndResolvedHistory(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	cfg, cfgPath := writeTestConfig(t, dir)
+	s := seedCLIStore(t, cfg.DBPath)
+	ref := store.FailureRef{Operation: "sync_messages", Source: "discord", GuildID: "g1", ChannelID: "c1"}
+	require.NoError(t, s.RecordFailure(ctx, ref, errors.New("synthetic timeout")))
+	require.NoError(t, s.Close())
+
+	var out bytes.Buffer
+	require.NoError(t, Run(ctx, []string{"--config", cfgPath, "failures"}, &out, &bytes.Buffer{}))
+	require.Contains(t, out.String(), "unresolved=1")
+	require.Contains(t, out.String(), "source=discord operation=sync_messages")
+
+	out.Reset()
+	require.NoError(t, Run(ctx, []string{"--config", cfgPath, "failures", "--json"}, &out, &bytes.Buffer{}))
+	var report store.FailureReport
+	require.NoError(t, json.Unmarshal(out.Bytes(), &report))
+	require.Equal(t, 1, report.UnresolvedCount)
+	require.Len(t, report.Failures, 1)
+	require.Equal(t, "c1", report.Failures[0].ChannelID)
+
+	s, err := store.Open(ctx, cfg.DBPath)
+	require.NoError(t, err)
+	require.NoError(t, s.ResolveFailures(ctx, ref))
+	require.NoError(t, s.Close())
+	out.Reset()
+	require.NoError(t, Run(ctx, []string{"--config", cfgPath, "failures", "--all", "--json"}, &out, &bytes.Buffer{}))
+	require.NoError(t, json.Unmarshal(out.Bytes(), &report))
+	require.Zero(t, report.UnresolvedCount)
+	require.Len(t, report.Failures, 1)
+	require.False(t, report.Failures[0].ResolvedAt.IsZero())
+}
+
 func TestWiretapStatsIncludesCoverage(t *testing.T) {
 	ctx := context.Background()
 	dir := t.TempDir()

--- a/internal/cli/failures.go
+++ b/internal/cli/failures.go
@@ -30,6 +30,9 @@ func (r *runtime) runFailures(args []string) error {
 	if *jsonOut {
 		r.json = true
 	}
+	if r.store == nil {
+		return dbErr(errors.New("failures requires a local SQLite archive"))
+	}
 	report, err := r.store.ListFailures(r.ctx, store.FailureListOptions{
 		IncludeResolved: *includeResolved,
 		Source:          strings.TrimSpace(*source),

--- a/internal/cli/failures.go
+++ b/internal/cli/failures.go
@@ -1,0 +1,44 @@
+package cli
+
+import (
+	"errors"
+	"flag"
+	"io"
+	"strings"
+
+	"github.com/openclaw/discrawl/internal/store"
+)
+
+func (r *runtime) runFailures(args []string) error {
+	fs := flag.NewFlagSet("failures", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	includeResolved := fs.Bool("all", false, "")
+	source := fs.String("source", "", "")
+	guildID := fs.String("guild", "", "")
+	channelID := fs.String("channel", "", "")
+	limit := fs.Int("limit", 100, "")
+	jsonOut := fs.Bool("json", false, "")
+	if err := fs.Parse(args); err != nil {
+		return usageErr(err)
+	}
+	if fs.NArg() != 0 {
+		return usageErr(errors.New("failures takes flags only"))
+	}
+	if *limit <= 0 {
+		return usageErr(errors.New("failure limit must be positive"))
+	}
+	if *jsonOut {
+		r.json = true
+	}
+	report, err := r.store.ListFailures(r.ctx, store.FailureListOptions{
+		IncludeResolved: *includeResolved,
+		Source:          strings.TrimSpace(*source),
+		GuildID:         strings.TrimSpace(*guildID),
+		ChannelID:       strings.TrimSpace(*channelID),
+		Limit:           *limit,
+	}, r.nowUTC())
+	if err != nil {
+		return err
+	}
+	return r.print(report)
+}

--- a/internal/cli/output.go
+++ b/internal/cli/output.go
@@ -126,6 +126,7 @@ Commands:
   status
   diagnostics
   coverage
+  failures
   remote
   whoami
   report
@@ -148,6 +149,11 @@ func printCommandUsage(w io.Writer, args []string) error {
 }
 
 var commandUsage = map[string]string{
+	"failures": `Usage:
+  discrawl failures [--all] [--source SOURCE] [--guild ID] [--channel ID] [--limit N] [--json]
+
+Lists unresolved local sync, import, media, embedding, and write failures by default. Use --all to include resolved rows retained for 90 days.
+`,
 	"coverage": `Usage:
   discrawl coverage [--guild ID] [--json]
 
@@ -307,6 +313,24 @@ func printHuman(w io.Writer, value any) error {
 		return err
 	case store.CoverageReport:
 		return printCoverageHuman(w, v)
+	case store.FailureReport:
+		if _, err := fmt.Fprintf(w, "unresolved=%d\nreturned=%d\n", v.UnresolvedCount, len(v.Failures)); err != nil {
+			return err
+		}
+		for _, row := range v.Failures {
+			status := "unresolved"
+			if !row.ResolvedAt.IsZero() {
+				status = "resolved"
+			}
+			if _, err := fmt.Fprintf(w, "\n%s source=%s operation=%s guild=%s channel=%s message=%s %s=%s retries=%d last=%s\n%s: %s\n",
+				status, row.Source, row.Operation, row.GuildID, row.ChannelID, row.MessageID,
+				row.RelatedKind, row.RelatedID, row.RetryCount, formatTime(row.LastSeenAt),
+				row.ErrorClass, row.ErrorMessage,
+			); err != nil {
+				return err
+			}
+		}
+		return nil
 	case wiretapProgress:
 		if _, err := fmt.Fprintf(w, "import_messages=%d\nimport_channels=%d\nimport_skipped_messages=%d\nimport_skipped_channels=%d\n", v.Import.Messages, v.Import.Channels, v.Import.SkippedMessages, v.Import.SkippedChannels); err != nil {
 			return err
@@ -617,7 +641,7 @@ func printHuman(w io.Writer, value any) error {
 }
 
 func printCoverageHuman(w io.Writer, report store.CoverageReport) error {
-	if _, err := fmt.Fprintf(w, "guilds=%d\nchannels=%d\nmessage_channels=%d\nnamed_channels=%d\nsynthetic_channels=%d\nmessages=%d\nhistory_complete_channels=%d\nlast_bot_sync=%s\nlast_wiretap_import=%s\nwiretap_skipped_messages=%d\nwiretap_skipped_channels=%d\n",
+	if _, err := fmt.Fprintf(w, "guilds=%d\nchannels=%d\nmessage_channels=%d\nnamed_channels=%d\nsynthetic_channels=%d\nmessages=%d\nhistory_complete_channels=%d\nknown_failures=%d\nunscoped_known_failures=%d\nlast_bot_sync=%s\nlast_wiretap_import=%s\nwiretap_skipped_messages=%d\nwiretap_skipped_channels=%d\n",
 		report.Totals.GuildCount,
 		report.Totals.ChannelCount,
 		report.Totals.MessageChannelCount,
@@ -625,6 +649,8 @@ func printCoverageHuman(w io.Writer, report store.CoverageReport) error {
 		report.Totals.SyntheticChannelCount,
 		report.Totals.MessageCount,
 		report.Totals.HistoryCompleteChannelCount,
+		report.Totals.KnownFailureCount,
+		report.Totals.UnscopedKnownFailureCount,
 		formatTime(report.LastBotSyncAt),
 		formatTime(report.Wiretap.LastImportAt),
 		report.Wiretap.SkippedMessages,
@@ -633,15 +659,15 @@ func printCoverageHuman(w io.Writer, report store.CoverageReport) error {
 		return err
 	}
 	for _, guild := range report.Guilds {
-		if _, err := fmt.Fprintf(w, "\n%s (%s): messages=%d channels=%d named=%d synthetic=%d first=%s last=%s\n",
+		if _, err := fmt.Fprintf(w, "\n%s (%s): messages=%d channels=%d named=%d synthetic=%d known_failures=%d first=%s last=%s\n",
 			guild.Name, guild.ID, guild.MessageCount, guild.ChannelCount,
-			guild.NamedChannelCount, guild.SyntheticChannelCount,
+			guild.NamedChannelCount, guild.SyntheticChannelCount, guild.KnownFailureCount,
 			formatTime(guild.EarliestMessageAt), formatTime(guild.LatestMessageAt),
 		); err != nil {
 			return err
 		}
 		tw := tabwriter.NewWriter(w, 2, 4, 2, ' ', 0)
-		_, _ = fmt.Fprintln(tw, "CHANNEL\tID\tKIND\tSOURCE\tMESSAGES\tFIRST\tLAST\tHISTORY")
+		_, _ = fmt.Fprintln(tw, "CHANNEL\tID\tKIND\tSOURCE\tMESSAGES\tFAILURES\tFIRST\tLAST\tHISTORY")
 		for _, channel := range guild.Channels {
 			source := "named"
 			if channel.Synthetic {
@@ -651,8 +677,8 @@ func printCoverageHuman(w io.Writer, report store.CoverageReport) error {
 			if channel.HistoryComplete != nil && *channel.HistoryComplete {
 				history = "complete"
 			}
-			_, _ = fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%d\t%s\t%s\t%s\n",
-				channel.Name, channel.ID, channel.Kind, source, channel.MessageCount,
+			_, _ = fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%d\t%d\t%s\t%s\t%s\n",
+				channel.Name, channel.ID, channel.Kind, source, channel.MessageCount, channel.KnownFailureCount,
 				formatTime(channel.EarliestMessageAt), formatTime(channel.LatestMessageAt), history,
 			)
 		}

--- a/internal/discorddesktop/import.go
+++ b/internal/discorddesktop/import.go
@@ -798,6 +798,17 @@ func writeSnapshot(ctx context.Context, st *store.Store, snap snapshot, prune bo
 			return err
 		}
 		if err := st.UpsertGuild(ctx, guild); err != nil {
+			return recordImportFailure(ctx, st, store.FailureRef{
+				Operation: "import_guild",
+				Source:    "wiretap",
+				GuildID:   guild.ID,
+			}, err)
+		}
+		if err := resolveImportFailures(ctx, st, store.FailureRef{
+			Operation: "import_guild",
+			Source:    "wiretap",
+			GuildID:   guild.ID,
+		}); err != nil {
 			return err
 		}
 	}
@@ -808,12 +819,35 @@ func writeSnapshot(ctx context.Context, st *store.Store, snap snapshot, prune bo
 			return err
 		}
 		if err := st.UpsertChannel(ctx, channel); err != nil {
+			return recordImportFailure(ctx, st, store.FailureRef{
+				Operation: "import_channel",
+				Source:    "wiretap",
+				GuildID:   channel.GuildID,
+				ChannelID: channel.ID,
+			}, err)
+		}
+		if err := resolveImportFailures(ctx, st, store.FailureRef{
+			Operation: "import_channel",
+			Source:    "wiretap",
+			GuildID:   channel.GuildID,
+			ChannelID: channel.ID,
+		}); err != nil {
 			return err
 		}
 	}
 	messages := mapValues(snap.messages)
 	sort.Slice(messages, func(i, j int) bool { return messages[i].Record.ID < messages[j].Record.ID })
 	if err := st.UpsertMessages(ctx, messages); err != nil {
+		return recordImportFailure(ctx, st, store.FailureRef{
+			Operation: "import_messages",
+			Source:    "wiretap",
+		}, err)
+	}
+	messageIDs := make([]string, 0, len(messages))
+	for _, message := range messages {
+		messageIDs = append(messageIDs, message.Record.ID)
+	}
+	if err := resolveImportMessageFailures(ctx, st, messageIDs); err != nil {
 		return err
 	}
 	if prune {
@@ -822,6 +856,30 @@ func writeSnapshot(ctx context.Context, st *store.Store, snap snapshot, prune bo
 		}
 	}
 	return st.SetSyncState(ctx, "wiretap:last_import", time.Now().UTC().Format(time.RFC3339Nano))
+}
+
+func recordImportFailure(ctx context.Context, st *store.Store, ref store.FailureRef, failure error) error {
+	ledgerCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 5*time.Second)
+	defer cancel()
+	if err := st.RecordFailure(ledgerCtx, ref, failure); err != nil {
+		return fmt.Errorf("%w (record failure ledger: %w)", failure, err)
+	}
+	return failure
+}
+
+func resolveImportFailures(ctx context.Context, st *store.Store, ref store.FailureRef) error {
+	ledgerCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 5*time.Second)
+	defer cancel()
+	return st.ResolveFailures(ledgerCtx, ref)
+}
+
+func resolveImportMessageFailures(ctx context.Context, st *store.Store, messageIDs []string) error {
+	ledgerCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 5*time.Second)
+	defer cancel()
+	return st.ResolveMessageFailures(ledgerCtx, store.FailureRef{
+		Operation: "import_messages",
+		Source:    "wiretap",
+	}, messageIDs)
 }
 
 func collectValue(snap snapshot, channelLookup map[string]store.ChannelRecord, value any, fallbackTime time.Time) {

--- a/internal/discorddesktop/import.go
+++ b/internal/discorddesktop/import.go
@@ -847,6 +847,12 @@ func writeSnapshot(ctx context.Context, st *store.Store, snap snapshot, prune bo
 	for _, message := range messages {
 		messageIDs = append(messageIDs, message.Record.ID)
 	}
+	if err := resolveImportFailureIdentity(ctx, st, store.FailureRef{
+		Operation: "import_messages",
+		Source:    "wiretap",
+	}); err != nil {
+		return err
+	}
 	if err := resolveImportMessageFailures(ctx, st, messageIDs); err != nil {
 		return err
 	}
@@ -871,6 +877,12 @@ func resolveImportFailures(ctx context.Context, st *store.Store, ref store.Failu
 	ledgerCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 5*time.Second)
 	defer cancel()
 	return st.ResolveFailures(ledgerCtx, ref)
+}
+
+func resolveImportFailureIdentity(ctx context.Context, st *store.Store, ref store.FailureRef) error {
+	ledgerCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 5*time.Second)
+	defer cancel()
+	return st.ResolveFailureIdentity(ledgerCtx, ref)
 }
 
 func resolveImportMessageFailures(ctx context.Context, st *store.Store, messageIDs []string) error {

--- a/internal/discorddesktop/import_test.go
+++ b/internal/discorddesktop/import_test.go
@@ -229,6 +229,18 @@ func TestImportFailureLedgerHelpersRecordAndResolve(t *testing.T) {
 
 	require.ErrorIs(t, recordImportFailure(ctx, st, ref, original), original)
 	require.NoError(t, resolveImportFailures(ctx, st, ref))
+
+	unscoped := store.FailureRef{Operation: "import_messages", Source: "wiretap"}
+	remaining := unscoped
+	remaining.MessageID = "m2"
+	require.ErrorIs(t, recordImportFailure(ctx, st, unscoped, original), original)
+	require.ErrorIs(t, recordImportFailure(ctx, st, remaining, original), original)
+	require.NoError(t, resolveImportFailureIdentity(ctx, st, unscoped))
+	report, err = st.ListFailures(ctx, store.FailureListOptions{}, time.Now())
+	require.NoError(t, err)
+	require.Len(t, report.Failures, 1)
+	require.Equal(t, "m2", report.Failures[0].MessageID)
+	require.NoError(t, resolveImportMessageFailures(ctx, st, []string{"m2"}))
 }
 
 func TestImportExtractsCompressedUnknownMessageArrayFromChromiumCache(t *testing.T) {

--- a/internal/discorddesktop/import_test.go
+++ b/internal/discorddesktop/import_test.go
@@ -5,6 +5,7 @@ import (
 	"compress/gzip"
 	"context"
 	"encoding/json"
+	"errors"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -202,6 +203,32 @@ func TestImportMissingDesktopPathIsEmpty(t *testing.T) {
 	require.Zero(t, stats.FilesScanned)
 	require.Zero(t, stats.Messages)
 	require.False(t, stats.FinishedAt.IsZero())
+}
+
+func TestImportFailureLedgerHelpersRecordAndResolve(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	st, err := store.Open(ctx, filepath.Join(t.TempDir(), "discrawl.db"))
+	require.NoError(t, err)
+	defer func() { _ = st.Close() }()
+
+	ref := store.FailureRef{
+		Operation: "import_messages", Source: "wiretap", GuildID: "g1", ChannelID: "c1", MessageID: "m1",
+	}
+	original := errors.New("forced import failure")
+	require.ErrorIs(t, recordImportFailure(ctx, st, ref, original), original)
+	report, err := st.ListFailures(ctx, store.FailureListOptions{}, time.Now())
+	require.NoError(t, err)
+	require.Len(t, report.Failures, 1)
+	require.Equal(t, "m1", report.Failures[0].MessageID)
+
+	require.NoError(t, resolveImportMessageFailures(ctx, st, []string{"m1"}))
+	report, err = st.ListFailures(ctx, store.FailureListOptions{}, time.Now())
+	require.NoError(t, err)
+	require.Empty(t, report.Failures)
+
+	require.ErrorIs(t, recordImportFailure(ctx, st, ref, original), original)
+	require.NoError(t, resolveImportFailures(ctx, st, ref))
 }
 
 func TestImportExtractsCompressedUnknownMessageArrayFromChromiumCache(t *testing.T) {

--- a/internal/media/cache.go
+++ b/internal/media/cache.go
@@ -77,6 +77,9 @@ func Fetch(ctx context.Context, s *store.Store, opts FetchOptions) (FetchStats, 
 		}
 		if attachment.MediaPath != "" && (missingOnly || !opts.Force) {
 			if mediaFileReusable(opts.CacheDir, attachment) {
+				if err := resolveAttachmentFailure(ctx, s, attachment); err != nil {
+					return stats, err
+				}
 				stats.Reused++
 				continue
 			}
@@ -89,8 +92,12 @@ func Fetch(ctx context.Context, s *store.Store, opts FetchOptions) (FetchStats, 
 		switch {
 		case err != nil:
 			stats.Failed++
+			if recordErr := s.RecordFailure(ctx, attachmentFailureRef(attachment), err); recordErr != nil {
+				return stats, recordErr
+			}
 			if opts.StatusUpdate {
 				if err := s.UpdateAttachmentFetchStatus(ctx, attachment.AttachmentID, opts.Now().UTC().Format(time.RFC3339Nano), "failed", clampError(err.Error())); err != nil {
+					_ = s.RecordFailure(ctx, attachmentFailureRef(attachment), err)
 					return stats, err
 				}
 			}
@@ -100,6 +107,9 @@ func Fetch(ctx context.Context, s *store.Store, opts FetchOptions) (FetchStats, 
 				if err := s.UpdateAttachmentFetchStatus(ctx, attachment.AttachmentID, opts.Now().UTC().Format(time.RFC3339Nano), result.reason, ""); err != nil {
 					return stats, err
 				}
+			}
+			if err := resolveAttachmentFailure(ctx, s, attachment); err != nil {
+				return stats, err
 			}
 		default:
 			stats.Fetched++
@@ -112,11 +122,31 @@ func Fetch(ctx context.Context, s *store.Store, opts FetchOptions) (FetchStats, 
 				FetchedAt:     opts.Now().UTC().Format(time.RFC3339Nano),
 				FetchStatus:   "fetched",
 			}); err != nil {
+				_ = s.RecordFailure(ctx, attachmentFailureRef(attachment), err)
+				return stats, err
+			}
+			if err := resolveAttachmentFailure(ctx, s, attachment); err != nil {
 				return stats, err
 			}
 		}
 	}
 	return stats, nil
+}
+
+func attachmentFailureRef(attachment store.AttachmentRow) store.FailureRef {
+	return store.FailureRef{
+		Operation:   "fetch_attachment",
+		Source:      "media",
+		GuildID:     attachment.GuildID,
+		ChannelID:   attachment.ChannelID,
+		MessageID:   attachment.MessageID,
+		RelatedKind: "attachment_id",
+		RelatedID:   attachment.AttachmentID,
+	}
+}
+
+func resolveAttachmentFailure(ctx context.Context, s *store.Store, attachment store.AttachmentRow) error {
+	return s.ResolveFailures(ctx, attachmentFailureRef(attachment))
 }
 
 func mediaFileReusable(cacheDir string, attachment store.AttachmentRow) bool {

--- a/internal/media/cache.go
+++ b/internal/media/cache.go
@@ -220,15 +220,22 @@ func fetchURL(ctx context.Context, opts FetchOptions, attachment store.Attachmen
 	}
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
-		return fetchResult{}, err
+		return fetchResult{}, errors.New("build attachment fetch request")
 	}
 	resp, err := opts.HTTPClient.Do(req)
 	if err != nil {
-		return fetchResult{}, err
+		switch {
+		case errors.Is(err, context.Canceled):
+			return fetchResult{}, context.Canceled
+		case errors.Is(err, context.DeadlineExceeded):
+			return fetchResult{}, context.DeadlineExceeded
+		default:
+			return fetchResult{}, errors.New("attachment fetch request failed")
+		}
 	}
 	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return fetchResult{}, fmt.Errorf("GET %s returned HTTP %d", url, resp.StatusCode)
+		return fetchResult{}, fmt.Errorf("attachment fetch returned HTTP %d", resp.StatusCode)
 	}
 	if resp.ContentLength > opts.MaxBytes {
 		return fetchResult{status: "skipped", reason: "too_large"}, nil

--- a/internal/media/cache_test.go
+++ b/internal/media/cache_test.go
@@ -258,7 +258,7 @@ func TestFetchRecordsSkippedAndFailedStatuses(t *testing.T) {
 	rows, err = s.ListAttachments(ctx, store.AttachmentListOptions{MessageID: "m2"})
 	require.NoError(t, err)
 	require.Equal(t, "failed", rows[0].FetchStatus)
-	require.Len(t, rows[0].FetchError, 512)
+	require.Equal(t, "attachment fetch request failed", rows[0].FetchError)
 
 	failures, err := s.ListFailures(ctx, store.FailureListOptions{}, time.Now())
 	require.NoError(t, err)
@@ -280,6 +280,39 @@ func TestFetchRecordsSkippedAndFailedStatuses(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, failures.Failures, 1)
 	require.False(t, failures.Failures[0].ResolvedAt.IsZero())
+}
+
+func TestFetchHTTPFailureDoesNotPersistSignedURL(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	s, err := store.Open(ctx, filepath.Join(t.TempDir(), "discrawl.db"))
+	require.NoError(t, err)
+	defer func() { _ = s.Close() }()
+	signedURL := "https://cdn.discordapp.com/attachments/c1/private.png?ex=one&is=two&hm=signed-value"
+	require.NoError(t, seedAttachment(ctx, s, signedURL))
+
+	stats, err := Fetch(ctx, s, FetchOptions{
+		CacheDir: t.TempDir(),
+		MaxBytes: 1024,
+		HTTPClient: &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: http.StatusForbidden,
+				Header:     make(http.Header),
+				Body:       io.NopCloser(strings.NewReader("")),
+				Request:    req,
+			}, nil
+		})},
+	})
+	require.NoError(t, err)
+	require.Equal(t, 1, stats.Failed)
+
+	report, err := s.ListFailures(ctx, store.FailureListOptions{}, time.Now())
+	require.NoError(t, err)
+	require.Len(t, report.Failures, 1)
+	require.Contains(t, report.Failures[0].ErrorMessage, "HTTP 403")
+	require.NotContains(t, report.Failures[0].ErrorMessage, "cdn.discordapp.com")
+	require.NotContains(t, report.Failures[0].ErrorMessage, "signed-value")
 }
 
 func TestFetchRejectsNonDiscordAttachmentURL(t *testing.T) {

--- a/internal/media/cache_test.go
+++ b/internal/media/cache_test.go
@@ -259,6 +259,27 @@ func TestFetchRecordsSkippedAndFailedStatuses(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "failed", rows[0].FetchStatus)
 	require.Len(t, rows[0].FetchError, 512)
+
+	failures, err := s.ListFailures(ctx, store.FailureListOptions{}, time.Now())
+	require.NoError(t, err)
+	require.Len(t, failures.Failures, 1)
+	require.Equal(t, "a2", failures.Failures[0].RelatedID)
+
+	stats, err = Fetch(ctx, s, FetchOptions{
+		CacheDir:   t.TempDir(),
+		MaxBytes:   1024,
+		HTTPClient: staticHTTPClient([]byte("recovered")),
+		List:       store.AttachmentListOptions{MessageID: "m2"},
+	})
+	require.NoError(t, err)
+	require.Equal(t, 1, stats.Fetched)
+	failures, err = s.ListFailures(ctx, store.FailureListOptions{}, time.Now())
+	require.NoError(t, err)
+	require.Empty(t, failures.Failures)
+	failures, err = s.ListFailures(ctx, store.FailureListOptions{IncludeResolved: true}, time.Now())
+	require.NoError(t, err)
+	require.Len(t, failures.Failures, 1)
+	require.False(t, failures.Failures[0].ResolvedAt.IsZero())
 }
 
 func TestFetchRejectsNonDiscordAttachmentURL(t *testing.T) {

--- a/internal/share/share_test.go
+++ b/internal/share/share_test.go
@@ -7,6 +7,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"io"
 	"os"
 	"os/exec"
@@ -1209,7 +1210,7 @@ func TestImportRepairsBlankMessageGuildIDs(t *testing.T) {
 	require.Equal(t, "g1", results[0].GuildID)
 }
 
-func TestSnapshotExcludesLocalEmbeddingState(t *testing.T) {
+func TestSnapshotExcludesLocalEmbeddingAndFailureState(t *testing.T) {
 	ctx := context.Background()
 	src := seedStore(t, filepath.Join(t.TempDir(), "src.db"))
 	defer func() { _ = src.Close() }()
@@ -1219,6 +1220,7 @@ func TestSnapshotExcludesLocalEmbeddingState(t *testing.T) {
 		values ('m1', 'done', 0, 'ollama', 'nomic-embed-text', ?, ?)
 	`, store.EmbeddingInputVersion, time.Now().UTC().Format(time.RFC3339Nano))
 	require.NoError(t, err)
+	require.NoError(t, src.RecordFailure(ctx, store.FailureRef{Operation: "sync_messages", Source: "discord", GuildID: "g1"}, errors.New("private local failure")))
 	_, err = src.DB().ExecContext(ctx, `
 		insert into message_embeddings(
 			message_id, provider, model, input_version, dimensions, embedding_blob, embedded_at
@@ -1231,10 +1233,12 @@ func TestSnapshotExcludesLocalEmbeddingState(t *testing.T) {
 	require.NoError(t, err)
 	require.NotContains(t, tableNames(manifest), "embedding_jobs")
 	require.NotContains(t, tableNames(manifest), "message_embeddings")
+	require.NotContains(t, tableNames(manifest), "failure_ledger")
 	require.Empty(t, manifest.Embeddings)
 
 	dst, err := store.Open(ctx, filepath.Join(t.TempDir(), "dst.db"))
 	require.NoError(t, err)
+	require.NoError(t, dst.RecordFailure(ctx, store.FailureRef{Operation: "sync_messages", Source: "discord", GuildID: "local"}, errors.New("keep me")))
 	defer func() { _ = dst.Close() }()
 	_, err = dst.DB().ExecContext(ctx, `
 		insert into embedding_jobs(message_id, state, attempts, provider, model, input_version, updated_at)
@@ -1249,6 +1253,9 @@ func TestSnapshotExcludesLocalEmbeddingState(t *testing.T) {
 		select state from embedding_jobs where message_id = 'm1'
 	`).Scan(&state))
 	require.Equal(t, "pending", state)
+	var failures int
+	require.NoError(t, dst.DB().QueryRowContext(ctx, `select count(*) from failure_ledger where guild_id = 'local'`).Scan(&failures))
+	require.Equal(t, 1, failures)
 }
 
 func TestSnapshotExcludesAndPreservesDirectMessages(t *testing.T) {

--- a/internal/store/coverage.go
+++ b/internal/store/coverage.go
@@ -35,6 +35,7 @@ type CoverageGuild struct {
 	NamedChannelCount           int               `json:"named_channel_count"`
 	SyntheticChannelCount       int               `json:"synthetic_channel_count"`
 	HistoryCompleteChannelCount int               `json:"history_complete_channel_count"`
+	KnownFailureCount           int               `json:"known_failure_count"`
 	EarliestMessageAt           time.Time         `json:"earliest_message_at,omitzero"`
 	LatestMessageAt             time.Time         `json:"latest_message_at,omitzero"`
 	Channels                    []CoverageChannel `json:"channels"`
@@ -50,6 +51,7 @@ type CoverageChannel struct {
 	EarliestMessageAt time.Time `json:"earliest_message_at,omitzero"`
 	LatestMessageAt   time.Time `json:"latest_message_at,omitzero"`
 	HistoryComplete   *bool     `json:"history_complete,omitempty"`
+	KnownFailureCount int       `json:"known_failure_count"`
 }
 
 type CoverageTotals struct {
@@ -60,6 +62,8 @@ type CoverageTotals struct {
 	NamedChannelCount           int `json:"named_channel_count"`
 	SyntheticChannelCount       int `json:"synthetic_channel_count"`
 	HistoryCompleteChannelCount int `json:"history_complete_channel_count"`
+	KnownFailureCount           int `json:"known_failure_count"`
+	UnscopedKnownFailureCount   int `json:"unscoped_known_failure_count"`
 }
 
 type WiretapImportStats struct {
@@ -213,10 +217,60 @@ func (s *Store) Coverage(ctx context.Context, guildID string, generatedAt time.T
 		report.Totals.SyntheticChannelCount += guild.SyntheticChannelCount
 		report.Totals.HistoryCompleteChannelCount += guild.HistoryCompleteChannelCount
 	}
+	if err := s.loadKnownFailureCoverage(queryCtx, guildID, &report); err != nil {
+		return CoverageReport{}, err
+	}
 	if err := s.loadCoverageState(ctx, &report); err != nil {
 		return CoverageReport{}, err
 	}
 	return report, nil
+}
+
+func (s *Store) loadKnownFailureCoverage(ctx context.Context, guildID string, report *CoverageReport) error {
+	rows, err := s.db.QueryContext(ctx, `
+		select guild_id, channel_id, count(*)
+		from failure_ledger
+		where resolved_at is null and (? = '' or guild_id = ?)
+		group by guild_id, channel_id
+	`, guildID, guildID)
+	if err != nil {
+		return fmt.Errorf("query known failure coverage: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	guilds := make(map[string]*CoverageGuild, len(report.Guilds))
+	channels := map[string]*CoverageChannel{}
+	channelGuilds := map[string]*CoverageGuild{}
+	for i := range report.Guilds {
+		guild := &report.Guilds[i]
+		guilds[guild.ID] = guild
+		for j := range guild.Channels {
+			channel := &guild.Channels[j]
+			channels[channel.ID] = channel
+			channelGuilds[channel.ID] = guild
+		}
+	}
+	for rows.Next() {
+		var failureGuildID, channelID string
+		var count int
+		if err := rows.Scan(&failureGuildID, &channelID, &count); err != nil {
+			return fmt.Errorf("scan known failure coverage: %w", err)
+		}
+		report.Totals.KnownFailureCount += count
+		if channel := channels[channelID]; channel != nil {
+			channel.KnownFailureCount += count
+			channelGuilds[channelID].KnownFailureCount += count
+			continue
+		}
+		if guild := guilds[failureGuildID]; guild != nil {
+			guild.KnownFailureCount += count
+			continue
+		}
+		report.Totals.UnscopedKnownFailureCount += count
+	}
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("query known failure coverage: %w", err)
+	}
+	return nil
 }
 
 func (s *Store) loadCoverageState(ctx context.Context, report *CoverageReport) error {

--- a/internal/store/coverage_test.go
+++ b/internal/store/coverage_test.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"context"
+	"errors"
 	"path/filepath"
 	"testing"
 	"time"
@@ -35,6 +36,8 @@ func TestCoverageReportsGuildChannelAndWiretapState(t *testing.T) {
 		FilesScanned: 4, Messages: 3, Channels: 2, SkippedMessages: 5, SkippedChannels: 6,
 		FinishedAt: time.Date(2026, 6, 4, 12, 0, 0, 0, time.UTC),
 	}))
+	require.NoError(t, s.RecordFailure(ctx, FailureRef{Operation: "sync_messages", Source: "discord", GuildID: "g1", ChannelID: "c1"}, errors.New("known channel failure")))
+	require.NoError(t, s.RecordFailure(ctx, FailureRef{Operation: "embed_message", Source: "embeddings", MessageID: "missing"}, errors.New("unscoped failure")))
 
 	generatedAt := time.Date(2026, 6, 5, 12, 0, 0, 0, time.UTC)
 	report, err := s.Coverage(ctx, "", generatedAt)
@@ -43,6 +46,7 @@ func TestCoverageReportsGuildChannelAndWiretapState(t *testing.T) {
 	require.Equal(t, CoverageTotals{
 		GuildCount: 2, MessageCount: 3, ChannelCount: 3, MessageChannelCount: 2,
 		NamedChannelCount: 2, SyntheticChannelCount: 1, HistoryCompleteChannelCount: 1,
+		KnownFailureCount: 2, UnscopedKnownFailureCount: 1,
 	}, report.Totals)
 	require.Equal(t, time.Date(2026, 6, 4, 10, 0, 0, 0, time.UTC), report.LastBotSyncAt)
 	require.Equal(t, 5, report.Wiretap.SkippedMessages)
@@ -56,6 +60,8 @@ func TestCoverageReportsGuildChannelAndWiretapState(t *testing.T) {
 	require.Equal(t, "c1", report.Guilds[0].Channels[0].ID)
 	require.NotNil(t, report.Guilds[0].Channels[0].HistoryComplete)
 	require.True(t, *report.Guilds[0].Channels[0].HistoryComplete)
+	require.Equal(t, 1, report.Guilds[0].KnownFailureCount)
+	require.Equal(t, 1, report.Guilds[0].Channels[0].KnownFailureCount)
 	require.True(t, report.Guilds[0].Channels[1].Synthetic)
 
 	filtered, err := s.Coverage(ctx, "g2", generatedAt)

--- a/internal/store/embeddings.go
+++ b/internal/store/embeddings.go
@@ -104,6 +104,9 @@ func (s *Store) DrainEmbeddingJobs(ctx context.Context, provider embed.Provider,
 			if err := s.markEmbeddingJobsDone(ctx, opts, []embeddingJob{job}); err != nil {
 				return stats, err
 			}
+			if err := s.ResolveMessageFailures(ctx, FailureRef{Operation: "embed_message", Source: "embeddings"}, []string{job.MessageID}); err != nil {
+				return stats, err
+			}
 			stats.Processed++
 			stats.Skipped++
 			continue
@@ -221,11 +224,17 @@ func (s *Store) processEmbeddingBatch(ctx context.Context, provider embed.Provid
 			if markErr := s.markEmbeddingJobsRateLimited(ctx, opts, jobs, err); markErr != nil {
 				return false, markErr
 			}
+			if recordErr := s.recordEmbeddingFailures(ctx, opts, jobs, err); recordErr != nil {
+				return false, recordErr
+			}
 			stats.Requeued += len(jobs)
 			return true, nil
 		}
 		if markErr := s.markEmbeddingJobsFailed(ctx, opts, jobs, err); markErr != nil {
 			return false, markErr
+		}
+		if recordErr := s.recordEmbeddingFailures(ctx, opts, jobs, err); recordErr != nil {
+			return false, recordErr
 		}
 		stats.Processed += len(jobs)
 		stats.Failed += len(jobs)
@@ -236,16 +245,49 @@ func (s *Store) processEmbeddingBatch(ctx context.Context, provider embed.Provid
 		if markErr := s.markEmbeddingJobsFailed(ctx, opts, jobs, err); markErr != nil {
 			return false, markErr
 		}
+		if recordErr := s.recordEmbeddingFailures(ctx, opts, jobs, err); recordErr != nil {
+			return false, recordErr
+		}
 		stats.Processed += len(jobs)
 		stats.Failed += len(jobs)
 		return false, nil
 	}
 	if err := s.storeEmbeddingBatch(ctx, opts, jobs, batch.Vectors, dimensions); err != nil {
+		return false, withEmbeddingFailureRecord(err, s.recordEmbeddingFailures(ctx, opts, jobs, err))
+	}
+	messageIDs := make([]string, 0, len(jobs))
+	for _, job := range jobs {
+		messageIDs = append(messageIDs, job.MessageID)
+	}
+	if err := s.ResolveMessageFailures(ctx, FailureRef{Operation: "embed_message", Source: "embeddings"}, messageIDs); err != nil {
 		return false, err
 	}
 	stats.Processed += len(jobs)
 	stats.Succeeded += len(jobs)
 	return false, nil
+}
+
+func (s *Store) recordEmbeddingFailures(ctx context.Context, opts EmbeddingDrainOptions, jobs []embeddingJob, failure error) error {
+	identity := strings.Join([]string{opts.Provider, opts.Model, opts.InputVersion}, "/")
+	for _, job := range jobs {
+		if err := s.RecordFailure(ctx, FailureRef{
+			Operation:   "embed_message",
+			Source:      "embeddings",
+			MessageID:   job.MessageID,
+			RelatedKind: "embedding_identity",
+			RelatedID:   identity,
+		}, failure); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func withEmbeddingFailureRecord(failure, recordErr error) error {
+	if recordErr == nil {
+		return failure
+	}
+	return fmt.Errorf("%w (record failure ledger: %w)", failure, recordErr)
 }
 
 func (s *Store) lockEmbeddingJobs(ctx context.Context, jobs []embeddingJob, lockedAt, staleBefore string) ([]embeddingJob, error) {

--- a/internal/store/embeddings.go
+++ b/internal/store/embeddings.go
@@ -259,7 +259,7 @@ func (s *Store) processEmbeddingBatch(ctx context.Context, provider embed.Provid
 	for _, job := range jobs {
 		messageIDs = append(messageIDs, job.MessageID)
 	}
-	if err := s.ResolveMessageFailures(ctx, FailureRef{Operation: "embed_message", Source: "embeddings"}, messageIDs); err != nil {
+	if err := s.ResolveMessageFailures(ctx, embeddingFailureRef(opts, ""), messageIDs); err != nil {
 		return false, err
 	}
 	stats.Processed += len(jobs)
@@ -268,19 +268,22 @@ func (s *Store) processEmbeddingBatch(ctx context.Context, provider embed.Provid
 }
 
 func (s *Store) recordEmbeddingFailures(ctx context.Context, opts EmbeddingDrainOptions, jobs []embeddingJob, failure error) error {
-	identity := strings.Join([]string{opts.Provider, opts.Model, opts.InputVersion}, "/")
 	for _, job := range jobs {
-		if err := s.RecordFailure(ctx, FailureRef{
-			Operation:   "embed_message",
-			Source:      "embeddings",
-			MessageID:   job.MessageID,
-			RelatedKind: "embedding_identity",
-			RelatedID:   identity,
-		}, failure); err != nil {
+		if err := s.RecordFailure(ctx, embeddingFailureRef(opts, job.MessageID), failure); err != nil {
 			return err
 		}
 	}
 	return nil
+}
+
+func embeddingFailureRef(opts EmbeddingDrainOptions, messageID string) FailureRef {
+	return FailureRef{
+		Operation:   "embed_message",
+		Source:      "embeddings",
+		MessageID:   messageID,
+		RelatedKind: "embedding_identity",
+		RelatedID:   strings.Join([]string{opts.Provider, opts.Model, opts.InputVersion}, "/"),
+	}
 }
 
 func withEmbeddingFailureRecord(failure, recordErr error) error {

--- a/internal/store/failures.go
+++ b/internal/store/failures.go
@@ -181,11 +181,27 @@ func (s *Store) ResolveMessageFailures(ctx context.Context, ref FailureRef, mess
 		return nil
 	}
 	now := time.Now().UTC()
+	clauses := []string{"resolved_at is null", "operation = ?", "source = ?"}
+	baseArgs := []any{now.Format(timeLayout), ref.Operation, ref.Source}
+	for _, field := range []struct {
+		name  string
+		value string
+	}{
+		{"guild_id", ref.GuildID},
+		{"channel_id", ref.ChannelID},
+		{"related_kind", ref.RelatedKind},
+		{"related_id", ref.RelatedID},
+	} {
+		if field.value != "" {
+			clauses = append(clauses, field.name+" = ?")
+			baseArgs = append(baseArgs, field.value)
+		}
+	}
 	for start := 0; start < len(ids); start += 500 {
 		batch := ids[start:min(start+500, len(ids))]
 		placeholders := strings.TrimSuffix(strings.Repeat("?,", len(batch)), ",")
-		query := `update failure_ledger set resolved_at = ? where resolved_at is null and operation = ? and source = ? and message_id in (` + placeholders + `)`
-		args := []any{now.Format(timeLayout), ref.Operation, ref.Source}
+		query := `update failure_ledger set resolved_at = ? where ` + strings.Join(clauses, " and ") + ` and message_id in (` + placeholders + `)`
+		args := append([]any(nil), baseArgs...)
 		for _, id := range batch {
 			args = append(args, id)
 		}

--- a/internal/store/failures.go
+++ b/internal/store/failures.go
@@ -1,0 +1,361 @@
+package store
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"reflect"
+	"regexp"
+	"strings"
+	"time"
+)
+
+const (
+	defaultFailureLimit   = 100
+	maxFailureLimit       = 1000
+	maxFailureMessage     = 2048
+	resolvedFailureMaxAge = 90 * 24 * time.Hour
+)
+
+var (
+	failureBearerPattern = regexp.MustCompile(`(?i)(bearer\s+)[^\s,;]+`)
+	failureSecretPattern = regexp.MustCompile(`(?i)([?&](?:token|key|secret|authorization)=)[^&\s]+`)
+	failureJSONPattern   = regexp.MustCompile(`(?i)("(?:token|key|secret|authorization)"\s*:\s*")[^"]+`)
+)
+
+type FailureRef struct {
+	Operation   string
+	Source      string
+	GuildID     string
+	ChannelID   string
+	MessageID   string
+	RelatedKind string
+	RelatedID   string
+}
+
+type Failure struct {
+	FailureID    int64     `json:"failure_id"`
+	Operation    string    `json:"operation"`
+	Source       string    `json:"source"`
+	GuildID      string    `json:"guild_id,omitempty"`
+	ChannelID    string    `json:"channel_id,omitempty"`
+	MessageID    string    `json:"message_id,omitempty"`
+	RelatedKind  string    `json:"related_kind,omitempty"`
+	RelatedID    string    `json:"related_id,omitempty"`
+	ErrorClass   string    `json:"error_class"`
+	ErrorMessage string    `json:"error_message"`
+	FirstSeenAt  time.Time `json:"first_seen_at"`
+	LastSeenAt   time.Time `json:"last_seen_at"`
+	RetryCount   int       `json:"retry_count"`
+	ResolvedAt   time.Time `json:"resolved_at,omitzero"`
+}
+
+type FailureListOptions struct {
+	IncludeResolved bool
+	Source          string
+	GuildID         string
+	ChannelID       string
+	Limit           int
+}
+
+type FailureReport struct {
+	GeneratedAt     time.Time `json:"generated_at"`
+	UnresolvedCount int       `json:"unresolved_count"`
+	Failures        []Failure `json:"failures"`
+}
+
+// RowWriteError carries identifiers without retaining message content, URLs, or raw payloads.
+type RowWriteError struct {
+	Ref         FailureRef
+	AuthorID    string
+	Filename    string
+	ContentType string
+	Size        int64
+	Err         error
+}
+
+func (e *RowWriteError) Error() string {
+	if e == nil {
+		return "row write failed"
+	}
+	return fmt.Sprintf(
+		"%s failed: guild_id=%q channel_id=%q message_id=%q %s=%q author_id=%q filename=%q content_type=%q size=%d: %v",
+		firstNonEmpty(e.Ref.Operation, "row write"), e.Ref.GuildID, e.Ref.ChannelID, e.Ref.MessageID,
+		firstNonEmpty(e.Ref.RelatedKind, "related_id"), e.Ref.RelatedID, e.AuthorID, e.Filename, e.ContentType, e.Size, e.Err,
+	)
+}
+
+func (e *RowWriteError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.Err
+}
+
+func FailureRefFromError(err error) FailureRef {
+	var rowErr *RowWriteError
+	if errors.As(err, &rowErr) && rowErr != nil {
+		return rowErr.Ref
+	}
+	return FailureRef{}
+}
+
+func (s *Store) RecordFailure(ctx context.Context, ref FailureRef, failure error) error {
+	if failure == nil {
+		return s.ResolveFailures(ctx, ref)
+	}
+	ref = normalizeFailureRef(mergeFailureRef(ref, FailureRefFromError(failure)))
+	if ref.Operation == "" || ref.Source == "" {
+		return errors.New("failure operation and source are required")
+	}
+	now := time.Now().UTC()
+	if _, err := s.db.ExecContext(ctx, `
+		insert into failure_ledger(
+			operation, source, guild_id, channel_id, message_id, related_kind, related_id,
+			error_class, error_message, first_seen_at, last_seen_at, retry_count, resolved_at
+		) values(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0, null)
+		on conflict(operation, source, guild_id, channel_id, message_id, related_kind, related_id)
+		do update set
+			error_class = excluded.error_class,
+			error_message = excluded.error_message,
+			last_seen_at = excluded.last_seen_at,
+			retry_count = failure_ledger.retry_count + 1,
+			resolved_at = null
+	`, ref.Operation, ref.Source, ref.GuildID, ref.ChannelID, ref.MessageID, ref.RelatedKind, ref.RelatedID,
+		failureClass(failure), sanitizeFailureMessage(failure.Error()), now.Format(timeLayout), now.Format(timeLayout)); err != nil {
+		return fmt.Errorf("record %s/%s failure: %w", ref.Source, ref.Operation, err)
+	}
+	return s.pruneResolvedFailures(ctx, now)
+}
+
+// ResolveFailures resolves every unresolved row matching the non-empty identifiers in ref.
+func (s *Store) ResolveFailures(ctx context.Context, ref FailureRef) error {
+	ref = normalizeFailureRef(ref)
+	if ref.Operation == "" || ref.Source == "" {
+		return errors.New("failure operation and source are required")
+	}
+	now := time.Now().UTC()
+	clauses := []string{"resolved_at is null", "operation = ?", "source = ?"}
+	args := []any{now.Format(timeLayout), ref.Operation, ref.Source}
+	for _, field := range []struct {
+		name  string
+		value string
+	}{
+		{"guild_id", ref.GuildID},
+		{"channel_id", ref.ChannelID},
+		{"message_id", ref.MessageID},
+		{"related_kind", ref.RelatedKind},
+		{"related_id", ref.RelatedID},
+	} {
+		if field.value != "" {
+			clauses = append(clauses, field.name+" = ?")
+			args = append(args, field.value)
+		}
+	}
+	query := `update failure_ledger set resolved_at = ? where ` + strings.Join(clauses, " and ")
+	if _, err := s.db.ExecContext(ctx, query, args...); err != nil {
+		return fmt.Errorf("resolve %s/%s failures: %w", ref.Source, ref.Operation, err)
+	}
+	return s.pruneResolvedFailures(ctx, now)
+}
+
+func (s *Store) ResolveMessageFailures(ctx context.Context, ref FailureRef, messageIDs []string) error {
+	ref = normalizeFailureRef(ref)
+	if ref.Operation == "" || ref.Source == "" {
+		return errors.New("failure operation and source are required")
+	}
+	seen := map[string]struct{}{}
+	ids := make([]string, 0, len(messageIDs))
+	for _, id := range messageIDs {
+		id = strings.TrimSpace(id)
+		if id == "" {
+			continue
+		}
+		if _, ok := seen[id]; ok {
+			continue
+		}
+		seen[id] = struct{}{}
+		ids = append(ids, id)
+	}
+	if len(ids) == 0 {
+		return nil
+	}
+	now := time.Now().UTC()
+	for start := 0; start < len(ids); start += 500 {
+		batch := ids[start:min(start+500, len(ids))]
+		placeholders := strings.TrimSuffix(strings.Repeat("?,", len(batch)), ",")
+		query := `update failure_ledger set resolved_at = ? where resolved_at is null and operation = ? and source = ? and message_id in (` + placeholders + `)`
+		args := []any{now.Format(timeLayout), ref.Operation, ref.Source}
+		for _, id := range batch {
+			args = append(args, id)
+		}
+		if _, err := s.db.ExecContext(ctx, query, args...); err != nil {
+			return fmt.Errorf("resolve %s/%s message failures: %w", ref.Source, ref.Operation, err)
+		}
+	}
+	return s.pruneResolvedFailures(ctx, now)
+}
+
+func (s *Store) ListFailures(ctx context.Context, opts FailureListOptions, generatedAt time.Time) (FailureReport, error) {
+	opts.Source = strings.TrimSpace(opts.Source)
+	opts.GuildID = strings.TrimSpace(opts.GuildID)
+	opts.ChannelID = strings.TrimSpace(opts.ChannelID)
+	if opts.Limit <= 0 {
+		opts.Limit = defaultFailureLimit
+	}
+	if opts.Limit > maxFailureLimit {
+		return FailureReport{}, fmt.Errorf("failure limit must be at most %d", maxFailureLimit)
+	}
+	where, args := failureWhere(opts)
+	report := FailureReport{GeneratedAt: generatedAt.UTC(), Failures: []Failure{}}
+	countOpts := opts
+	countOpts.IncludeResolved = false
+	countWhere, countArgs := failureWhere(countOpts)
+	if err := s.db.QueryRowContext(ctx, `select count(*) from failure_ledger `+countWhere, countArgs...).Scan(&report.UnresolvedCount); err != nil {
+		return FailureReport{}, fmt.Errorf("count unresolved failures: %w", err)
+	}
+	rows, err := s.db.QueryContext(ctx, `
+		select failure_id, operation, source, guild_id, channel_id, message_id,
+		       related_kind, related_id, error_class, error_message,
+		       first_seen_at, last_seen_at, retry_count, coalesce(resolved_at, '')
+		from failure_ledger
+		`+where+`
+		order by (resolved_at is null) desc, last_seen_at desc, failure_id desc
+		limit ?`, append(args, opts.Limit)...)
+	if err != nil {
+		return FailureReport{}, fmt.Errorf("list failures: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	for rows.Next() {
+		var row Failure
+		var firstSeen, lastSeen, resolved string
+		if err := rows.Scan(
+			&row.FailureID, &row.Operation, &row.Source, &row.GuildID, &row.ChannelID, &row.MessageID,
+			&row.RelatedKind, &row.RelatedID, &row.ErrorClass, &row.ErrorMessage,
+			&firstSeen, &lastSeen, &row.RetryCount, &resolved,
+		); err != nil {
+			return FailureReport{}, fmt.Errorf("scan failure: %w", err)
+		}
+		row.FirstSeenAt = parseTime(firstSeen)
+		row.LastSeenAt = parseTime(lastSeen)
+		row.ResolvedAt = parseTime(resolved)
+		report.Failures = append(report.Failures, row)
+	}
+	if err := rows.Err(); err != nil {
+		return FailureReport{}, fmt.Errorf("list failures: %w", err)
+	}
+	return report, nil
+}
+
+func (s *Store) pruneResolvedFailures(ctx context.Context, now time.Time) error {
+	cutoff := now.Add(-resolvedFailureMaxAge).Format(timeLayout)
+	if _, err := s.db.ExecContext(ctx, `delete from failure_ledger where resolved_at is not null and resolved_at < ?`, cutoff); err != nil {
+		return fmt.Errorf("prune resolved failures: %w", err)
+	}
+	return nil
+}
+
+func failureWhere(opts FailureListOptions) (string, []any) {
+	clauses := []string{"1 = 1"}
+	args := []any{}
+	if !opts.IncludeResolved {
+		clauses = append(clauses, "resolved_at is null")
+	}
+	if opts.Source != "" {
+		clauses = append(clauses, "source = ?")
+		args = append(args, opts.Source)
+	}
+	if opts.GuildID != "" {
+		clauses = append(clauses, "guild_id = ?")
+		args = append(args, opts.GuildID)
+	}
+	if opts.ChannelID != "" {
+		clauses = append(clauses, "channel_id = ?")
+		args = append(args, opts.ChannelID)
+	}
+	return "where " + strings.Join(clauses, " and "), args
+}
+
+func mergeFailureRef(base, contextual FailureRef) FailureRef {
+	if base.Operation == "" {
+		base.Operation = contextual.Operation
+	}
+	if base.Source == "" {
+		base.Source = contextual.Source
+	}
+	if base.GuildID == "" {
+		base.GuildID = contextual.GuildID
+	}
+	if base.ChannelID == "" {
+		base.ChannelID = contextual.ChannelID
+	}
+	if base.MessageID == "" {
+		base.MessageID = contextual.MessageID
+	}
+	if base.RelatedKind == "" {
+		base.RelatedKind = contextual.RelatedKind
+	}
+	if base.RelatedID == "" {
+		base.RelatedID = contextual.RelatedID
+	}
+	return base
+}
+
+func normalizeFailureRef(ref FailureRef) FailureRef {
+	ref.Operation = strings.TrimSpace(ref.Operation)
+	ref.Source = strings.TrimSpace(ref.Source)
+	ref.GuildID = strings.TrimSpace(ref.GuildID)
+	ref.ChannelID = strings.TrimSpace(ref.ChannelID)
+	ref.MessageID = strings.TrimSpace(ref.MessageID)
+	ref.RelatedKind = strings.TrimSpace(ref.RelatedKind)
+	ref.RelatedID = strings.TrimSpace(ref.RelatedID)
+	return ref
+}
+
+func failureClass(err error) string {
+	switch {
+	case errors.Is(err, context.Canceled):
+		return "context_canceled"
+	case errors.Is(err, context.DeadlineExceeded):
+		return "deadline_exceeded"
+	}
+	root := err
+	for {
+		unwrapped := errors.Unwrap(root)
+		if unwrapped == nil {
+			break
+		}
+		root = unwrapped
+	}
+	typ := reflect.TypeOf(root)
+	if typ == nil {
+		return "error"
+	}
+	name := strings.TrimPrefix(typ.String(), "*")
+	if strings.Contains(strings.ToLower(name), "sqlite") {
+		return "sqlite"
+	}
+	return name
+}
+
+func sanitizeFailureMessage(message string) string {
+	message = strings.ToValidUTF8(message, "")
+	message = strings.Join(strings.Fields(message), " ")
+	message = failureBearerPattern.ReplaceAllString(message, `${1}[redacted]`)
+	message = failureSecretPattern.ReplaceAllString(message, `${1}[redacted]`)
+	message = failureJSONPattern.ReplaceAllString(message, `${1}[redacted]`)
+	runes := []rune(message)
+	if len(runes) > maxFailureMessage {
+		message = string(runes[:maxFailureMessage])
+	}
+	return message
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return value
+		}
+	}
+	return ""
+}

--- a/internal/store/failures.go
+++ b/internal/store/failures.go
@@ -19,8 +19,9 @@ const (
 
 var (
 	failureBearerPattern = regexp.MustCompile(`(?i)(bearer\s+)[^\s,;]+`)
-	failureSecretPattern = regexp.MustCompile(`(?i)([?&](?:token|key|secret|authorization)=)[^&\s]+`)
-	failureJSONPattern   = regexp.MustCompile(`(?i)("(?:token|key|secret|authorization)"\s*:\s*")[^"]+`)
+	failureHeaderPattern = regexp.MustCompile(`(?i)(\b[a-z0-9_.-]*(?:token|key|secret|authorization)[a-z0-9_.-]*\s*:\s*)(?:(?:bearer|basic)\s+)?[^\s,;]+`)
+	failureSecretPattern = regexp.MustCompile(`(?i)([?&]?[a-z0-9_.-]*(?:token|key|secret|authorization)[a-z0-9_.-]*=)[^&\s,;]+`)
+	failureJSONPattern   = regexp.MustCompile(`(?i)("[a-z0-9_.-]*(?:token|key|secret|authorization)[a-z0-9_.-]*"\s*:\s*")[^"]+`)
 )
 
 type FailureRef struct {
@@ -357,6 +358,7 @@ func failureClass(err error) string {
 func sanitizeFailureMessage(message string) string {
 	message = strings.ToValidUTF8(message, "")
 	message = strings.Join(strings.Fields(message), " ")
+	message = failureHeaderPattern.ReplaceAllString(message, `${1}[redacted]`)
 	message = failureBearerPattern.ReplaceAllString(message, `${1}[redacted]`)
 	message = failureSecretPattern.ReplaceAllString(message, `${1}[redacted]`)
 	message = failureJSONPattern.ReplaceAllString(message, `${1}[redacted]`)

--- a/internal/store/failures.go
+++ b/internal/store/failures.go
@@ -18,6 +18,7 @@ const (
 )
 
 var (
+	failureURLPattern    = regexp.MustCompile(`(?i)\bhttps?://[^\s,;]+`)
 	failureBearerPattern = regexp.MustCompile(`(?i)(bearer\s+)[^\s,;]+`)
 	failureHeaderPattern = regexp.MustCompile(`(?i)(\b[a-z0-9_.-]*(?:token|key|secret|authorization)[a-z0-9_.-]*\s*:\s*)(?:(?:bearer|basic)\s+)?[^\s,;]+`)
 	failureSecretPattern = regexp.MustCompile(`(?i)([?&]?[a-z0-9_.-]*(?:token|key|secret|authorization)[a-z0-9_.-]*=)[^&\s,;]+`)
@@ -156,6 +157,24 @@ func (s *Store) ResolveFailures(ctx context.Context, ref FailureRef) error {
 	query := `update failure_ledger set resolved_at = ? where ` + strings.Join(clauses, " and ")
 	if _, err := s.db.ExecContext(ctx, query, args...); err != nil {
 		return fmt.Errorf("resolve %s/%s failures: %w", ref.Source, ref.Operation, err)
+	}
+	return s.pruneResolvedFailures(ctx, now)
+}
+
+// ResolveFailureIdentity resolves only the exact failure identity, including empty scope fields.
+func (s *Store) ResolveFailureIdentity(ctx context.Context, ref FailureRef) error {
+	ref = normalizeFailureRef(ref)
+	if ref.Operation == "" || ref.Source == "" {
+		return errors.New("failure operation and source are required")
+	}
+	now := time.Now().UTC()
+	if _, err := s.db.ExecContext(ctx, `
+		update failure_ledger set resolved_at = ?
+		where resolved_at is null and operation = ? and source = ?
+		  and guild_id = ? and channel_id = ? and message_id = ?
+		  and related_kind = ? and related_id = ?
+	`, now.Format(timeLayout), ref.Operation, ref.Source, ref.GuildID, ref.ChannelID, ref.MessageID, ref.RelatedKind, ref.RelatedID); err != nil {
+		return fmt.Errorf("resolve exact %s/%s failure: %w", ref.Source, ref.Operation, err)
 	}
 	return s.pruneResolvedFailures(ctx, now)
 }
@@ -358,6 +377,7 @@ func failureClass(err error) string {
 func sanitizeFailureMessage(message string) string {
 	message = strings.ToValidUTF8(message, "")
 	message = strings.Join(strings.Fields(message), " ")
+	message = failureURLPattern.ReplaceAllString(message, "[redacted-url]")
 	message = failureHeaderPattern.ReplaceAllString(message, `${1}[redacted]`)
 	message = failureBearerPattern.ReplaceAllString(message, `${1}[redacted]`)
 	message = failureSecretPattern.ReplaceAllString(message, `${1}[redacted]`)

--- a/internal/store/failures_test.go
+++ b/internal/store/failures_test.go
@@ -21,7 +21,7 @@ func TestFailureLedgerRetriesResolvesReopensAndRedacts(t *testing.T) {
 	defer func() { _ = s.Close() }()
 
 	ref := FailureRef{Operation: "sync_messages", Source: "discord", GuildID: "g1", ChannelID: "c1"}
-	failure := errors.New(`request failed: Bearer abc123 https://example.test/?token=secret {"authorization":"hidden"}`)
+	failure := errors.New(`request failed: Bearer abc123 https://example.test/?api_key=api-value&access_token=access-value {"authorization":"hidden","refresh_token":"refresh-value","client_secret":"client-value"} X-API-Key: header-value Authorization: Basic basic-value`)
 	require.NoError(t, s.RecordFailure(ctx, ref, failure))
 	require.NoError(t, s.RecordFailure(ctx, ref, failure))
 
@@ -32,8 +32,13 @@ func TestFailureLedgerRetriesResolvesReopensAndRedacts(t *testing.T) {
 	require.Equal(t, 1, report.Failures[0].RetryCount)
 	require.Contains(t, report.Failures[0].ErrorMessage, "[redacted]")
 	require.NotContains(t, report.Failures[0].ErrorMessage, "abc123")
-	require.NotContains(t, report.Failures[0].ErrorMessage, "secret")
+	require.NotContains(t, report.Failures[0].ErrorMessage, "api-value")
 	require.NotContains(t, report.Failures[0].ErrorMessage, "hidden")
+	require.NotContains(t, report.Failures[0].ErrorMessage, "access-value")
+	require.NotContains(t, report.Failures[0].ErrorMessage, "refresh-value")
+	require.NotContains(t, report.Failures[0].ErrorMessage, "client-value")
+	require.NotContains(t, report.Failures[0].ErrorMessage, "header-value")
+	require.NotContains(t, report.Failures[0].ErrorMessage, "basic-value")
 	firstSeen := report.Failures[0].FirstSeenAt
 
 	require.NoError(t, s.ResolveFailures(ctx, ref))

--- a/internal/store/failures_test.go
+++ b/internal/store/failures_test.go
@@ -21,7 +21,7 @@ func TestFailureLedgerRetriesResolvesReopensAndRedacts(t *testing.T) {
 	defer func() { _ = s.Close() }()
 
 	ref := FailureRef{Operation: "sync_messages", Source: "discord", GuildID: "g1", ChannelID: "c1"}
-	failure := errors.New(`request failed: Bearer abc123 https://example.test/?api_key=api-value&access_token=access-value {"authorization":"hidden","refresh_token":"refresh-value","client_secret":"client-value"} X-API-Key: header-value Authorization: Basic basic-value`)
+	failure := errors.New(`request failed: Bearer abc123 https://example.test/private?hm=signed-value api_key=api-value&access_token=access-value {"authorization":"hidden","refresh_token":"refresh-value","client_secret":"client-value"} X-API-Key: header-value Authorization: Basic basic-value`)
 	require.NoError(t, s.RecordFailure(ctx, ref, failure))
 	require.NoError(t, s.RecordFailure(ctx, ref, failure))
 
@@ -32,6 +32,8 @@ func TestFailureLedgerRetriesResolvesReopensAndRedacts(t *testing.T) {
 	require.Equal(t, 1, report.Failures[0].RetryCount)
 	require.Contains(t, report.Failures[0].ErrorMessage, "[redacted]")
 	require.NotContains(t, report.Failures[0].ErrorMessage, "abc123")
+	require.NotContains(t, report.Failures[0].ErrorMessage, "example.test")
+	require.NotContains(t, report.Failures[0].ErrorMessage, "signed-value")
 	require.NotContains(t, report.Failures[0].ErrorMessage, "api-value")
 	require.NotContains(t, report.Failures[0].ErrorMessage, "hidden")
 	require.NotContains(t, report.Failures[0].ErrorMessage, "access-value")
@@ -183,6 +185,26 @@ func TestFailureLedgerPrunesOldResolvedRows(t *testing.T) {
 	var oldCount int
 	require.NoError(t, s.DB().QueryRowContext(ctx, `select count(*) from failure_ledger where message_id = 'old'`).Scan(&oldCount))
 	require.Zero(t, oldCount)
+}
+
+func TestResolveFailureIdentityDoesNotClearScopedFailures(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	s, err := Open(ctx, filepath.Join(t.TempDir(), "discrawl.db"))
+	require.NoError(t, err)
+	defer func() { _ = s.Close() }()
+
+	unscoped := FailureRef{Operation: "import_messages", Source: "wiretap"}
+	scoped := FailureRef{Operation: "import_messages", Source: "wiretap", MessageID: "m1"}
+	require.NoError(t, s.RecordFailure(ctx, unscoped, errors.New("transaction failed")))
+	require.NoError(t, s.RecordFailure(ctx, scoped, errors.New("row failed")))
+	require.NoError(t, s.ResolveFailureIdentity(ctx, unscoped))
+
+	report, err := s.ListFailures(ctx, FailureListOptions{}, time.Now())
+	require.NoError(t, err)
+	require.Equal(t, 1, report.UnresolvedCount)
+	require.Len(t, report.Failures, 1)
+	require.Equal(t, "m1", report.Failures[0].MessageID)
 }
 
 func TestFailureHelpersHandleNilContextsAndBounds(t *testing.T) {

--- a/internal/store/failures_test.go
+++ b/internal/store/failures_test.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"fmt"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -116,4 +118,104 @@ func TestOpenMigratesSchemaV3FailureLedger(t *testing.T) {
 	var version int
 	require.NoError(t, s.DB().QueryRowContext(ctx, `pragma user_version`).Scan(&version))
 	require.Equal(t, storeSchemaVersion, version)
+}
+
+func TestFailureLedgerFiltersLimitsAndBulkResolution(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	s, err := Open(ctx, filepath.Join(t.TempDir(), "discrawl.db"))
+	require.NoError(t, err)
+	defer func() { _ = s.Close() }()
+
+	refs := []FailureRef{
+		{Operation: "sync", Source: "discord", GuildID: "g1", ChannelID: "c1", MessageID: "m1"},
+		{Operation: "sync", Source: "discord", GuildID: "g1", ChannelID: "c2", MessageID: "m2"},
+		{Operation: "import", Source: "wiretap", GuildID: "g2", ChannelID: "c3", MessageID: "m3"},
+	}
+	for i, ref := range refs {
+		require.NoError(t, s.RecordFailure(ctx, ref, fmt.Errorf("failure %d", i)))
+	}
+
+	report, err := s.ListFailures(ctx, FailureListOptions{Source: " discord ", GuildID: " g1 ", ChannelID: " c1 ", Limit: 1}, time.Now())
+	require.NoError(t, err)
+	require.Equal(t, 1, report.UnresolvedCount)
+	require.Len(t, report.Failures, 1)
+	require.Equal(t, "m1", report.Failures[0].MessageID)
+
+	_, err = s.ListFailures(ctx, FailureListOptions{Limit: maxFailureLimit + 1}, time.Now())
+	require.ErrorContains(t, err, "at most 1000")
+	require.Error(t, s.ResolveMessageFailures(ctx, FailureRef{Operation: "sync"}, []string{"m1"}))
+	require.NoError(t, s.ResolveMessageFailures(ctx, FailureRef{Operation: "sync", Source: "discord"}, []string{" ", "m1", "m1", "m2"}))
+
+	report, err = s.ListFailures(ctx, FailureListOptions{}, time.Now())
+	require.NoError(t, err)
+	require.Equal(t, 1, report.UnresolvedCount)
+	require.Equal(t, "m3", report.Failures[0].MessageID)
+	report, err = s.ListFailures(ctx, FailureListOptions{IncludeResolved: true}, time.Now())
+	require.NoError(t, err)
+	require.Len(t, report.Failures, 3)
+
+	require.Error(t, s.RecordFailure(ctx, FailureRef{Operation: "sync"}, errors.New("missing source")))
+	require.Error(t, s.ResolveFailures(ctx, FailureRef{Source: "discord"}))
+	require.NoError(t, s.ResolveMessageFailures(ctx, FailureRef{Operation: "sync", Source: "discord"}, nil))
+}
+
+func TestFailureLedgerPrunesOldResolvedRows(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	s, err := Open(ctx, filepath.Join(t.TempDir(), "discrawl.db"))
+	require.NoError(t, err)
+	defer func() { _ = s.Close() }()
+
+	oldRef := FailureRef{Operation: "sync", Source: "discord", MessageID: "old"}
+	require.NoError(t, s.RecordFailure(ctx, oldRef, errors.New("old failure")))
+	require.NoError(t, s.ResolveFailures(ctx, oldRef))
+	oldResolvedAt := time.Now().Add(-resolvedFailureMaxAge - time.Hour).UTC().Format(timeLayout)
+	_, err = s.DB().ExecContext(ctx, `update failure_ledger set resolved_at = ? where message_id = 'old'`, oldResolvedAt)
+	require.NoError(t, err)
+
+	require.NoError(t, s.RecordFailure(ctx, FailureRef{Operation: "sync", Source: "discord", MessageID: "new"}, errors.New("new failure")))
+	var oldCount int
+	require.NoError(t, s.DB().QueryRowContext(ctx, `select count(*) from failure_ledger where message_id = 'old'`).Scan(&oldCount))
+	require.Zero(t, oldCount)
+}
+
+func TestFailureHelpersHandleNilContextsAndBounds(t *testing.T) {
+	t.Parallel()
+	var rowErr *RowWriteError
+	require.Equal(t, "row write failed", rowErr.Error())
+	require.NoError(t, rowErr.Unwrap())
+	require.Empty(t, FailureRefFromError(errors.New("plain")))
+	require.Equal(t, "context_canceled", failureClass(context.Canceled))
+	require.Equal(t, "deadline_exceeded", failureClass(context.DeadlineExceeded))
+	require.Equal(t, "error", failureClass(nil))
+	require.Empty(t, firstNonEmpty(" ", ""))
+
+	wrapped := &RowWriteError{Ref: FailureRef{Operation: "write_message", Source: "wiretap"}, Err: errors.New("boom")}
+	require.Equal(t, wrapped.Ref, FailureRefFromError(fmt.Errorf("outer: %w", wrapped)))
+	require.ErrorContains(t, wrapped, "write_message failed")
+	require.ErrorIs(t, wrapped, wrapped.Err)
+
+	message := sanitizeFailureMessage(string([]byte{'a', 0xff, 'b'}) + " " + strings.Repeat("x", maxFailureMessage+10))
+	require.NotContains(t, message, "\ufffd")
+	require.Len(t, []rune(message), maxFailureMessage)
+
+	original := errors.New("embedding failed")
+	require.ErrorIs(t, withEmbeddingFailureRecord(original, nil), original)
+	require.ErrorContains(t, withEmbeddingFailureRecord(original, errors.New("ledger failed")), "record failure ledger: ledger failed")
+}
+
+func TestFailureLedgerReportsClosedDatabaseErrors(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	s, err := Open(ctx, filepath.Join(t.TempDir(), "discrawl.db"))
+	require.NoError(t, err)
+	require.NoError(t, s.Close())
+	ref := FailureRef{Operation: "sync", Source: "discord", MessageID: "m1"}
+
+	require.ErrorContains(t, s.RecordFailure(ctx, ref, errors.New("boom")), "record discord/sync failure")
+	require.ErrorContains(t, s.ResolveFailures(ctx, ref), "resolve discord/sync failures")
+	require.ErrorContains(t, s.ResolveMessageFailures(ctx, ref, []string{"m1"}), "resolve discord/sync message failures")
+	_, err = s.ListFailures(ctx, FailureListOptions{}, time.Now())
+	require.ErrorContains(t, err, "count unresolved failures")
 }

--- a/internal/store/failures_test.go
+++ b/internal/store/failures_test.go
@@ -1,0 +1,119 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestFailureLedgerRetriesResolvesReopensAndRedacts(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	s, err := Open(ctx, filepath.Join(t.TempDir(), "discrawl.db"))
+	require.NoError(t, err)
+	defer func() { _ = s.Close() }()
+
+	ref := FailureRef{Operation: "sync_messages", Source: "discord", GuildID: "g1", ChannelID: "c1"}
+	failure := errors.New(`request failed: Bearer abc123 https://example.test/?token=secret {"authorization":"hidden"}`)
+	require.NoError(t, s.RecordFailure(ctx, ref, failure))
+	require.NoError(t, s.RecordFailure(ctx, ref, failure))
+
+	report, err := s.ListFailures(ctx, FailureListOptions{}, time.Now())
+	require.NoError(t, err)
+	require.Equal(t, 1, report.UnresolvedCount)
+	require.Len(t, report.Failures, 1)
+	require.Equal(t, 1, report.Failures[0].RetryCount)
+	require.Contains(t, report.Failures[0].ErrorMessage, "[redacted]")
+	require.NotContains(t, report.Failures[0].ErrorMessage, "abc123")
+	require.NotContains(t, report.Failures[0].ErrorMessage, "secret")
+	require.NotContains(t, report.Failures[0].ErrorMessage, "hidden")
+	firstSeen := report.Failures[0].FirstSeenAt
+
+	require.NoError(t, s.ResolveFailures(ctx, ref))
+	report, err = s.ListFailures(ctx, FailureListOptions{}, time.Now())
+	require.NoError(t, err)
+	require.Zero(t, report.UnresolvedCount)
+	require.Empty(t, report.Failures)
+
+	report, err = s.ListFailures(ctx, FailureListOptions{IncludeResolved: true}, time.Now())
+	require.NoError(t, err)
+	require.Len(t, report.Failures, 1)
+	require.False(t, report.Failures[0].ResolvedAt.IsZero())
+
+	require.NoError(t, s.RecordFailure(ctx, ref, errors.New("failed again")))
+	report, err = s.ListFailures(ctx, FailureListOptions{}, time.Now())
+	require.NoError(t, err)
+	require.Len(t, report.Failures, 1)
+	require.Equal(t, 2, report.Failures[0].RetryCount)
+	require.Equal(t, firstSeen, report.Failures[0].FirstSeenAt)
+	require.True(t, report.Failures[0].ResolvedAt.IsZero())
+}
+
+func TestAttachmentWriteErrorIncludesSafeRowContext(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	s, err := Open(ctx, filepath.Join(t.TempDir(), "discrawl.db"))
+	require.NoError(t, err)
+	defer func() { _ = s.Close() }()
+	_, err = s.DB().ExecContext(ctx, `
+		create trigger fail_attachment before insert on message_attachments
+		begin select raise(abort, 'forced attachment failure'); end
+	`)
+	require.NoError(t, err)
+
+	err = s.UpsertMessages(ctx, []MessageMutation{{
+		Record: MessageRecord{
+			ID: "m1", GuildID: "g1", ChannelID: "c1", AuthorID: "u1",
+			CreatedAt: "2026-07-01T08:00:00Z", Content: "private body", NormalizedContent: "private body", RawJSON: `{}`,
+		},
+		Attachments: []AttachmentRecord{{
+			AttachmentID: "a1", MessageID: "m1", GuildID: "g1", ChannelID: "c1", AuthorID: "u1",
+			Filename: "trace.txt", ContentType: "text/plain", Size: 42, URL: "https://example.invalid/private",
+		}},
+	}})
+	require.Error(t, err)
+	require.ErrorContains(t, err, `attachment_id="a1"`)
+	require.ErrorContains(t, err, `message_id="m1"`)
+	require.ErrorContains(t, err, `guild_id="g1"`)
+	require.ErrorContains(t, err, `channel_id="c1"`)
+	require.ErrorContains(t, err, `author_id="u1"`)
+	require.ErrorContains(t, err, `filename="trace.txt"`)
+	require.ErrorContains(t, err, `content_type="text/plain"`)
+	require.ErrorContains(t, err, `size=42`)
+	require.NotContains(t, err.Error(), "private body")
+	require.NotContains(t, err.Error(), "example.invalid")
+	require.Equal(t, FailureRef{
+		Operation: "write_attachment", GuildID: "g1", ChannelID: "c1", MessageID: "m1",
+		RelatedKind: "attachment_id", RelatedID: "a1",
+	}, FailureRefFromError(err))
+}
+
+func TestOpenMigratesSchemaV3FailureLedger(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "discrawl.db")
+	s, err := Open(ctx, dbPath)
+	require.NoError(t, err)
+	require.NoError(t, s.Close())
+
+	db, err := sql.Open("sqlite", dbPath)
+	require.NoError(t, err)
+	_, err = db.ExecContext(ctx, `drop table failure_ledger`)
+	require.NoError(t, err)
+	_, err = db.ExecContext(ctx, `pragma user_version = 3`)
+	require.NoError(t, err)
+	require.NoError(t, db.Close())
+
+	s, err = Open(ctx, dbPath)
+	require.NoError(t, err)
+	defer func() { _ = s.Close() }()
+	require.NoError(t, s.RecordFailure(ctx, FailureRef{Operation: "sync", Source: "discord"}, errors.New("boom")))
+	var version int
+	require.NoError(t, s.DB().QueryRowContext(ctx, `pragma user_version`).Scan(&version))
+	require.Equal(t, storeSchemaVersion, version)
+}

--- a/internal/store/sqlc/schema.sql
+++ b/internal/store/sqlc/schema.sql
@@ -131,6 +131,24 @@ create table message_embeddings (
 	primary key (message_id, provider, model, input_version)
 );
 
+create table failure_ledger (
+	failure_id integer primary key autoincrement,
+	operation text not null,
+	source text not null,
+	guild_id text not null default '',
+	channel_id text not null default '',
+	message_id text not null default '',
+	related_kind text not null default '',
+	related_id text not null default '',
+	error_class text not null,
+	error_message text not null,
+	first_seen_at text not null,
+	last_seen_at text not null,
+	retry_count integer not null default 0,
+	resolved_at text,
+	unique(operation, source, guild_id, channel_id, message_id, related_kind, related_id)
+);
+
 -- sqlc only needs parseable table shapes. Runtime migrations create real FTS5
 -- virtual tables and maintain rowids.
 create table message_fts (

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -17,7 +17,7 @@ const (
 	timeLayout         = "2006-01-02T15:04:05.000000000Z07:00"
 	messageFTSVersion  = "2"
 	memberFTSVersion   = "1"
-	storeSchemaVersion = 3
+	storeSchemaVersion = 4
 )
 
 var ErrSchemaVersionMismatch = errors.New("database schema version mismatch")
@@ -190,6 +190,15 @@ func (s *Store) migrate(ctx context.Context) error {
 		if err := s.setSchemaVersion(ctx, 3); err != nil {
 			return err
 		}
+		currentVersion = 3
+	}
+	if currentVersion < 4 {
+		if err := s.applyFailureLedgerMigration(ctx); err != nil {
+			return err
+		}
+		if err := s.setSchemaVersion(ctx, 4); err != nil {
+			return err
+		}
 	}
 	if version, err := s.schemaVersion(ctx); err != nil {
 		return err
@@ -200,6 +209,9 @@ func (s *Store) migrate(ctx context.Context) error {
 		return err
 	}
 	if err := s.applyAttachmentMediaMigration(ctx); err != nil {
+		return err
+	}
+	if err := s.applyFailureLedgerMigration(ctx); err != nil {
 		return err
 	}
 	if err := s.ensureFTSRowIDs(ctx); err != nil {
@@ -420,6 +432,23 @@ func (s *Store) applyBaselineSchema(ctx context.Context) error {
 			embedded_at text not null,
 			primary key (message_id, provider, model, input_version)
 		);`,
+		`create table if not exists failure_ledger (
+			failure_id integer primary key autoincrement,
+			operation text not null,
+			source text not null,
+			guild_id text not null default '',
+			channel_id text not null default '',
+			message_id text not null default '',
+			related_kind text not null default '',
+			related_id text not null default '',
+			error_class text not null,
+			error_message text not null,
+			first_seen_at text not null,
+			last_seen_at text not null,
+			retry_count integer not null default 0,
+			resolved_at text,
+			unique(operation, source, guild_id, channel_id, message_id, related_kind, related_id)
+		);`,
 		// Uses SQLite FTS5's default unicode61 tokenizer; normalizeFTSQuery quotes user terms before MATCH.
 		`create virtual table if not exists message_fts using fts5(
 			message_id unindexed,
@@ -456,6 +485,8 @@ func (s *Store) applyBaselineSchema(ctx context.Context) error {
 		`create index if not exists idx_mentions_author on mention_events(author_id, event_at);`,
 		`create index if not exists idx_embedding_jobs_state_updated on embedding_jobs(state, updated_at);`,
 		`create index if not exists idx_message_embeddings_identity on message_embeddings(provider, model, input_version, dimensions);`,
+		`create index if not exists idx_failure_ledger_unresolved on failure_ledger(resolved_at, last_seen_at desc);`,
+		`create index if not exists idx_failure_ledger_scope on failure_ledger(guild_id, channel_id, message_id);`,
 	}
 	for _, stmt := range stmts {
 		if _, err := tx.ExecContext(ctx, stmt); err != nil {
@@ -494,6 +525,40 @@ func (s *Store) applyAttachmentMediaMigration(ctx context.Context) error {
 	}
 	if _, err := tx.ExecContext(ctx, `create index if not exists idx_attachments_sha256 on message_attachments(content_sha256)`); err != nil {
 		return fmt.Errorf("ensure attachment media index: %w", err)
+	}
+	return tx.Commit()
+}
+
+func (s *Store) applyFailureLedgerMigration(ctx context.Context) error {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer rollback(tx)
+	for _, stmt := range []string{
+		`create table if not exists failure_ledger (
+			failure_id integer primary key autoincrement,
+			operation text not null,
+			source text not null,
+			guild_id text not null default '',
+			channel_id text not null default '',
+			message_id text not null default '',
+			related_kind text not null default '',
+			related_id text not null default '',
+			error_class text not null,
+			error_message text not null,
+			first_seen_at text not null,
+			last_seen_at text not null,
+			retry_count integer not null default 0,
+			resolved_at text,
+			unique(operation, source, guild_id, channel_id, message_id, related_kind, related_id)
+		);`,
+		`create index if not exists idx_failure_ledger_unresolved on failure_ledger(resolved_at, last_seen_at desc);`,
+		`create index if not exists idx_failure_ledger_scope on failure_ledger(guild_id, channel_id, message_id);`,
+	} {
+		if _, err := tx.ExecContext(ctx, stmt); err != nil {
+			return fmt.Errorf("migrate failure ledger: %w", err)
+		}
 	}
 	return tx.Commit()
 }

--- a/internal/store/store_write_test.go
+++ b/internal/store/store_write_test.go
@@ -512,6 +512,50 @@ func TestUpsertMessageWithEmbeddingsDoesNotRequeueUnchangedDoneJob(t *testing.T)
 	require.Equal(t, [][]string{{"pending", "0", ""}}, rows)
 }
 
+func TestEmbeddingSuccessResolvesOnlyCurrentIdentityFailure(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	s, err := Open(ctx, filepath.Join(t.TempDir(), "discrawl.db"))
+	require.NoError(t, err)
+	defer func() { _ = s.Close() }()
+
+	require.NoError(t, s.UpsertMessageWithOptions(ctx, MessageRecord{
+		ID:                "m1",
+		GuildID:           "g1",
+		ChannelID:         "c1",
+		MessageType:       0,
+		CreatedAt:         time.Now().UTC().Format(time.RFC3339Nano),
+		Content:           "hello",
+		NormalizedContent: "hello",
+		RawJSON:           `{}`,
+	}, WriteOptions{EnqueueEmbedding: true}))
+
+	opts := normalizeEmbeddingDrainOptions(EmbeddingDrainOptions{
+		Provider: "ollama", Model: "nomic-embed-text", Limit: 10, BatchSize: 1,
+	})
+	currentRef := embeddingFailureRef(opts, "m1")
+	oldRef := currentRef
+	oldRef.RelatedID = "other/old-model/old-input"
+	require.NoError(t, s.RecordFailure(ctx, oldRef, errors.New("old provider failed")))
+	require.NoError(t, s.RecordFailure(ctx, currentRef, errors.New("current provider failed")))
+
+	stats, err := s.DrainEmbeddingJobs(ctx, &fakeEmbeddingProvider{
+		batches: []embed.EmbeddingBatch{{Vectors: [][]float32{{1, 2}}}},
+	}, opts)
+	require.NoError(t, err)
+	require.Equal(t, 1, stats.Succeeded)
+
+	report, err := s.ListFailures(ctx, FailureListOptions{}, time.Now())
+	require.NoError(t, err)
+	require.Equal(t, 1, report.UnresolvedCount)
+	require.Len(t, report.Failures, 1)
+	require.Equal(t, oldRef.RelatedID, report.Failures[0].RelatedID)
+	report, err = s.ListFailures(ctx, FailureListOptions{IncludeResolved: true}, time.Now())
+	require.NoError(t, err)
+	require.Len(t, report.Failures, 2)
+}
+
 func TestDrainEmbeddingJobsFailsWholeBatchOnDimensionMismatch(t *testing.T) {
 	t.Parallel()
 

--- a/internal/store/storedb/models.go
+++ b/internal/store/storedb/models.go
@@ -38,6 +38,23 @@ type EmbeddingJob struct {
 	UpdatedAt    string
 }
 
+type FailureLedger struct {
+	FailureID    int64
+	Operation    string
+	Source       string
+	GuildID      string
+	ChannelID    string
+	MessageID    string
+	RelatedKind  string
+	RelatedID    string
+	ErrorClass   string
+	ErrorMessage string
+	FirstSeenAt  string
+	LastSeenAt   string
+	RetryCount   int64
+	ResolvedAt   sql.NullString
+}
+
 type Guild struct {
 	ID        string
 	Name      string

--- a/internal/store/write.go
+++ b/internal/store/write.go
@@ -310,7 +310,16 @@ func upsertMessageTx(ctx context.Context, tx *sql.Tx, qtx *storedb.Queries, mess
 		}
 	}
 	if err := qtx.UpsertMessage(ctx, upsertMessageParams(message, now)); err != nil {
-		return err
+		return &RowWriteError{
+			Ref: FailureRef{
+				Operation: "write_message",
+				GuildID:   message.GuildID,
+				ChannelID: message.ChannelID,
+				MessageID: message.ID,
+			},
+			AuthorID: message.AuthorID,
+			Err:      err,
+		}
 	}
 	if rowID, ok := messageFTSRowID(message.ID); ok {
 		if _, err := tx.ExecContext(ctx, `delete from message_fts where rowid = ?`, rowID); err != nil {
@@ -418,7 +427,21 @@ func replaceAttachmentsTx(ctx context.Context, qtx *storedb.Queries, messageID s
 			attachment.FetchError = media.FetchError
 		}
 		if err := qtx.InsertMessageAttachment(ctx, insertMessageAttachmentParams(attachment, now)); err != nil {
-			return err
+			return &RowWriteError{
+				Ref: FailureRef{
+					Operation:   "write_attachment",
+					GuildID:     attachment.GuildID,
+					ChannelID:   attachment.ChannelID,
+					MessageID:   attachment.MessageID,
+					RelatedKind: "attachment_id",
+					RelatedID:   attachment.AttachmentID,
+				},
+				AuthorID:    attachment.AuthorID,
+				Filename:    attachment.Filename,
+				ContentType: attachment.ContentType,
+				Size:        attachment.Size,
+				Err:         err,
+			}
 		}
 	}
 	return nil

--- a/internal/syncer/failures.go
+++ b/internal/syncer/failures.go
@@ -1,0 +1,86 @@
+package syncer
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/openclaw/discrawl/internal/store"
+)
+
+const syncMessagesFailureOperation = "sync_messages"
+
+const tailMessageFailureOperation = "tail_message"
+
+func (s *Syncer) recordChannelFailure(ctx context.Context, guildID, channelID string, failure error) error {
+	if s == nil || s.store == nil || failure == nil {
+		return nil
+	}
+	ledgerCtx, cancel := failureLedgerContext(ctx)
+	defer cancel()
+	return s.store.RecordFailure(ledgerCtx, store.FailureRef{
+		Operation: syncMessagesFailureOperation,
+		Source:    "discord",
+		GuildID:   guildID,
+		ChannelID: channelID,
+	}, failure)
+}
+
+func (s *Syncer) resolveChannelFailures(ctx context.Context, guildID, channelID string) error {
+	if s == nil || s.store == nil {
+		return nil
+	}
+	ledgerCtx, cancel := failureLedgerContext(ctx)
+	defer cancel()
+	return s.store.ResolveFailures(ledgerCtx, store.FailureRef{
+		Operation: syncMessagesFailureOperation,
+		Source:    "discord",
+		GuildID:   guildID,
+		ChannelID: channelID,
+	})
+}
+
+func failureLedgerContext(ctx context.Context) (context.Context, context.CancelFunc) {
+	base := context.Background()
+	if ctx != nil {
+		base = context.WithoutCancel(ctx)
+	}
+	return context.WithTimeout(base, 5*time.Second)
+}
+
+func withFailureRecordError(failure, recordErr error) error {
+	if recordErr == nil {
+		return failure
+	}
+	return fmt.Errorf("%w (record failure ledger: %w)", failure, recordErr)
+}
+
+func (t *tailHandler) recordMessageFailure(ctx context.Context, guildID, channelID, messageID string, failure error) error {
+	if t == nil || t.store == nil || failure == nil {
+		return nil
+	}
+	ledgerCtx, cancel := failureLedgerContext(ctx)
+	defer cancel()
+	return t.store.RecordFailure(ledgerCtx, store.FailureRef{
+		Operation: tailMessageFailureOperation,
+		Source:    "discord",
+		GuildID:   guildID,
+		ChannelID: channelID,
+		MessageID: messageID,
+	}, failure)
+}
+
+func (t *tailHandler) resolveMessageFailures(ctx context.Context, guildID, channelID, messageID string) error {
+	if t == nil || t.store == nil {
+		return nil
+	}
+	ledgerCtx, cancel := failureLedgerContext(ctx)
+	defer cancel()
+	return t.store.ResolveFailures(ledgerCtx, store.FailureRef{
+		Operation: tailMessageFailureOperation,
+		Source:    "discord",
+		GuildID:   guildID,
+		ChannelID: channelID,
+		MessageID: messageID,
+	})
+}

--- a/internal/syncer/failures_test.go
+++ b/internal/syncer/failures_test.go
@@ -1,0 +1,46 @@
+package syncer
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/openclaw/discrawl/internal/store"
+)
+
+func TestTailFailureLedgerHelpers(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	st, err := store.Open(ctx, filepath.Join(t.TempDir(), "discrawl.db"))
+	require.NoError(t, err)
+	defer func() { _ = st.Close() }()
+
+	var nilSyncer *Syncer
+	require.NoError(t, nilSyncer.recordChannelFailure(ctx, "g", "c", errors.New("ignored")))
+	require.NoError(t, nilSyncer.resolveChannelFailures(ctx, "g", "c"))
+	var nilHandler *tailHandler
+	require.NoError(t, nilHandler.recordMessageFailure(ctx, "g", "c", "m", errors.New("ignored")))
+	require.NoError(t, nilHandler.resolveMessageFailures(ctx, "g", "c", "m"))
+
+	handler := &tailHandler{store: st}
+	require.NoError(t, handler.recordMessageFailure(nil, "g1", "c1", "m1", errors.New("gateway write failed")))
+	report, err := st.ListFailures(ctx, store.FailureListOptions{}, time.Now())
+	require.NoError(t, err)
+	require.Len(t, report.Failures, 1)
+	require.Equal(t, tailMessageFailureOperation, report.Failures[0].Operation)
+	require.Equal(t, "m1", report.Failures[0].MessageID)
+
+	require.NoError(t, handler.resolveMessageFailures(ctx, "g1", "c1", "m1"))
+	report, err = st.ListFailures(ctx, store.FailureListOptions{}, time.Now())
+	require.NoError(t, err)
+	require.Empty(t, report.Failures)
+	require.NoError(t, handler.recordMessageFailure(ctx, "g1", "c1", "m1", nil))
+
+	original := errors.New("original")
+	require.ErrorIs(t, withFailureRecordError(original, nil), original)
+	require.ErrorContains(t, withFailureRecordError(original, errors.New("ledger")), "record failure ledger: ledger")
+}

--- a/internal/syncer/failures_test.go
+++ b/internal/syncer/failures_test.go
@@ -27,7 +27,7 @@ func TestTailFailureLedgerHelpers(t *testing.T) {
 	require.NoError(t, nilHandler.resolveMessageFailures(ctx, "g", "c", "m"))
 
 	handler := &tailHandler{store: st}
-	require.NoError(t, handler.recordMessageFailure(nil, "g1", "c1", "m1", errors.New("gateway write failed")))
+	require.NoError(t, handler.recordMessageFailure(ctx, "g1", "c1", "m1", errors.New("gateway write failed")))
 	report, err := st.ListFailures(ctx, store.FailureListOptions{}, time.Now())
 	require.NoError(t, err)
 	require.Len(t, report.Failures, 1)

--- a/internal/syncer/message_sync.go
+++ b/internal/syncer/message_sync.go
@@ -86,12 +86,18 @@ func (s *Syncer) syncMessageChannelsSerial(ctx context.Context, guildID string, 
 		total += count
 		if err != nil {
 			if s.skipSyncError(ctx, channel, err) {
+				if recordErr := s.recordChannelFailure(ctx, guildID, channel.ID, err); recordErr != nil {
+					s.logger.Warn("record channel failure", "channel_id", channel.ID, "err", recordErr)
+				}
 				progress.recordSkip(channel, err)
 				continue
 			}
-			return total, fmt.Errorf("sync channel %s: %w", channel.ID, err)
+			return total, fmt.Errorf("sync channel %s: %w", channel.ID, withFailureRecordError(err, s.recordChannelFailure(ctx, guildID, channel.ID, err)))
 		}
 		if err := s.clearUnavailableChannel(ctx, channel.ID); err != nil {
+			return total, withFailureRecordError(err, s.recordChannelFailure(ctx, guildID, channel.ID, err))
+		}
+		if err := s.resolveChannelFailures(ctx, guildID, channel.ID); err != nil {
 			return total, err
 		}
 		progress.record(channel, count)
@@ -140,6 +146,16 @@ func (s *Syncer) syncMessageChannelsConcurrent(
 				}
 				if succeeded {
 					err = s.clearUnavailableChannel(ctx, channel.ID)
+					if err == nil {
+						err = s.resolveChannelFailures(ctx, guildID, channel.ID)
+					}
+				}
+				if skipped != nil {
+					if recordErr := s.recordChannelFailure(ctx, guildID, channel.ID, skipped); recordErr != nil {
+						s.logger.Warn("record channel failure", "channel_id", channel.ID, "err", recordErr)
+					}
+				} else if err != nil {
+					err = withFailureRecordError(err, s.recordChannelFailure(ctx, guildID, channel.ID, err))
 				}
 				select {
 				case results <- result{channelID: channel.ID, channel: channel, count: count, err: err, skipped: skipped}:

--- a/internal/syncer/syncer_test.go
+++ b/internal/syncer/syncer_test.go
@@ -1079,6 +1079,24 @@ func TestSyncSkipsRetryableChannelErrors(t *testing.T) {
 	unavailable, err := s.GetSyncState(ctx, "channel:c2:unavailable")
 	require.NoError(t, err)
 	require.Empty(t, unavailable)
+
+	failures, err := s.ListFailures(ctx, store.FailureListOptions{}, time.Now())
+	require.NoError(t, err)
+	require.Len(t, failures.Failures, 1)
+	require.Equal(t, "sync_messages", failures.Failures[0].Operation)
+	require.Equal(t, "c2", failures.Failures[0].ChannelID)
+	require.Equal(t, "deadline_exceeded", failures.Failures[0].ErrorClass)
+
+	delete(client.messageErrors, "c2")
+	_, err = svc.Sync(ctx, SyncOptions{Full: true, Concurrency: 2})
+	require.NoError(t, err)
+	failures, err = s.ListFailures(ctx, store.FailureListOptions{}, time.Now())
+	require.NoError(t, err)
+	require.Empty(t, failures.Failures)
+	failures, err = s.ListFailures(ctx, store.FailureListOptions{IncludeResolved: true}, time.Now())
+	require.NoError(t, err)
+	require.Len(t, failures.Failures, 1)
+	require.False(t, failures.Failures[0].ResolvedAt.IsZero())
 }
 
 func TestSyncClearsUnavailableMarkerAfterSuccessfulRead(t *testing.T) {

--- a/internal/syncer/tail.go
+++ b/internal/syncer/tail.go
@@ -74,18 +74,21 @@ func (t *tailHandler) OnMessageCreate(ctx context.Context, msg *discordgo.Messag
 	}
 	mutation, err := buildMessageMutation(ctx, msg, "", "", false, t.attachmentTextEnabled)
 	if err != nil {
-		return err
+		return withFailureRecordError(err, t.recordMessageFailure(ctx, msg.GuildID, msg.ChannelID, msg.ID, err))
 	}
 	if err := t.store.UpsertMessages(ctx, []store.MessageMutation{mutation}); err != nil {
-		return err
+		return withFailureRecordError(err, t.recordMessageFailure(ctx, msg.GuildID, msg.ChannelID, msg.ID, err))
 	}
 	if err := t.store.AppendMessageEvent(ctx, msg.GuildID, msg.ChannelID, msg.ID, "create", msg); err != nil {
-		return err
+		return withFailureRecordError(err, t.recordMessageFailure(ctx, msg.GuildID, msg.ChannelID, msg.ID, err))
 	}
 	if err := t.store.SetSyncState(ctx, "tail:last_event", msg.ID); err != nil {
-		return err
+		return withFailureRecordError(err, t.recordMessageFailure(ctx, msg.GuildID, msg.ChannelID, msg.ID, err))
 	}
-	return t.store.AdvanceChannelLatestMessageID(ctx, msg.ChannelID, msg.ID)
+	if err := t.store.AdvanceChannelLatestMessageID(ctx, msg.ChannelID, msg.ID); err != nil {
+		return withFailureRecordError(err, t.recordMessageFailure(ctx, msg.GuildID, msg.ChannelID, msg.ID, err))
+	}
+	return t.resolveMessageFailures(ctx, msg.GuildID, msg.ChannelID, msg.ID)
 }
 
 func (t *tailHandler) OnMessageUpdate(ctx context.Context, msg *discordgo.Message) error {
@@ -95,25 +98,29 @@ func (t *tailHandler) OnMessageUpdate(ctx context.Context, msg *discordgo.Messag
 	if msg.GuildID != "" && !t.allowGuild(msg.GuildID) {
 		return nil
 	}
+	guildID, channelID, messageID := msg.GuildID, msg.ChannelID, msg.ID
 	var err error
 	msg, err = t.messageUpdateSnapshot(ctx, msg)
 	if err != nil {
-		return err
+		return withFailureRecordError(err, t.recordMessageFailure(ctx, guildID, channelID, messageID, err))
 	}
 	if msg == nil || !t.allowGuild(msg.GuildID) {
 		return nil
 	}
 	mutation, err := buildMessageMutation(ctx, msg, "", "", false, t.attachmentTextEnabled)
 	if err != nil {
-		return err
+		return withFailureRecordError(err, t.recordMessageFailure(ctx, msg.GuildID, msg.ChannelID, msg.ID, err))
 	}
 	if err := t.store.UpsertMessages(ctx, []store.MessageMutation{mutation}); err != nil {
-		return err
+		return withFailureRecordError(err, t.recordMessageFailure(ctx, msg.GuildID, msg.ChannelID, msg.ID, err))
 	}
 	if err := t.store.AppendMessageEvent(ctx, msg.GuildID, msg.ChannelID, msg.ID, "update", msg); err != nil {
-		return err
+		return withFailureRecordError(err, t.recordMessageFailure(ctx, msg.GuildID, msg.ChannelID, msg.ID, err))
 	}
-	return t.store.SetSyncState(ctx, "tail:last_event", msg.ID)
+	if err := t.store.SetSyncState(ctx, "tail:last_event", msg.ID); err != nil {
+		return withFailureRecordError(err, t.recordMessageFailure(ctx, msg.GuildID, msg.ChannelID, msg.ID, err))
+	}
+	return t.resolveMessageFailures(ctx, msg.GuildID, msg.ChannelID, msg.ID)
 }
 
 func (t *tailHandler) messageUpdateSnapshot(ctx context.Context, msg *discordgo.Message) (*discordgo.Message, error) {


### PR DESCRIPTION
## Summary

- add schema-v4 local failure ledger with operation/source and available guild, channel, message, and related-row identifiers
- wrap message/attachment SQLite writes with row context that excludes content, URLs, and raw payloads
- track and resolve Discord sync/tail, wiretap import, attachment media, and embedding failures
- add `discrawl failures` human/JSON queries plus unresolved known-failure counts in `coverage`
- retain unresolved rows, prune resolved history after 90 days, redact common secret forms, and exclude the ledger from Git snapshots

## Verification

- `GOWORK=off go test -count=1 ./...`
- `GOWORK=off go vet ./...`
- `GOWORK=off go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.11.1 run --allow-parallel-runners` (0 issues)
- autoreview clean

### Exact built live proof

Built this PR head, then used an explicit disposable archive and synthetic Discord Desktop cache:

1. installed a disposable SQLite trigger that rejects one attachment insert
2. ran `wiretap`; it failed visibly with attachment/message/guild/channel/author/filename/content-type/size context
3. verified `failures --json` reported one unresolved `wiretap/import_messages` SQLite failure and `coverage --json` reported one known failure on that guild/channel
4. removed the disposable trigger and retried the same import
5. verified one message imported, unresolved failures returned to zero, `--all` retained the resolved row, and coverage returned to zero known failures
6. exported a disposable snapshot and verified its manifest omitted `failure_ledger`

Closes #105
