### PR TITLE
fix: make routine snapshot updates monotonic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@
 - Add a local-only failure ledger with row-level write context, retry/resolution tracking, JSON queries, and known-failure coverage counts.
 - Add a local-first maintainer archive workflow guide covering health, coverage, wiretap, stable queries, and privacy-safe publish preflight. Thanks @joshka.
 
+### Fixes
+
+- Prevent routine Git snapshot updates from clearing locally crawled cache rows: changed shards now merge monotonically, while removed shards, schema changes, historical restores, and exact reconciliation require explicit `--force`; upgrade Crawlkit to v0.13.2.
+
 ### Maintenance
 
 - Refresh stable Go modules and CI/release tooling, including SQLite, `go-toml`, Go analyzers, GitHub Actions, GoReleaser, and TruffleHog.

--- a/README.md
+++ b/README.md
@@ -240,7 +240,7 @@ By default, `sync` runs both live/local sources and does not import the Git snap
 - Discord bot-token sync for bot-visible guild data
 - local Discord Desktop cache import for classifiable cached messages and proven DMs
 
-Use `discrawl update` when you want to pull/import the shared Git snapshot. If you intentionally want a sync run to import the snapshot before live deltas, pass `--update=auto` to import only when stale or `--update=force` to pull/import before syncing. `--no-update` is accepted as an explicit no-op alias for the default.
+Use `discrawl update` when you want to pull/import the shared Git snapshot. Routine updates merge changed shards without deleting local cache rows. If you intentionally want a sync run to import the snapshot before live deltas, pass `--update=auto` for a stale safe merge or `--update=force` for an exact replacement. `--no-update` is accepted as an explicit no-op alias for the default.
 
 Run one explicit `--full` pass when you want a complete historical guild archive. Use plain `sync` afterward for frequent latest-message and desktop-cache refreshes.
 
@@ -592,7 +592,7 @@ Subscriber:
 discrawl subscribe https://github.com/example/discord-archive.git
 discrawl search "launch checklist"
 discrawl messages --channel general --hours 24
-discrawl update --ref backup-2026-06-19
+discrawl update --force --ref backup-2026-06-19
 ```
 
 `subscribe` is the Git-only setup path. It writes a config with `discord.token_source = "none"`, imports the snapshot, and does not require a Discord bot token. `sync` and `tail` remain disabled in this mode because they need live Discord access.
@@ -639,9 +639,9 @@ discrawl subscribe --stale-after 15m https://github.com/example/discord-archive.
 discrawl subscribe --no-auto-update https://github.com/example/discord-archive.git
 ```
 
-Once `share.remote` is configured, read commands auto-fetch and import when the local share import is older than `share.stale_after` (default `15m`). Imports are planned from crawlkit shard fingerprints, with a Git-object fallback for older manifests, so routine updates normally read only changed tail shards and preserve local FTS rows instead of rebuilding the whole archive. `discrawl update` forces the same pull/import step manually; `update --ref <tag-or-commit>` restores that historical snapshot without moving the share checkout. `discrawl sync` does not auto-import the share unless `--update=auto` or `--update=force` is provided, so routine live refreshes stay fast.
+Once `share.remote` is configured, read commands auto-fetch and import when the last share check is older than `share.stale_after` (default `15m`). Imports are planned from crawlkit shard fingerprints, with a Git-object fallback for older manifests, so routine updates normally read only changed canonical shards, preserve destination-only cache rows, and avoid rebuilding message FTS. `discrawl update` runs the same safe merge manually. Removed shards or incompatible table changes keep the database untouched and require `discrawl update --force`; historical restores require `update --force --ref <tag-or-commit>`. `discrawl sync` does not auto-import the share unless `--update=auto` or `--update=force` is provided.
 
-Hybrid mode is supported too: keep normal Discord credentials configured and set `share.remote`. `discrawl sync --update=auto` and `discrawl messages --sync` import the Git snapshot first, usually as a changed-shard delta, then use live Discord for latest-message deltas. Use `sync --all-channels` or `sync --full` when you intentionally want a broader live repair/backfill pass.
+Hybrid mode is supported too: keep normal Discord credentials configured and set `share.remote`. `discrawl sync --update=auto` and `discrawl messages --sync` safely merge the Git snapshot first, usually as a changed-shard delta, then use live Discord for latest-message deltas. `discrawl sync --update=force` intentionally replaces public snapshot tables before live sync. Use `sync --all-channels` or `sync --full` when you want a broader live repair/backfill pass.
 
 Git snapshots publish non-DM archive tables and cached non-DM attachment media by default. Cached media is written as gzip-compressed files under `media/` and restored to raw local cache files on import. Older snapshots that contain raw media files still import, and the next media-enabled `publish` rewrites the media tree into gzip form. DMs, desktop wiretap rows, DM media, and local secrets are never exported. Use `publish --no-media` to omit cached media files.
 Subscribers can use `subscribe --no-media` or `update --no-media` to import only SQLite rows and skip restoring cached files.

--- a/docs/commands/status.md
+++ b/docs/commands/status.md
@@ -16,7 +16,7 @@ discrawl status
 - channel and thread counts
 - message totals
 - latest archived message time
-- whether the Git share is configured and how stale the local import is
+- whether the Git share is configured, whether its last check is stale, and whether an exact replacement is pending (`--json`)
 - remote endpoint/archive metadata when `remote.mode = "cloud"`
 - embeddings status if `[search.embeddings]` is enabled
 

--- a/docs/commands/subscribe.md
+++ b/docs/commands/subscribe.md
@@ -14,6 +14,7 @@ discrawl subscribe --branch main https://github.com/example/discord-archive.git
 discrawl subscribe --stale-after 15m https://github.com/example/discord-archive.git
 discrawl subscribe --no-auto-update https://github.com/example/discord-archive.git
 discrawl subscribe --no-import https://github.com/example/discord-archive.git
+discrawl subscribe --force https://github.com/example/discord-archive.git
 discrawl subscribe --with-embeddings https://github.com/example/discord-archive.git
 discrawl subscribe --no-media https://github.com/example/discord-archive.git
 ```
@@ -21,7 +22,7 @@ discrawl subscribe --no-media https://github.com/example/discord-archive.git
 ## What it does
 
 - writes a config with `discord.token_source = "none"` (so no bot token is required)
-- imports the latest snapshot into the local SQLite archive
+- safely merges the latest snapshot into the local SQLite archive without deleting destination-only rows
 - enables auto-refresh: read commands fetch and import when the local share import is older than `share.stale_after` (default `15m`)
 
 ## Flags
@@ -31,6 +32,7 @@ discrawl subscribe --no-media https://github.com/example/discord-archive.git
 - `--stale-after <duration>` - how stale the local import can get before read commands auto-refresh
 - `--no-auto-update` - disable auto-refresh (use [`update`](update.html) manually)
 - `--no-import` - write config only; skip the initial pull/import
+- `--force` - replace public snapshot tables so the local database exactly matches the snapshot
 - `--with-embeddings` - import vectors that match your local `[search.embeddings]` identity
 - `--no-media` - skip restoring cached attachment media files into `cache_dir/media`
 

--- a/docs/commands/sync.md
+++ b/docs/commands/sync.md
@@ -7,7 +7,7 @@ By default, `sync` runs both live/local sources and does **not** import the Git 
 - Discord bot-token sync for bot-visible guild data
 - local Discord Desktop cache import for classifiable cached messages and proven DMs
 
-Use [`update`](update.html) when you want to pull/import the shared Git snapshot. Snapshot imports normally use changed-shard deltas, but unsafe table changes fall back to a full import. If you intentionally want a sync run to import the snapshot before live deltas, pass `--update=auto` (only when stale) or `--update=force` (always). `--no-update` is accepted as an explicit no-op alias for the default.
+Use [`update`](update.html) when you want to pull/import the shared Git snapshot. Routine imports upsert changed shards without deleting local cache rows. If you intentionally want a sync run to import the snapshot before live deltas, pass `--update=auto` for a stale safe merge or `--update=force` for an exact replacement. `--no-update` is accepted as an explicit no-op alias for the default.
 
 Run one explicit `--full` pass when you want a complete historical guild archive. Use plain `sync` afterward for frequent latest-message and desktop-cache refreshes.
 
@@ -44,14 +44,15 @@ discrawl sync --with-media
 | Command | Use when | Behavior |
 | --- | --- | --- |
 | `discrawl sync` | routine refresh | skips member refreshes, checks live top-level channels plus active threads, only fetches new messages for channels with a stored cursor |
-| `discrawl sync --update=auto` | hybrid Git/live refresh | imports a stale Git snapshot first, then runs the routine live refresh |
+| `discrawl sync --update=auto` | hybrid Git/live refresh | safely merges a stale Git snapshot first, then runs the routine live refresh |
+| `discrawl sync --update=force` | intentional exact reconciliation | replaces public snapshot tables first, then runs the routine live refresh |
 | `discrawl sync --all-channels` | repair pass | broad incremental sweep across every stored channel/thread, including archived threads |
 | `discrawl sync --full` | historical backfill | crawls older history until channels are complete |
 
 ## Flags
 
 - `--source <both|discord|wiretap>` - which archive sources to read
-- `--update <auto|force|none>` - whether to import the Git snapshot before live deltas
+- `--update <auto|force|none>` - safe-merge a stale snapshot, force an exact replacement, or skip snapshot import before live deltas
 - `--full` - historical backfill (slow on large guilds)
 - `--all-channels` - broader incremental sweep across every stored channel/thread
 - `--latest-only` - explicit latest-only run (also the default for untargeted `sync`)

--- a/docs/commands/update.md
+++ b/docs/commands/update.md
@@ -1,8 +1,8 @@
 # `update`
 
-Forces a Git snapshot pull and import.
+Pulls a Git snapshot and safely merges changed rows into the local cache.
 
-Routine imports are delta-planned from crawlkit shard fingerprints, with a Git-object fallback for older manifests. The usual publish only imports changed tail shards; unsafe table changes fall back to a full import.
+Routine imports are delta-planned from crawlkit shard fingerprints, with a Git-object fallback for older manifests. Changed and new shards are upserted without deleting destination-only rows. Discrawl never falls back to an exact replacement unless you pass `--force`.
 
 ## Usage
 
@@ -13,7 +13,8 @@ discrawl update \
   --remote https://github.com/example/discord-archive.git
 discrawl update --with-embeddings
 discrawl update --no-media
-discrawl update --ref backup-2026-06-19
+discrawl update --force
+discrawl update --force --ref backup-2026-06-19
 ```
 
 ## Flags
@@ -21,7 +22,8 @@ discrawl update --ref backup-2026-06-19
 - `--repo <path>` - local snapshot repo path (defaults to `[share].repo_path`)
 - `--remote <url>` - target Git remote (defaults to `[share].remote`)
 - `--branch <name>` - snapshot branch (defaults to `[share].branch`)
-- `--ref <tag-or-commit>` - import a historical snapshot without changing the share checkout
+- `--force` - replace the public snapshot tables and rebuild search indexes so the local database exactly matches the snapshot; local DM rows remain untouched
+- `--ref <tag-or-commit>` - import a historical snapshot without changing the share checkout; requires `--force`
 - `--with-embeddings` - also import vectors that match your local `[search.embeddings]` identity
 - `--no-media` - skip restoring cached attachment media files into `cache_dir/media`
 
@@ -30,11 +32,14 @@ discrawl update --ref backup-2026-06-19
 - you have `share.remote` configured and want a fresh shard-delta import before running a command that does not auto-update (`sync` does not auto-import unless `--update=auto` is passed)
 - you set `--no-auto-update` when subscribing and want to refresh on demand
 - a CI job already imported the latest snapshot but read commands still consider it stale
-- you need to restore a named tag or commit while leaving the checked-out share branch untouched
+- you need an exact reconciliation after Discrawl reports removed shards or an incompatible table change (`discrawl update --force`)
+- you need to restore a named tag or commit while leaving the checked-out share branch untouched (`discrawl update --force --ref <ref>`)
+
+Normal updates preserve rows learned from live Discord or the desktop cache, even when those rows are absent from the Git snapshot. Generated event history and local sync cursors are not replayed during routine merges. If a safe merge is impossible, Discrawl keeps the current database, marks the snapshot as needing attention in `status --json`, and asks you to rerun with `--force`.
 
 ## How `sync` interacts
 
-`discrawl sync` does **not** auto-import the share unless `--update=auto` (only when stale) or `--update=force` (always). Routine live refreshes stay fast; explicit imports happen via `update`.
+`discrawl sync` does **not** auto-import the share unless `--update=auto` (safe merge when stale) or `--update=force` (exact replacement before live deltas). Routine live refreshes stay fast; explicit imports happen via `update`.
 
 ## See also
 

--- a/docs/guides/git-snapshots.md
+++ b/docs/guides/git-snapshots.md
@@ -56,16 +56,18 @@ discrawl messages --channel general --hours 24
 
 ## Auto-update
 
-Once `share.remote` is configured, read commands auto-fetch and import when the local share import is older than `share.stale_after` (default `15m`):
+Once `share.remote` is configured, read commands auto-fetch and import when the last share check is older than `share.stale_after` (default `15m`):
 
 ```bash
 discrawl subscribe --stale-after 15m https://github.com/example/discord-archive.git
 discrawl subscribe --no-auto-update https://github.com/example/discord-archive.git
 ```
 
-`discrawl update` forces the same pull/import step manually. `discrawl update --ref <tag-or-commit>` reads the historical Git objects directly and leaves the share checkout unchanged. Snapshot imports are delta-planned from crawlkit shard fingerprints. Older manifests without those fields fall back to Git blob identity, so the common publish shape only imports the changed message tail shard plus small cursor tables. Unsafe table-shape changes still fall back to a full import.
+`discrawl update` runs the same safe pull/merge step manually. `discrawl update --force --ref <tag-or-commit>` reads historical Git objects directly and leaves the share checkout unchanged. Snapshot imports are delta-planned from crawlkit shard fingerprints. Older manifests without those fields fall back to Git blob identity, so the common publish shape only imports changed canonical shards. Routine merges preserve destination-only rows and do not replay generated event history or remote sync cursors.
 
-`discrawl sync` does **not** auto-import the share unless `--update=auto` or `--update=force` is provided, so routine live refreshes stay fast.
+Discrawl does not silently fall back to a full import. Removed shards and incompatible table changes leave the current database intact and require `discrawl update --force`. Forced updates replace public snapshot tables and rebuild search indexes; local DM rows remain untouched.
+
+`discrawl sync` does **not** auto-import the share unless `--update=auto` or `--update=force` is provided. Auto mode uses the safe merge; force mode performs exact replacement before live deltas.
 
 ## Hybrid mode
 

--- a/go.mod
+++ b/go.mod
@@ -44,7 +44,7 @@ require (
 	github.com/muesli/cancelreader v0.2.2 // indirect
 	github.com/muesli/termenv v0.16.0 // indirect
 	github.com/ncruces/go-strftime v1.0.0 // indirect
-	github.com/openclaw/crawlkit v0.13.1
+	github.com/openclaw/crawlkit v0.13.2
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect

--- a/go.sum
+++ b/go.sum
@@ -71,8 +71,8 @@ github.com/muesli/termenv v0.16.0 h1:S5AlUN9dENB57rsbnkPyfdGuWIlkmzJjbFf0Tf5FWUc
 github.com/muesli/termenv v0.16.0/go.mod h1:ZRfOIKPFDYQoDFF4Olj7/QJbW60Ol/kL1pU3VfY/Cnk=
 github.com/ncruces/go-strftime v1.0.0 h1:HMFp8mLCTPp341M/ZnA4qaf7ZlsbTc+miZjCLOFAw7w=
 github.com/ncruces/go-strftime v1.0.0/go.mod h1:Fwc5htZGVVkseilnfgOVb9mKy6w1naJmn9CehxcKcls=
-github.com/openclaw/crawlkit v0.13.1 h1:an4RNC9IhaGtwGUGFJWVlIydmu5SmZEWRCzLOXWBbgA=
-github.com/openclaw/crawlkit v0.13.1/go.mod h1:zOJv5WPWO1AuuXO7zW8NRTxb/ZTkIQXYPrx3StmnMUI=
+github.com/openclaw/crawlkit v0.13.2 h1:ZFWe24XvenYhMKNBuLfwBk7AcZ5Pay57ACipiXBsDc4=
+github.com/openclaw/crawlkit v0.13.2/go.mod h1:NUzZ6yJnY23DHv9MAowbUGA5k7ox2nbvBGkSQRExocE=
 github.com/pelletier/go-toml/v2 v2.4.2 h1:M2fKKbmyvI+hGId/D0W64qDBMVhJnNR10O5gIbMc//Q=
 github.com/pelletier/go-toml/v2 v2.4.2/go.mod h1:2gIqNv+qfxSVS7cM2xJQKtLSTLUE9V8t9Stt+h56mCY=
 github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=

--- a/internal/cli/admin_commands.go
+++ b/internal/cli/admin_commands.go
@@ -451,7 +451,7 @@ func (r *runtime) runStatus(args []string) error {
 		needsUpdate := false
 		if r.store != nil && r.cfg.ShareEnabled() {
 			if staleAfter, err := time.ParseDuration(r.cfg.Share.StaleAfter); err == nil {
-				needsUpdate = share.NeedsImport(r.ctx, r.store, staleAfter)
+				needsUpdate = share.NeedsImport(r.ctx, r.store, staleAfter) || share.HasPendingReplacement(r.ctx, r.store)
 			}
 		}
 		return r.print(controlStatus(r.configPath, r.cfg, status, needsUpdate))

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -655,8 +655,16 @@ func (r *runtime) autoUpdateShare(mode shareUpdateMode) error {
 		return err
 	}
 	r.setSyncLockPhase("share import")
-	_, _, err = share.ImportIfChanged(r.ctx, r.store, opts)
+	if mode == shareUpdateForce {
+		_, _, err = share.Replace(r.ctx, r.store, opts)
+	} else {
+		_, _, err = share.MergeIfChanged(r.ctx, r.store, opts)
+	}
 	if errors.Is(err, share.ErrNoManifest) {
+		return nil
+	}
+	if errors.Is(err, share.ErrReplacementRequired) && mode != shareUpdateForce {
+		r.logger.Warn("share update requires forced exact reconciliation", "error", err)
 		return nil
 	}
 	return err

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -1034,7 +1034,7 @@ func TestReadCommandsAutoImportStaleShare(t *testing.T) {
 	reader, err := store.Open(ctx, cfg.DBPath)
 	require.NoError(t, err)
 	defer func() { _ = reader.Close() }()
-	lastImport, err := reader.GetSyncState(ctx, share.LastImportSyncScope)
+	lastImport, err := reader.GetSyncState(ctx, share.LastMergeSyncScope)
 	require.NoError(t, err)
 	require.NotEmpty(t, lastImport)
 }
@@ -1258,7 +1258,7 @@ func TestReadCommandsCanDisableAutoImportWithEnv(t *testing.T) {
 	reader, err = store.Open(ctx, cfg.DBPath)
 	require.NoError(t, err)
 	defer func() { _ = reader.Close() }()
-	lastImport, err := reader.GetSyncState(ctx, share.LastImportSyncScope)
+	lastImport, err := reader.GetSyncState(ctx, share.LastMergeSyncScope)
 	require.NoError(t, err)
 	require.Empty(t, lastImport)
 }
@@ -1998,7 +1998,7 @@ func TestShareCommandsPublishSubscribeAndUpdate(t *testing.T) {
 	require.NoError(t, Run(ctx, []string{"--config", readerCfgPath, "update"}, &out, &bytes.Buffer{}))
 	require.Contains(t, out.String(), "generated_at")
 	out.Reset()
-	require.NoError(t, Run(ctx, []string{"--config", readerCfgPath, "update", "--ref", "test-snapshot"}, &out, &bytes.Buffer{}))
+	require.NoError(t, Run(ctx, []string{"--config", readerCfgPath, "update", "--force", "--ref", "test-snapshot"}, &out, &bytes.Buffer{}))
 	require.Contains(t, out.String(), "test-snapshot")
 	out.Reset()
 	require.NoError(t, Run(ctx, []string{"--config", readerCfgPath, "search", "automatic"}, &out, &bytes.Buffer{}))
@@ -2273,6 +2273,22 @@ func TestShareUpdateImportsNewRemoteSnapshot(t *testing.T) {
 	require.NoError(t, Run(ctx, []string{"--config", readerCfgPath, "search", "automatic"}, &out, &bytes.Buffer{}))
 	require.Contains(t, out.String(), "automatic updates work")
 
+	reader, err := store.Open(ctx, readerCfg.DBPath)
+	require.NoError(t, err)
+	require.NoError(t, reader.UpsertMessage(ctx, store.MessageRecord{
+		ID:                "local-only",
+		GuildID:           "g1",
+		ChannelID:         "c1",
+		ChannelName:       "general",
+		AuthorID:          "local",
+		AuthorName:        "Local",
+		CreatedAt:         time.Now().UTC().Format(time.RFC3339Nano),
+		Content:           "local cache row",
+		NormalizedContent: "local cache row",
+		RawJSON:           `{}`,
+	}))
+	require.NoError(t, reader.Close())
+
 	require.NoError(t, publisher.UpsertMessage(ctx, store.MessageRecord{
 		ID:                "m200",
 		GuildID:           "g1",
@@ -2291,9 +2307,25 @@ func TestShareUpdateImportsNewRemoteSnapshot(t *testing.T) {
 	out.Reset()
 	require.NoError(t, Run(ctx, []string{"--config", readerCfgPath, "update"}, &out, &bytes.Buffer{}))
 	require.Contains(t, out.String(), "imported=true")
+	reader, err = store.Open(ctx, readerCfg.DBPath)
+	require.NoError(t, err)
+	_, rows, err := reader.ReadOnlyQuery(ctx, `select count(*) from messages where id = 'local-only'`)
+	require.NoError(t, err)
+	require.Equal(t, "1", rows[0][0], "routine update must preserve local cache rows")
+	require.NoError(t, reader.Close())
 	out.Reset()
 	require.NoError(t, Run(ctx, []string{"--config", readerCfgPath, "search", "newer snapshot"}, &out, &bytes.Buffer{}))
 	require.Contains(t, out.String(), "newer git snapshot arrived")
+
+	out.Reset()
+	require.NoError(t, Run(ctx, []string{"--config", readerCfgPath, "update", "--force"}, &out, &bytes.Buffer{}))
+	require.Contains(t, out.String(), "forced=true")
+	reader, err = store.Open(ctx, readerCfg.DBPath)
+	require.NoError(t, err)
+	defer func() { _ = reader.Close() }()
+	_, rows, err = reader.ReadOnlyQuery(ctx, `select count(*) from messages where id = 'local-only'`)
+	require.NoError(t, err)
+	require.Equal(t, "0", rows[0][0], "forced update must reconcile exactly")
 }
 
 func TestSyncSkipsGitShareByDefaultAndCanImportBeforeLiveDiscord(t *testing.T) {
@@ -4003,6 +4035,7 @@ func TestCommandUsageBranches(t *testing.T) {
 		{[]string{"--config", cfgPath, "embed", "--batch-size", "0"}, "--batch-size must be positive"},
 		{[]string{"--config", cfgPath, "publish", "extra"}, "publish takes no positional arguments"},
 		{[]string{"--config", cfgPath, "update", "extra"}, "update takes no positional arguments"},
+		{[]string{"--config", cfgPath, "update", "--ref", "HEAD"}, "update --ref requires --force"},
 		{[]string{"--config", cfgPath, "subscribe"}, "subscribe requires one remote"},
 		{[]string{"--config", cfgPath, "subscribe", "one", "two"}, "subscribe requires one remote"},
 	}

--- a/internal/cli/share_commands.go
+++ b/internal/cli/share_commands.go
@@ -172,6 +172,7 @@ func (r *runtime) runSubscribe(args []string) error {
 	staleAfter := fs.String("stale-after", "15m", "")
 	noAutoUpdate := fs.Bool("no-auto-update", false, "")
 	noImport := fs.Bool("no-import", false, "")
+	force := fs.Bool("force", false, "")
 	withEmbeddings := fs.Bool("with-embeddings", false, "")
 	noMedia := fs.Bool("no-media", false, "")
 	if err := fs.Parse(args); err != nil {
@@ -232,8 +233,17 @@ func (r *runtime) runSubscribe(args []string) error {
 			return err
 		}
 		r.setSyncLockPhase("share import")
-		manifest, imported, err := share.ImportIfChanged(r.ctx, s, opts)
+		var manifest share.Manifest
+		var imported bool
+		if *force {
+			manifest, imported, err = share.Replace(r.ctx, s, opts)
+		} else {
+			manifest, imported, err = share.MergeIfChanged(r.ctx, s, opts)
+		}
 		if err != nil {
+			if errors.Is(err, share.ErrReplacementRequired) {
+				return fmt.Errorf("%w; rerun subscribe with --force to reconcile exactly", err)
+			}
 			return err
 		}
 		return r.print(map[string]any{
@@ -245,6 +255,7 @@ func (r *runtime) runSubscribe(args []string) error {
 			"media":        manifest.Media,
 			"embeddings":   manifest.Embeddings,
 			"imported":     imported,
+			"forced":       *force,
 		})
 	})
 }
@@ -256,6 +267,7 @@ func (r *runtime) runUpdate(args []string) error {
 	remote := fs.String("remote", r.cfg.Share.Remote, "")
 	branch := fs.String("branch", r.cfg.Share.Branch, "")
 	ref := fs.String("ref", "", "")
+	force := fs.Bool("force", false, "")
 	withEmbeddings := fs.Bool("with-embeddings", false, "")
 	noMedia := fs.Bool("no-media", !r.cfg.ShareMediaEnabled(), "")
 	if err := fs.Parse(args); err != nil {
@@ -263,6 +275,9 @@ func (r *runtime) runUpdate(args []string) error {
 	}
 	if fs.NArg() != 0 {
 		return usageErr(errors.New("update takes no positional arguments"))
+	}
+	if strings.TrimSpace(*ref) != "" && !*force {
+		return usageErr(errors.New("update --ref requires --force because historical imports replace local cache rows"))
 	}
 	opts, err := shareOptionsFromFlags(*repoPath, *remote, *branch)
 	if err != nil {
@@ -283,8 +298,15 @@ func (r *runtime) runUpdate(args []string) error {
 			return err
 		}
 		r.setSyncLockPhase("share import")
-		manifest, imported, err = share.ImportIfChanged(r.ctx, r.store, opts)
+		if *force {
+			manifest, imported, err = share.Replace(r.ctx, r.store, opts)
+		} else {
+			manifest, imported, err = share.MergeIfChanged(r.ctx, r.store, opts)
+		}
 		if err != nil {
+			if errors.Is(err, share.ErrReplacementRequired) {
+				return fmt.Errorf("%w; rerun update with --force to reconcile exactly", err)
+			}
 			return err
 		}
 	} else {
@@ -304,6 +326,7 @@ func (r *runtime) runUpdate(args []string) error {
 		"embeddings":   manifest.Embeddings,
 		"imported":     imported,
 		"ref":          strings.TrimSpace(*ref),
+		"forced":       *force,
 	})
 }
 

--- a/internal/share/import_memory_test.go
+++ b/internal/share/import_memory_test.go
@@ -28,7 +28,7 @@ func TestImportRealSnapshot(t *testing.T) {
 	require.NoError(t, err)
 	defer func() { _ = dst.Close() }()
 
-	_, changed, err := ImportIfChanged(ctx, dst, Options{
+	_, changed, err := MergeIfChanged(ctx, dst, Options{
 		RepoPath: repo,
 		Branch:   "main",
 		Progress: func(p ImportProgress) {
@@ -66,14 +66,14 @@ func TestImportMemoryBounded(t *testing.T) {
 	defer func() { _ = dst.Close() }()
 
 	var progress []ImportProgress
-	_, changed, err := ImportIfChanged(ctx, dst, Options{
+	_, changed, err := MergeIfChanged(ctx, dst, Options{
 		RepoPath: repo,
 		Branch:   "main",
 		Progress: func(p ImportProgress) { progress = append(progress, p) },
 	})
 	require.NoError(t, err)
 	require.True(t, changed)
-	require.Contains(t, progressPhases(progress), "rebuild_fts")
+	require.NotContains(t, progressPhases(progress), "rebuild_fts")
 
 	needle := "oomunique000042"
 	results, err := dst.SearchMessages(ctx, store.SearchOptions{Query: needle, Limit: 10})

--- a/internal/share/merge.go
+++ b/internal/share/merge.go
@@ -1,0 +1,236 @@
+package share
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/openclaw/crawlkit/snapshot"
+	"github.com/openclaw/discrawl/internal/store"
+)
+
+const (
+	LastCheckSyncScope          = "share:last_check_at"
+	LastMergeSyncScope          = "share:last_merge_at"
+	LastMergeManifestSyncScope  = "share:last_merge_manifest_generated_at"
+	LastMergeManifestJSONScope  = "share:last_merge_manifest_json"
+	PendingReplacementSyncScope = "share:pending_replacement"
+)
+
+var ErrReplacementRequired = errors.New("share snapshot replacement required")
+
+type ReplacementRequiredError struct {
+	Reason string
+	Tables []string
+}
+
+func (e *ReplacementRequiredError) Error() string {
+	detail := strings.TrimSpace(e.Reason)
+	if len(e.Tables) > 0 {
+		detail = "tables: " + strings.Join(e.Tables, ", ")
+	}
+	if detail == "" {
+		return ErrReplacementRequired.Error()
+	}
+	return ErrReplacementRequired.Error() + " (" + detail + ")"
+}
+
+func (e *ReplacementRequiredError) Unwrap() error {
+	return ErrReplacementRequired
+}
+
+// MergeIfChanged refreshes canonical snapshot rows without deleting local rows.
+// Exact reconciliation remains separate so callers can require explicit consent.
+func MergeIfChanged(ctx context.Context, s *store.Store, opts Options) (Manifest, bool, error) {
+	manifest, err := ReadManifest(opts.RepoPath)
+	if err != nil {
+		return Manifest{}, false, err
+	}
+	manifest = enrichManifestFromGit(ctx, opts.RepoPath, "HEAD", manifest)
+	previous, ok := PreviousMergedManifest(ctx, s, opts)
+	allowEventMerge := false
+	if !ok {
+		previous = Manifest{Version: manifest.Version}
+		allowEventMerge, err = eventTablesEmpty(ctx, s)
+		if err != nil {
+			return Manifest{}, false, err
+		}
+	}
+	plan := snapshot.PlanMergeImport(snapshotManifest(previous), snapshotManifest(manifest))
+	plan, err = shareMergePlan(plan, allowEventMerge)
+	if err != nil {
+		if markErr := MarkReplacementPending(ctx, s, manifest, err.Error()); markErr != nil {
+			return Manifest{}, false, errors.Join(err, markErr)
+		}
+		return Manifest{}, false, err
+	}
+	return importMergePlan(ctx, s, opts, previous, manifest, plan)
+}
+
+func shareMergePlan(plan snapshot.ImportPlan, allowEventMerge bool) (snapshot.ImportPlan, error) {
+	if plan.Full {
+		return snapshot.ImportPlan{}, &ReplacementRequiredError{Reason: plan.Reason}
+	}
+	out := snapshot.ImportPlan{Tables: make([]snapshot.TableImportPlan, 0, len(plan.Tables))}
+	var replacements []string
+	for _, tablePlan := range plan.Tables {
+		switch tablePlan.Table.Name {
+		case "message_events", "mention_events":
+			if allowEventMerge && tablePlan.Mode == snapshot.TableImportFiles {
+				out.Tables = append(out.Tables, tablePlan)
+				continue
+			}
+			// Event shards have generated IDs, so replay would duplicate history.
+			// Only an explicitly forced exact import may replace these tables.
+			tablePlan.Mode = snapshot.TableImportSkip
+			tablePlan.Files = nil
+			tablePlan.Reason = "force-only snapshot table"
+			out.Tables = append(out.Tables, tablePlan)
+			continue
+		case "sync_state":
+			tablePlan.Mode = snapshot.TableImportSkip
+			tablePlan.Files = nil
+			tablePlan.Reason = "local ownership"
+			out.Tables = append(out.Tables, tablePlan)
+			continue
+		case "guilds", "channels", "members", "messages", "message_attachments":
+		default:
+			replacements = append(replacements, tablePlan.Table.Name)
+			continue
+		}
+		if tablePlan.Mode == snapshot.TableImportReplace {
+			replacements = append(replacements, tablePlan.Table.Name)
+			continue
+		}
+		out.Tables = append(out.Tables, tablePlan)
+	}
+	if len(replacements) > 0 {
+		sort.Strings(replacements)
+		return snapshot.ImportPlan{}, &ReplacementRequiredError{Tables: replacements}
+	}
+	return out, nil
+}
+
+func eventTablesEmpty(ctx context.Context, s *store.Store) (bool, error) {
+	var rows int
+	if err := s.DB().QueryRowContext(ctx, `select (select count(*) from message_events) + (select count(*) from mention_events)`).Scan(&rows); err != nil {
+		return false, fmt.Errorf("count local share events: %w", err)
+	}
+	return rows == 0, nil
+}
+
+func mergePlanSearchRebuilds(plan snapshot.ImportPlan) (bool, bool) {
+	for _, tablePlan := range plan.Tables {
+		if tablePlan.Mode != snapshot.TableImportSkip && tablePlan.Table.Name == "members" {
+			return false, true
+		}
+	}
+	return false, false
+}
+
+func importMergeSnapshotRow(ctx context.Context, tx *sql.Tx, table string, row map[string]any) error {
+	channelID := ""
+	previousName := ""
+	if table == "channels" {
+		channelID = stringValue(row["id"])
+		if channelID != "" {
+			err := tx.QueryRowContext(ctx, `select coalesce(name, '') from channels where id = ?`, channelID).Scan(&previousName)
+			if err != nil && !errors.Is(err, sql.ErrNoRows) {
+				return fmt.Errorf("read message search channel %s: %w", channelID, err)
+			}
+		}
+	}
+	applied, err := upsertMergeSnapshotRow(ctx, tx, table, row)
+	if err != nil {
+		return err
+	}
+	if !applied {
+		return nil
+	}
+	if table == "messages" {
+		messageID := stringValue(row["id"])
+		if messageID != "" {
+			return upsertMessageFTSRow(ctx, tx, messageID)
+		}
+		return nil
+	}
+	currentName := stringValue(row["name"])
+	if channelID == "" || previousName == currentName {
+		return nil
+	}
+	if _, err := tx.ExecContext(ctx, `update message_fts set channel_name = ? where channel_id = ?`, currentName, channelID); err != nil {
+		return fmt.Errorf("refresh message search channel %s: %w", channelID, err)
+	}
+	return nil
+}
+
+func ManifestAlreadyMerged(ctx context.Context, s *store.Store, manifest Manifest) bool {
+	if manifest.GeneratedAt.IsZero() {
+		return false
+	}
+	last, err := s.GetSyncState(ctx, LastMergeManifestSyncScope)
+	if err != nil || strings.TrimSpace(last) == "" {
+		return false
+	}
+	t, err := time.Parse(time.RFC3339Nano, last)
+	return err == nil && t.Equal(manifest.GeneratedAt)
+}
+
+func PreviousMergedManifest(ctx context.Context, s *store.Store, opts Options) (Manifest, bool) {
+	body, err := s.GetSyncState(ctx, LastMergeManifestJSONScope)
+	if err == nil && strings.TrimSpace(body) != "" {
+		var manifest Manifest
+		if json.Unmarshal([]byte(body), &manifest) == nil && !manifest.GeneratedAt.IsZero() {
+			return manifest, true
+		}
+	}
+	return PreviousImportedManifest(ctx, s, opts)
+}
+
+func MarkChecked(ctx context.Context, s *store.Store) error {
+	return s.SetSyncState(ctx, LastCheckSyncScope, time.Now().UTC().Format(time.RFC3339Nano))
+}
+
+func MarkMerged(ctx context.Context, s *store.Store, manifest Manifest) error {
+	now := time.Now().UTC().Format(time.RFC3339Nano)
+	if err := s.SetSyncState(ctx, LastCheckSyncScope, now); err != nil {
+		return err
+	}
+	if err := s.SetSyncState(ctx, LastMergeSyncScope, now); err != nil {
+		return err
+	}
+	if !manifest.GeneratedAt.IsZero() {
+		if err := s.SetSyncState(ctx, LastMergeManifestSyncScope, manifest.GeneratedAt.Format(time.RFC3339Nano)); err != nil {
+			return err
+		}
+		body, err := json.Marshal(manifest)
+		if err != nil {
+			return fmt.Errorf("marshal merged manifest state: %w", err)
+		}
+		if err := s.SetSyncState(ctx, LastMergeManifestJSONScope, string(body)); err != nil {
+			return err
+		}
+	}
+	return s.SetSyncState(ctx, PendingReplacementSyncScope, "")
+}
+
+func MarkReplacementPending(ctx context.Context, s *store.Store, manifest Manifest, reason string) error {
+	if err := MarkChecked(ctx, s); err != nil {
+		return err
+	}
+	value := strings.TrimSpace(reason)
+	if !manifest.GeneratedAt.IsZero() {
+		value = manifest.GeneratedAt.Format(time.RFC3339Nano) + " " + value
+	}
+	return s.SetSyncState(ctx, PendingReplacementSyncScope, strings.TrimSpace(value))
+}
+
+func HasPendingReplacement(ctx context.Context, s *store.Store) bool {
+	value, err := s.GetSyncState(ctx, PendingReplacementSyncScope)
+	return err == nil && strings.TrimSpace(value) != ""
+}

--- a/internal/share/merge_test.go
+++ b/internal/share/merge_test.go
@@ -1,0 +1,230 @@
+package share
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/openclaw/crawlkit/snapshot"
+	"github.com/stretchr/testify/require"
+
+	"github.com/openclaw/discrawl/internal/store"
+)
+
+func TestMergeIfChangedPreservesLocalRowsUntilForcedReplacement(t *testing.T) {
+	ctx := context.Background()
+	src := seedStore(t, filepath.Join(t.TempDir(), "src.db"))
+	defer func() { _ = src.Close() }()
+	repo := filepath.Join(t.TempDir(), "share")
+	initial, err := Export(ctx, src, Options{RepoPath: repo, Branch: "main"})
+	require.NoError(t, err)
+
+	dst, err := store.Open(ctx, filepath.Join(t.TempDir(), "dst.db"))
+	require.NoError(t, err)
+	defer func() { _ = dst.Close() }()
+	_, changed, err := MergeIfChanged(ctx, dst, Options{RepoPath: repo, Branch: "main"})
+	require.NoError(t, err)
+	require.True(t, changed)
+	require.True(t, ManifestAlreadyMerged(ctx, dst, initial))
+
+	require.NoError(t, dst.UpsertMessage(ctx, store.MessageRecord{
+		ID:                "local-only",
+		GuildID:           "g1",
+		ChannelID:         "c1",
+		ChannelName:       "general",
+		AuthorID:          "local",
+		AuthorName:        "Local",
+		CreatedAt:         time.Now().UTC().Format(time.RFC3339Nano),
+		Content:           "must survive safe refresh",
+		NormalizedContent: "must survive safe refresh",
+		RawJSON:           `{}`,
+	}))
+	require.NoError(t, dst.UpsertMessage(ctx, store.MessageRecord{
+		ID:                "m1",
+		GuildID:           "g1",
+		ChannelID:         "c1",
+		ChannelName:       "general",
+		AuthorID:          "local",
+		AuthorName:        "Local",
+		CreatedAt:         time.Now().UTC().Format(time.RFC3339Nano),
+		Content:           "newer local edit",
+		NormalizedContent: "newer local edit",
+		RawJSON:           `{}`,
+	}))
+	_, err = dst.DB().ExecContext(ctx, `update messages set updated_at = ? where id = 'm1'`, time.Now().UTC().Add(time.Hour).Format(time.RFC3339Nano))
+	require.NoError(t, err)
+	now := time.Now().UTC().Add(time.Minute).Format(time.RFC3339Nano)
+	require.NoError(t, src.UpsertMessages(ctx, []store.MessageMutation{{
+		Record: store.MessageRecord{
+			ID:                "m2",
+			GuildID:           "g1",
+			ChannelID:         "c1",
+			ChannelName:       "general",
+			AuthorID:          "u1",
+			AuthorName:        "Peter",
+			CreatedAt:         now,
+			Content:           "remote merge delta",
+			NormalizedContent: "remote merge delta",
+			RawJSON:           `{}`,
+		},
+		EventType:   "upsert",
+		PayloadJSON: `{"id":"m2"}`,
+		Options:     store.WriteOptions{AppendEvent: true},
+	}}))
+	updated, err := Export(ctx, src, Options{RepoPath: repo, Branch: "main"})
+	require.NoError(t, err)
+
+	var progress []ImportProgress
+	_, changed, err = MergeIfChanged(ctx, dst, Options{
+		RepoPath: repo,
+		Branch:   "main",
+		Progress: func(p ImportProgress) { progress = append(progress, p) },
+	})
+	require.NoError(t, err)
+	require.True(t, changed)
+	require.NotContains(t, progressPhases(progress), "rebuild_fts")
+	require.NotContains(t, progressPhases(progress), "rebuild_member_fts")
+
+	_, rows, err := dst.ReadOnlyQuery(ctx, `select id from messages where id in ('local-only', 'm2') order by id`)
+	require.NoError(t, err)
+	require.Equal(t, [][]string{{"local-only"}, {"m2"}}, rows)
+	results, err := dst.SearchMessages(ctx, store.SearchOptions{Query: "remote merge delta", Limit: 10})
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	results, err = dst.SearchMessages(ctx, store.SearchOptions{Query: "newer local edit", Limit: 10})
+	require.NoError(t, err)
+	require.Len(t, results, 1, "routine merge must not overwrite a newer local version of the same row")
+	_, rows, err = dst.ReadOnlyQuery(ctx, `select count(*) from message_events`)
+	require.NoError(t, err)
+	require.Equal(t, "1", rows[0][0], "routine merge must not replay generated event IDs")
+	require.True(t, ManifestAlreadyMerged(ctx, dst, updated))
+	lastExact, err := dst.GetSyncState(ctx, LastImportManifestSyncScope)
+	require.NoError(t, err)
+	require.Empty(t, lastExact)
+
+	_, changed, err = Replace(ctx, dst, Options{RepoPath: repo, Branch: "main"})
+	require.NoError(t, err)
+	require.True(t, changed)
+	_, rows, err = dst.ReadOnlyQuery(ctx, `select count(*) from messages where id = 'local-only'`)
+	require.NoError(t, err)
+	require.Equal(t, "0", rows[0][0])
+	_, rows, err = dst.ReadOnlyQuery(ctx, `select count(*) from message_events`)
+	require.NoError(t, err)
+	require.Equal(t, "2", rows[0][0])
+	require.True(t, ManifestAlreadyImported(ctx, dst, updated))
+
+	require.NoError(t, dst.UpsertMessage(ctx, store.MessageRecord{
+		ID:                "local-after-force",
+		GuildID:           "g1",
+		ChannelID:         "c1",
+		ChannelName:       "general",
+		CreatedAt:         now,
+		Content:           "must be reconciled",
+		NormalizedContent: "must be reconciled",
+		RawJSON:           `{}`,
+	}))
+	_, changed, err = Replace(ctx, dst, Options{RepoPath: repo, Branch: "main"})
+	require.NoError(t, err)
+	require.True(t, changed)
+	_, rows, err = dst.ReadOnlyQuery(ctx, `select count(*) from messages where id = 'local-after-force'`)
+	require.NoError(t, err)
+	require.Equal(t, "0", rows[0][0], "force must reconcile even when the manifest is unchanged")
+}
+
+func TestMergeIfChangedMarksReplacementPendingWithoutChangingRows(t *testing.T) {
+	ctx := context.Background()
+	src := seedStore(t, filepath.Join(t.TempDir(), "src.db"))
+	defer func() { _ = src.Close() }()
+	repo := filepath.Join(t.TempDir(), "share")
+	manifest, err := Export(ctx, src, Options{RepoPath: repo, Branch: "main"})
+	require.NoError(t, err)
+	dst, err := store.Open(ctx, filepath.Join(t.TempDir(), "dst.db"))
+	require.NoError(t, err)
+	defer func() { _ = dst.Close() }()
+	_, _, err = MergeIfChanged(ctx, dst, Options{RepoPath: repo, Branch: "main"})
+	require.NoError(t, err)
+
+	manifest.GeneratedAt = manifest.GeneratedAt.Add(time.Minute)
+	manifest.Tables = removeManifestTable(manifest.Tables, "messages")
+	writeShareManifest(t, repo, manifest)
+	_, changed, err := MergeIfChanged(ctx, dst, Options{RepoPath: repo, Branch: "main"})
+	require.ErrorIs(t, err, ErrReplacementRequired)
+	require.False(t, changed)
+	require.True(t, HasPendingReplacement(ctx, dst))
+	_, rows, queryErr := dst.ReadOnlyQuery(ctx, `select count(*) from messages`)
+	require.NoError(t, queryErr)
+	require.Equal(t, "1", rows[0][0])
+	require.False(t, NeedsImport(ctx, dst, 15*time.Minute), "the failed check is still fresh")
+}
+
+func TestShareMergePlanKeepsGeneratedHistoryForceOnly(t *testing.T) {
+	plan, err := shareMergePlan(snapshot.ImportPlan{Tables: []snapshot.TableImportPlan{
+		{Table: snapshot.TableManifest{Name: "messages"}, Mode: snapshot.TableImportFiles},
+		{Table: snapshot.TableManifest{Name: "message_events"}, Mode: snapshot.TableImportFiles},
+		{Table: snapshot.TableManifest{Name: "mention_events"}, Mode: snapshot.TableImportFiles},
+		{Table: snapshot.TableManifest{Name: "sync_state"}, Mode: snapshot.TableImportFiles},
+	}}, false)
+	require.NoError(t, err)
+	require.Equal(t, snapshot.TableImportFiles, importPlanTable(t, plan, "messages").Mode)
+	require.Equal(t, snapshot.TableImportSkip, importPlanTable(t, plan, "message_events").Mode)
+	require.Equal(t, snapshot.TableImportSkip, importPlanTable(t, plan, "mention_events").Mode)
+	require.Equal(t, snapshot.TableImportSkip, importPlanTable(t, plan, "sync_state").Mode)
+
+	bootstrap, err := shareMergePlan(snapshot.ImportPlan{Tables: []snapshot.TableImportPlan{
+		{Table: snapshot.TableManifest{Name: "message_events"}, Mode: snapshot.TableImportFiles},
+		{Table: snapshot.TableManifest{Name: "sync_state"}, Mode: snapshot.TableImportFiles},
+	}}, true)
+	require.NoError(t, err)
+	require.Equal(t, snapshot.TableImportFiles, importPlanTable(t, bootstrap, "message_events").Mode)
+	require.Equal(t, snapshot.TableImportSkip, importPlanTable(t, bootstrap, "sync_state").Mode)
+
+	_, err = shareMergePlan(snapshot.ImportPlan{Tables: []snapshot.TableImportPlan{{
+		Table: snapshot.TableManifest{Name: "messages"},
+		Mode:  snapshot.TableImportReplace,
+	}}}, false)
+	var replacement *ReplacementRequiredError
+	require.ErrorAs(t, err, &replacement)
+	require.Equal(t, []string{"messages"}, replacement.Tables)
+
+	_, err = shareMergePlan(snapshot.ImportPlan{Full: true, Reason: "manifest version changed"}, false)
+	require.ErrorContains(t, err, "manifest version changed")
+	_, err = shareMergePlan(snapshot.ImportPlan{Tables: []snapshot.TableImportPlan{{
+		Table: snapshot.TableManifest{Name: "unknown"},
+		Mode:  snapshot.TableImportFiles,
+	}}}, false)
+	require.ErrorContains(t, err, "unknown")
+}
+
+func TestMergeStateTracksChecksAndPendingReplacement(t *testing.T) {
+	ctx := context.Background()
+	s, err := store.Open(ctx, filepath.Join(t.TempDir(), "discrawl.db"))
+	require.NoError(t, err)
+	defer func() { _ = s.Close() }()
+	manifest := Manifest{Version: 1, GeneratedAt: time.Now().UTC().Truncate(time.Nanosecond)}
+
+	require.False(t, ManifestAlreadyMerged(ctx, s, Manifest{}))
+	require.False(t, ManifestAlreadyMerged(ctx, s, manifest))
+	require.NoError(t, MarkReplacementPending(ctx, s, manifest, "table removed"))
+	require.True(t, HasPendingReplacement(ctx, s))
+	require.NoError(t, MarkMerged(ctx, s, manifest))
+	require.False(t, HasPendingReplacement(ctx, s))
+	require.True(t, ManifestAlreadyMerged(ctx, s, manifest))
+	require.False(t, NeedsImport(ctx, s, 15*time.Minute))
+
+	require.NoError(t, s.SetSyncState(ctx, LastMergeManifestSyncScope, "not-a-time"))
+	require.False(t, ManifestAlreadyMerged(ctx, s, manifest))
+	empty, err := eventTablesEmpty(ctx, s)
+	require.NoError(t, err)
+	require.True(t, empty)
+}
+
+func removeManifestTable(tables []snapshot.TableManifest, name string) []snapshot.TableManifest {
+	out := make([]snapshot.TableManifest, 0, len(tables))
+	for _, table := range tables {
+		if table.Name != name {
+			out = append(out, table)
+		}
+	}
+	return out
+}

--- a/internal/share/share.go
+++ b/internal/share/share.go
@@ -585,39 +585,9 @@ func applyImportPragmas(ctx context.Context, db *sql.DB) (func(context.Context) 
 	}, nil
 }
 
-func ImportIfChanged(ctx context.Context, s *store.Store, opts Options) (Manifest, bool, error) {
-	manifest, err := ReadManifest(opts.RepoPath)
-	if err != nil {
-		return Manifest{}, false, err
-	}
-	manifest = enrichManifestFromGit(ctx, opts.RepoPath, "HEAD", manifest)
-	if ManifestAlreadyImported(ctx, s, manifest) {
-		if opts.IncludeEmbeddings {
-			if err := ImportEmbeddings(ctx, s, opts, manifest); err != nil {
-				return Manifest{}, false, err
-			}
-		}
-		if opts.IncludeMedia {
-			copied, err := importMedia(ctx, opts, manifest.Media)
-			if err != nil {
-				return Manifest{}, false, err
-			}
-			if err := MarkImported(ctx, s, manifest); err != nil {
-				return Manifest{}, false, err
-			}
-			return manifest, copied > 0, nil
-		}
-		if err := MarkImported(ctx, s, manifest); err != nil {
-			return Manifest{}, false, err
-		}
-		return manifest, false, nil
-	}
-	if previous, ok := PreviousImportedManifest(ctx, s, opts); ok {
-		imported, changed, err := ImportIncremental(ctx, s, opts, previous, manifest)
-		if err == nil || !errors.Is(err, errIncrementalUnsupported) {
-			return imported, changed, err
-		}
-	}
+// Replace makes the local public archive exactly match the snapshot. It always
+// reconciles the database, even when the manifest itself has not changed.
+func Replace(ctx context.Context, s *store.Store, opts Options) (Manifest, bool, error) {
 	imported, err := Import(ctx, s, opts)
 	if err != nil {
 		return Manifest{}, false, err
@@ -625,15 +595,20 @@ func ImportIfChanged(ctx context.Context, s *store.Store, opts Options) (Manifes
 	return imported, true, nil
 }
 
-var errIncrementalUnsupported = errors.New("incremental share import unsupported")
-
-func ImportIncremental(ctx context.Context, s *store.Store, opts Options, previous, manifest Manifest) (Manifest, bool, error) {
-	plan := snapshot.PlanIncrementalImport(snapshotManifest(previous), snapshotManifest(manifest))
-	plan, supported := shareIncrementalPlan(plan)
-	if !supported {
-		return Manifest{}, false, errIncrementalUnsupported
-	}
+func importMergePlan(
+	ctx context.Context,
+	s *store.Store,
+	opts Options,
+	previous Manifest,
+	manifest Manifest,
+	plan snapshot.ImportPlan,
+) (Manifest, bool, error) {
 	if !plan.Changed() {
+		if opts.IncludeEmbeddings {
+			if err := ImportEmbeddings(ctx, s, opts, manifest); err != nil {
+				return Manifest{}, false, err
+			}
+		}
 		copied := 0
 		if opts.IncludeMedia {
 			var err error
@@ -642,7 +617,7 @@ func ImportIncremental(ctx context.Context, s *store.Store, opts Options, previo
 				return Manifest{}, false, err
 			}
 		}
-		if err := MarkImported(ctx, s, manifest); err != nil {
+		if err := MarkMerged(ctx, s, manifest); err != nil {
 			return Manifest{}, false, err
 		}
 		return manifest, copied > 0, nil
@@ -660,10 +635,11 @@ func ImportIncremental(ctx context.Context, s *store.Store, opts Options, previo
 		}
 	}()
 	if _, _, err := snapshot.ImportIncremental(ctx, snapshot.IncrementalImportOptions{
-		DB:      s.DB(),
-		RootDir: opts.RepoPath,
-		Current: snapshotManifest(manifest),
-		Plan:    plan,
+		DB:       s.DB(),
+		RootDir:  opts.RepoPath,
+		Previous: snapshotManifest(previous),
+		Current:  snapshotManifest(manifest),
+		Plan:     plan,
 		Progress: func(progress snapshot.ImportProgress) {
 			opts.reportProgress(ImportProgress{
 				Phase:     progress.Phase,
@@ -690,7 +666,7 @@ func ImportIncremental(ctx context.Context, s *store.Store, opts Options, previo
 			}
 			return nil
 		},
-		ImportRow: importIncrementalSnapshotRow,
+		ImportRow: importMergeSnapshotRow,
 		AfterImport: func(ctx context.Context, tx *sql.Tx) error {
 			if err := repairImportedGuildIDs(ctx, tx); err != nil {
 				return err
@@ -706,7 +682,7 @@ func ImportIncremental(ctx context.Context, s *store.Store, opts Options, previo
 	}); err != nil {
 		return Manifest{}, false, err
 	}
-	rebuildMessageFTS, rebuildMemberFTS := importPlanSearchRebuilds(plan)
+	rebuildMessageFTS, rebuildMemberFTS := mergePlanSearchRebuilds(plan)
 	if rebuildMessageFTS {
 		opts.reportProgress(ImportProgress{Phase: "rebuild_fts"})
 		if err := s.RebuildMessageSearchIndex(ctx); err != nil {
@@ -724,7 +700,7 @@ func ImportIncremental(ctx context.Context, s *store.Store, opts Options, previo
 			return Manifest{}, false, err
 		}
 	}
-	if err := MarkImported(ctx, s, manifest); err != nil {
+	if err := MarkMerged(ctx, s, manifest); err != nil {
 		return Manifest{}, false, err
 	}
 	if err := restorePragmas(ctx); err != nil {
@@ -773,27 +749,6 @@ func importPlanRowCount(plan snapshot.ImportPlan) int {
 	return total
 }
 
-func importPlanSearchRebuilds(plan snapshot.ImportPlan) (bool, bool) {
-	rebuildMessageFTS := false
-	rebuildMemberFTS := false
-	for _, tablePlan := range plan.Tables {
-		if tablePlan.Mode == snapshot.TableImportSkip {
-			continue
-		}
-		switch tablePlan.Table.Name {
-		case "channels":
-			rebuildMessageFTS = true
-		case "messages":
-			if tablePlan.Mode == snapshot.TableImportReplace {
-				rebuildMessageFTS = true
-			}
-		case "members":
-			rebuildMemberFTS = true
-		}
-	}
-	return rebuildMessageFTS, rebuildMemberFTS
-}
-
 func ImportEmbeddings(ctx context.Context, s *store.Store, opts Options, manifest Manifest) error {
 	tx, err := s.DB().BeginTx(ctx, nil)
 	if err != nil {
@@ -835,7 +790,7 @@ func MarkImported(ctx context.Context, s *store.Store, manifest Manifest) error 
 		return err
 	}
 	if manifest.GeneratedAt.IsZero() {
-		return nil
+		return MarkMerged(ctx, s, manifest)
 	}
 	if err := s.SetSyncState(ctx, LastImportManifestSyncScope, manifest.GeneratedAt.Format(time.RFC3339Nano)); err != nil {
 		return err
@@ -844,7 +799,10 @@ func MarkImported(ctx context.Context, s *store.Store, manifest Manifest) error 
 	if err != nil {
 		return fmt.Errorf("marshal imported manifest state: %w", err)
 	}
-	return s.SetSyncState(ctx, LastImportManifestJSONScope, string(body))
+	if err := s.SetSyncState(ctx, LastImportManifestJSONScope, string(body)); err != nil {
+		return err
+	}
+	return MarkMerged(ctx, s, manifest)
 }
 
 func PreviousImportedManifest(ctx context.Context, s *store.Store, opts Options) (Manifest, bool) {
@@ -962,41 +920,6 @@ func snapshotManifest(manifest Manifest) snapshot.Manifest {
 		Tables:      manifest.Tables,
 		Files:       manifest.Files,
 	}
-}
-
-func shareIncrementalPlan(plan snapshot.ImportPlan) (snapshot.ImportPlan, bool) {
-	if plan.Full {
-		return plan, false
-	}
-	out := snapshot.ImportPlan{Tables: make([]snapshot.TableImportPlan, 0, len(plan.Tables))}
-	for _, tablePlan := range plan.Tables {
-		switch tablePlan.Mode {
-		case snapshot.TableImportSkip:
-			out.Tables = append(out.Tables, tablePlan)
-		case snapshot.TableImportFiles:
-			switch tablePlan.Table.Name {
-			case "messages":
-				out.Tables = append(out.Tables, tablePlan)
-			case "guilds", "channels", "members", "message_events", "message_attachments", "mention_events", "sync_state":
-				tablePlan.Mode = snapshot.TableImportReplace
-				tablePlan.Files = nil
-				tablePlan.Reason = "replace changed " + tablePlan.Table.Name + " snapshot table"
-				out.Tables = append(out.Tables, tablePlan)
-			default:
-				return plan, false
-			}
-		case snapshot.TableImportReplace:
-			switch tablePlan.Table.Name {
-			case "guilds", "channels", "members", "messages", "message_events", "message_attachments", "mention_events", "sync_state":
-				out.Tables = append(out.Tables, tablePlan)
-			default:
-				return plan, false
-			}
-		default:
-			return plan, false
-		}
-	}
-	return out, true
 }
 
 func ReadManifest(repoPath string) (Manifest, error) {
@@ -1121,7 +1044,10 @@ func NeedsImport(ctx context.Context, s *store.Store, staleAfter time.Duration) 
 	if staleAfter <= 0 {
 		staleAfter = 15 * time.Minute
 	}
-	last, err := s.GetSyncState(ctx, LastImportSyncScope)
+	last, err := s.GetSyncState(ctx, LastCheckSyncScope)
+	if err != nil || strings.TrimSpace(last) == "" {
+		last, err = s.GetSyncState(ctx, LastImportSyncScope)
+	}
 	if err != nil || strings.TrimSpace(last) == "" {
 		return true
 	}
@@ -2473,6 +2399,7 @@ func importValue(value any) any {
 }
 
 type attachmentMediaRecord struct {
+	TextContent   string
 	MediaPath     string
 	ContentSHA256 string
 	ContentSize   int64
@@ -2533,77 +2460,85 @@ func nullableString(v string) any {
 	return v
 }
 
-func importIncrementalSnapshotRow(ctx context.Context, tx *sql.Tx, table string, row map[string]any) error {
+func upsertMergeSnapshotRow(ctx context.Context, tx *sql.Tx, table string, row map[string]any) (bool, error) {
 	if table == "message_events" || table == "mention_events" {
 		delete(row, "event_id")
 	}
 	if table == "message_attachments" {
-		if err := preserveIncrementalAttachmentMedia(ctx, tx, row); err != nil {
-			return err
+		if err := preserveIncrementalAttachmentState(ctx, tx, row); err != nil {
+			return false, err
 		}
 	}
-	if err := insertOrReplaceSnapshotRow(ctx, tx, table, row); err != nil {
-		return err
-	}
-	if table != "messages" {
-		return nil
-	}
-	messageID := stringValue(row["id"])
-	if messageID == "" {
-		return nil
-	}
-	return upsertMessageFTSRow(ctx, tx, messageID)
+	protectNewer := slices.Contains([]string{"guilds", "channels", "members", "messages"}, table)
+	return upsertSnapshotRow(ctx, tx, table, row, protectNewer)
 }
 
-func preserveIncrementalAttachmentMedia(ctx context.Context, tx *sql.Tx, row map[string]any) error {
-	if stringValue(row["media_path"]) != "" {
-		return nil
-	}
+func preserveIncrementalAttachmentState(ctx context.Context, tx *sql.Tx, row map[string]any) error {
 	attachmentID := stringValue(row["attachment_id"])
 	if attachmentID == "" {
 		return nil
 	}
 	var record attachmentMediaRecord
 	err := tx.QueryRowContext(ctx, `
-		select coalesce(media_path, ''), coalesce(content_sha256, ''), content_size,
+		select coalesce(text_content, ''), coalesce(media_path, ''), coalesce(content_sha256, ''), content_size,
 		       coalesce(fetched_at, ''), coalesce(fetch_status, ''), coalesce(fetch_error, '')
 		from message_attachments
-		where attachment_id = ? and coalesce(media_path, '') <> ''
-	`, attachmentID).Scan(&record.MediaPath, &record.ContentSHA256, &record.ContentSize, &record.FetchedAt, &record.FetchStatus, &record.FetchError)
+		where attachment_id = ?
+	`, attachmentID).Scan(&record.TextContent, &record.MediaPath, &record.ContentSHA256, &record.ContentSize, &record.FetchedAt, &record.FetchStatus, &record.FetchError)
 	if errors.Is(err, sql.ErrNoRows) {
 		return nil
 	}
 	if err != nil {
 		return fmt.Errorf("query existing attachment media %s: %w", attachmentID, err)
 	}
-	row["media_path"] = record.MediaPath
-	row["content_sha256"] = record.ContentSHA256
-	row["content_size"] = record.ContentSize
-	row["fetched_at"] = record.FetchedAt
-	row["fetch_status"] = record.FetchStatus
-	row["fetch_error"] = record.FetchError
+	if stringValue(row["text_content"]) == "" {
+		row["text_content"] = record.TextContent
+	}
+	if stringValue(row["media_path"]) == "" {
+		row["media_path"] = record.MediaPath
+		row["content_sha256"] = record.ContentSHA256
+		row["content_size"] = record.ContentSize
+		row["fetched_at"] = record.FetchedAt
+		row["fetch_status"] = record.FetchStatus
+		row["fetch_error"] = record.FetchError
+	}
 	return nil
 }
 
-func insertOrReplaceSnapshotRow(ctx context.Context, tx *sql.Tx, table string, row map[string]any) error {
+func upsertSnapshotRow(ctx context.Context, tx *sql.Tx, table string, row map[string]any, protectNewer bool) (bool, error) {
 	cols := make([]string, 0, len(row))
 	for col := range row {
 		cols = append(cols, col)
 	}
 	sort.Strings(cols)
 	quoted := make([]string, 0, len(cols))
+	updates := make([]string, 0, len(cols))
 	placeholders := make([]string, 0, len(cols))
 	args := make([]any, 0, len(cols))
 	for _, col := range cols {
-		quoted = append(quoted, quoteIdent(col))
+		quotedCol := quoteIdent(col)
+		quoted = append(quoted, quotedCol)
+		updates = append(updates, quotedCol+" = excluded."+quotedCol)
 		placeholders = append(placeholders, "?")
 		args = append(args, importValue(row[col]))
 	}
-	stmt := "insert or replace into " + quoteIdent(table) + "(" + strings.Join(quoted, ",") + ") values(" + strings.Join(placeholders, ",") + ")"
-	if _, err := tx.ExecContext(ctx, stmt, args...); err != nil {
-		return fmt.Errorf("insert %s: %w", table, err)
+	verb := "insert or replace into "
+	suffix := ""
+	if protectNewer {
+		verb = "insert into "
+		suffix = " on conflict do update set " + strings.Join(updates, ",") +
+			" where coalesce(julianday(excluded.\"updated_at\"), 0) >= coalesce(julianday(" + quoteIdent(table) + ".\"updated_at\"), 0)"
 	}
-	return nil
+	stmt := verb + quoteIdent(table) + "(" + strings.Join(quoted, ",") + ") values(" + strings.Join(placeholders, ",") + ")" + suffix
+	result, err := tx.ExecContext(ctx, stmt, args...)
+	if err != nil {
+		return false, fmt.Errorf("insert %s: %w", table, err)
+	}
+	changed, err := result.RowsAffected()
+	if err != nil {
+		return false, fmt.Errorf("check inserted %s row: %w", table, err)
+	}
+	return changed > 0, nil
 }
 
 func upsertMessageFTSRow(ctx context.Context, tx *sql.Tx, messageID string) error {

--- a/internal/share/share_test.go
+++ b/internal/share/share_test.go
@@ -42,7 +42,7 @@ func TestExportImportRoundTrip(t *testing.T) {
 	defer func() { _ = dst.Close() }()
 
 	var progress []ImportProgress
-	imported, changed, err := ImportIfChanged(ctx, dst, Options{
+	imported, changed, err := MergeIfChanged(ctx, dst, Options{
 		RepoPath: repo,
 		Branch:   "main",
 		Progress: func(p ImportProgress) { progress = append(progress, p) },
@@ -53,7 +53,7 @@ func TestExportImportRoundTrip(t *testing.T) {
 	require.Contains(t, progressPhases(progress), "start")
 	require.Contains(t, progressPhases(progress), "table_start")
 	require.Contains(t, progressPhases(progress), "file_done")
-	require.Contains(t, progressPhases(progress), "rebuild_fts")
+	require.NotContains(t, progressPhases(progress), "rebuild_fts")
 	require.Contains(t, progressPhases(progress), "done")
 
 	results, err := dst.SearchMessages(ctx, store.SearchOptions{Query: "launch", Limit: 10})
@@ -65,15 +65,15 @@ func TestExportImportRoundTrip(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, mentions, 1)
 
-	lastImport, err := dst.GetSyncState(ctx, LastImportSyncScope)
+	lastImport, err := dst.GetSyncState(ctx, LastMergeSyncScope)
 	require.NoError(t, err)
 	require.NotEmpty(t, lastImport)
-	lastManifest, err := dst.GetSyncState(ctx, LastImportManifestSyncScope)
+	lastManifest, err := dst.GetSyncState(ctx, LastMergeManifestSyncScope)
 	require.NoError(t, err)
 	require.Equal(t, manifest.GeneratedAt.Format(time.RFC3339Nano), lastManifest)
 	require.False(t, NeedsImport(ctx, dst, 15*time.Minute))
 
-	imported, changed, err = ImportIfChanged(ctx, dst, Options{RepoPath: repo, Branch: "main"})
+	imported, changed, err = MergeIfChanged(ctx, dst, Options{RepoPath: repo, Branch: "main"})
 	require.NoError(t, err)
 	require.False(t, changed)
 	require.Equal(t, manifest.GeneratedAt, imported.GeneratedAt)
@@ -122,7 +122,7 @@ func TestExportImportRestoresMediaFiles(t *testing.T) {
 	require.NoError(t, err)
 	defer func() { _ = dst.Close() }()
 	dstCache := filepath.Join(dir, "dst-cache")
-	imported, changed, err := ImportIfChanged(ctx, dst, Options{RepoPath: repo, CacheDir: dstCache, Branch: "main", IncludeMedia: true})
+	imported, changed, err := MergeIfChanged(ctx, dst, Options{RepoPath: repo, CacheDir: dstCache, Branch: "main", IncludeMedia: true})
 	require.NoError(t, err)
 	require.True(t, changed)
 	require.NotNil(t, imported.Media)
@@ -137,7 +137,7 @@ func TestExportImportRestoresMediaFiles(t *testing.T) {
 	require.Equal(t, mediaPath, rows[0].MediaPath)
 
 	require.NoError(t, os.Remove(dstFile))
-	imported, changed, err = ImportIfChanged(ctx, dst, Options{RepoPath: repo, CacheDir: dstCache, Branch: "main", IncludeMedia: true})
+	imported, changed, err = MergeIfChanged(ctx, dst, Options{RepoPath: repo, CacheDir: dstCache, Branch: "main", IncludeMedia: true})
 	require.NoError(t, err)
 	require.True(t, changed)
 	require.NotNil(t, imported.Media)
@@ -272,7 +272,7 @@ func TestImportPreservesLocalAttachmentMediaMetadata(t *testing.T) {
 	require.Equal(t, "fetched", rows[0].FetchStatus)
 }
 
-func TestIncrementalImportPreservesLocalAttachmentMediaMetadata(t *testing.T) {
+func TestMergeImportPreservesLocalAttachmentState(t *testing.T) {
 	ctx := context.Background()
 	dir := t.TempDir()
 	dst := seedStore(t, filepath.Join(dir, "dst.db"))
@@ -282,6 +282,8 @@ func TestIncrementalImportPreservesLocalAttachmentMediaMetadata(t *testing.T) {
 	hash := hex.EncodeToString(sum[:])
 	mediaPath := filepath.ToSlash(filepath.Join("attachments", hash[:2], hash+"-file.png"))
 	require.NoError(t, addCachedAttachment(ctx, dst, mediaPath, hash, int64(len(body))))
+	_, err := dst.DB().ExecContext(ctx, `update message_attachments set text_content = 'local extracted text' where attachment_id = 'a1'`)
+	require.NoError(t, err)
 
 	tx, err := dst.DB().BeginTx(ctx, nil)
 	require.NoError(t, err)
@@ -305,7 +307,9 @@ func TestIncrementalImportPreservesLocalAttachmentMediaMetadata(t *testing.T) {
 		"fetch_error":    "",
 		"updated_at":     time.Now().UTC().Format(time.RFC3339Nano),
 	}
-	require.NoError(t, importIncrementalSnapshotRow(ctx, tx, "message_attachments", row))
+	applied, err := upsertMergeSnapshotRow(ctx, tx, "message_attachments", row)
+	require.NoError(t, err)
+	require.True(t, applied)
 	require.NoError(t, tx.Commit())
 
 	rows, err := dst.ListAttachments(ctx, store.AttachmentListOptions{MessageID: "m1"})
@@ -315,6 +319,7 @@ func TestIncrementalImportPreservesLocalAttachmentMediaMetadata(t *testing.T) {
 	require.Equal(t, hash, rows[0].ContentSHA256)
 	require.Equal(t, int64(len(body)), rows[0].ContentSize)
 	require.Equal(t, "fetched", rows[0].FetchStatus)
+	require.Equal(t, "local extracted text", rows[0].TextContent)
 }
 
 func TestImportMediaRejectsSymlinkedFiles(t *testing.T) {
@@ -450,7 +455,7 @@ func TestImportMediaRejectsInvalidAndMismatchedFiles(t *testing.T) {
 	require.Contains(t, err.Error(), "media hash mismatch")
 }
 
-func TestImportIncrementalRestoresMediaWhenTablesUnchanged(t *testing.T) {
+func TestMergeIfChangedRestoresMediaWhenTablesUnchanged(t *testing.T) {
 	ctx := context.Background()
 	dir := t.TempDir()
 	src := seedStore(t, filepath.Join(dir, "src.db"))
@@ -476,7 +481,7 @@ func TestImportIncrementalRestoresMediaWhenTablesUnchanged(t *testing.T) {
 	require.NoError(t, err)
 
 	dstCache := filepath.Join(dir, "dst-cache")
-	imported, changed, err := ImportIncremental(ctx, dst, Options{RepoPath: repo, CacheDir: dstCache, Branch: "main", IncludeMedia: true}, manifest, manifest)
+	imported, changed, err := MergeIfChanged(ctx, dst, Options{RepoPath: repo, CacheDir: dstCache, Branch: "main", IncludeMedia: true})
 	require.NoError(t, err)
 	require.True(t, changed)
 	require.Equal(t, manifest.GeneratedAt, imported.GeneratedAt)
@@ -485,34 +490,6 @@ func TestImportIncrementalRestoresMediaWhenTablesUnchanged(t *testing.T) {
 	got, err := os.ReadFile(dstFile)
 	require.NoError(t, err)
 	require.Equal(t, body, got)
-}
-
-func TestShareIncrementalPlanHandlesSupportedModesAndRejectsOthers(t *testing.T) {
-	_, supported := shareIncrementalPlan(snapshot.ImportPlan{Full: true, Reason: "schema changed"})
-	require.False(t, supported)
-
-	_, supported = shareIncrementalPlan(snapshot.ImportPlan{Tables: []snapshot.TableImportPlan{{
-		Table: snapshot.TableManifest{Name: "custom"},
-		Mode:  snapshot.TableImportFiles,
-	}}})
-	require.False(t, supported)
-
-	plan, supported := shareIncrementalPlan(snapshot.ImportPlan{Tables: []snapshot.TableImportPlan{{
-		Table: snapshot.TableManifest{Name: "messages"},
-		Mode:  snapshot.TableImportReplace,
-	}}})
-	require.True(t, supported)
-	require.Equal(t, snapshot.TableImportReplace, plan.Tables[0].Mode)
-
-	plan, supported = shareIncrementalPlan(snapshot.ImportPlan{Tables: []snapshot.TableImportPlan{
-		{Table: snapshot.TableManifest{Name: "messages"}, Mode: snapshot.TableImportFiles},
-		{Table: snapshot.TableManifest{Name: "guilds"}, Mode: snapshot.TableImportFiles},
-		{Table: snapshot.TableManifest{Name: "channels"}, Mode: snapshot.TableImportReplace},
-		{Table: snapshot.TableManifest{Name: "sync_state"}, Mode: snapshot.TableImportSkip},
-	}})
-	require.True(t, supported)
-	require.Len(t, plan.Tables, 4)
-	require.Equal(t, snapshot.TableImportReplace, plan.Tables[1].Mode)
 }
 
 func TestMessageFTSHelpers(t *testing.T) {
@@ -526,17 +503,6 @@ func TestMessageFTSHelpers(t *testing.T) {
 	require.False(t, ok)
 	require.Nil(t, nullIfEmpty(""))
 	require.Equal(t, "value", nullIfEmpty("value"))
-}
-
-func TestImportPlanSearchRebuildsKeepsEarlierChannelRebuild(t *testing.T) {
-	rebuildMessages, rebuildMembers := importPlanSearchRebuilds(snapshot.ImportPlan{
-		Tables: []snapshot.TableImportPlan{
-			{Table: snapshot.TableManifest{Name: "channels"}, Mode: snapshot.TableImportReplace},
-			{Table: snapshot.TableManifest{Name: "messages"}, Mode: snapshot.TableImportFiles},
-		},
-	})
-	require.True(t, rebuildMessages)
-	require.False(t, rebuildMembers)
 }
 
 func TestPreviousImportedManifestFallsBackToGitHistory(t *testing.T) {
@@ -913,7 +879,7 @@ func TestExportSkipsSymlinkedMediaDirectories(t *testing.T) {
 	require.True(t, os.IsNotExist(err))
 }
 
-func TestImportIfChangedUsesIncrementalTailImport(t *testing.T) {
+func TestMergeIfChangedUsesIncrementalTailImport(t *testing.T) {
 	ctx := context.Background()
 	src := seedStore(t, filepath.Join(t.TempDir(), "src.db"))
 	defer func() { _ = src.Close() }()
@@ -926,7 +892,7 @@ func TestImportIfChangedUsesIncrementalTailImport(t *testing.T) {
 	dst, err := store.Open(ctx, filepath.Join(t.TempDir(), "dst.db"))
 	require.NoError(t, err)
 	defer func() { _ = dst.Close() }()
-	_, changed, err := ImportIfChanged(ctx, dst, Options{RepoPath: repo, Branch: "main"})
+	_, changed, err := MergeIfChanged(ctx, dst, Options{RepoPath: repo, Branch: "main"})
 	require.NoError(t, err)
 	require.True(t, changed)
 
@@ -951,7 +917,7 @@ func TestImportIfChangedUsesIncrementalTailImport(t *testing.T) {
 	require.NotEqual(t, manifest.GeneratedAt, updated.GeneratedAt)
 
 	var progress []ImportProgress
-	imported, changed, err := ImportIfChanged(ctx, dst, Options{
+	imported, changed, err := MergeIfChanged(ctx, dst, Options{
 		RepoPath: repo,
 		Branch:   "main",
 		Progress: func(p ImportProgress) { progress = append(progress, p) },
@@ -960,18 +926,18 @@ func TestImportIfChangedUsesIncrementalTailImport(t *testing.T) {
 	require.True(t, changed)
 	require.Equal(t, updated.GeneratedAt, imported.GeneratedAt)
 	require.Contains(t, progressPhases(progress), "table_start")
-	require.Contains(t, progressPhases(progress), "rebuild_fts")
+	require.NotContains(t, progressPhases(progress), "rebuild_fts")
 
 	results, err := dst.SearchMessages(ctx, store.SearchOptions{Query: "delta landed", Limit: 10})
 	require.NoError(t, err)
 	require.Len(t, results, 1)
 	require.Equal(t, "m2", results[0].MessageID)
-	state, err := dst.GetSyncState(ctx, LastImportManifestJSONScope)
+	state, err := dst.GetSyncState(ctx, LastMergeManifestJSONScope)
 	require.NoError(t, err)
 	require.Contains(t, state, `"file_manifests"`)
 }
 
-func TestImportIfChangedUsesMixedIncrementalPlanForMetadataChanges(t *testing.T) {
+func TestMergeIfChangedUsesMixedIncrementalPlanForMetadataChanges(t *testing.T) {
 	ctx := context.Background()
 	src := seedStore(t, filepath.Join(t.TempDir(), "src.db"))
 	defer func() { _ = src.Close() }()
@@ -983,7 +949,7 @@ func TestImportIfChangedUsesMixedIncrementalPlanForMetadataChanges(t *testing.T)
 	dst, err := store.Open(ctx, filepath.Join(t.TempDir(), "dst.db"))
 	require.NoError(t, err)
 	defer func() { _ = dst.Close() }()
-	_, changed, err := ImportIfChanged(ctx, dst, Options{RepoPath: repo, Branch: "main"})
+	_, changed, err := MergeIfChanged(ctx, dst, Options{RepoPath: repo, Branch: "main"})
 	require.NoError(t, err)
 	require.True(t, changed)
 
@@ -1038,19 +1004,19 @@ func TestImportIfChangedUsesMixedIncrementalPlanForMetadataChanges(t *testing.T)
 	require.NoError(t, err)
 	require.NotEqual(t, manifest.GeneratedAt, updated.GeneratedAt)
 
-	previous, ok := PreviousImportedManifest(ctx, dst, Options{RepoPath: repo, Branch: "main"})
+	previous, ok := PreviousMergedManifest(ctx, dst, Options{RepoPath: repo, Branch: "main"})
 	require.True(t, ok)
-	planned, supported := shareIncrementalPlan(snapshot.PlanIncrementalImport(snapshotManifest(previous), snapshotManifest(updated)))
-	require.True(t, supported, "%+v", planned)
-	require.Equal(t, snapshot.TableImportReplace, importPlanTable(t, planned, "channels").Mode)
-	require.Equal(t, snapshot.TableImportReplace, importPlanTable(t, planned, "members").Mode)
-	require.Equal(t, snapshot.TableImportReplace, importPlanTable(t, planned, "messages").Mode)
-	require.Equal(t, snapshot.TableImportReplace, importPlanTable(t, planned, "message_events").Mode)
-	require.Equal(t, snapshot.TableImportReplace, importPlanTable(t, planned, "message_attachments").Mode)
-	require.Equal(t, snapshot.TableImportReplace, importPlanTable(t, planned, "mention_events").Mode)
+	planned, err := shareMergePlan(snapshot.PlanMergeImport(snapshotManifest(previous), snapshotManifest(updated)), false)
+	require.NoError(t, err)
+	require.Equal(t, snapshot.TableImportFiles, importPlanTable(t, planned, "channels").Mode)
+	require.Equal(t, snapshot.TableImportFiles, importPlanTable(t, planned, "members").Mode)
+	require.Equal(t, snapshot.TableImportFiles, importPlanTable(t, planned, "messages").Mode)
+	require.Equal(t, snapshot.TableImportSkip, importPlanTable(t, planned, "message_events").Mode)
+	require.Equal(t, snapshot.TableImportFiles, importPlanTable(t, planned, "message_attachments").Mode)
+	require.Equal(t, snapshot.TableImportSkip, importPlanTable(t, planned, "mention_events").Mode)
 
 	var progress []ImportProgress
-	imported, changed, err := ImportIfChanged(ctx, dst, Options{
+	imported, changed, err := MergeIfChanged(ctx, dst, Options{
 		RepoPath: repo,
 		Branch:   "main",
 		Progress: func(p ImportProgress) { progress = append(progress, p) },
@@ -1058,7 +1024,7 @@ func TestImportIfChangedUsesMixedIncrementalPlanForMetadataChanges(t *testing.T)
 	require.NoError(t, err)
 	require.True(t, changed)
 	require.Equal(t, updated.GeneratedAt, imported.GeneratedAt)
-	require.Contains(t, progressPhases(progress), "rebuild_fts")
+	require.NotContains(t, progressPhases(progress), "rebuild_fts")
 	require.Contains(t, progressPhases(progress), "rebuild_member_fts")
 	require.Equal(t, importPlanRowCount(planned), progressTotalRows(t, progress, "start"))
 	require.Positive(t, progressTotalRows(t, progress, "start"))
@@ -1077,16 +1043,16 @@ func TestImportIfChangedUsesMixedIncrementalPlanForMetadataChanges(t *testing.T)
 	require.Equal(t, "launch", rows[0][0])
 	_, rows, err = dst.ReadOnlyQuery(ctx, "select count(*) from mention_events")
 	require.NoError(t, err)
-	require.Equal(t, "2", rows[0][0])
+	require.Equal(t, "1", rows[0][0])
 	_, rows, err = dst.ReadOnlyQuery(ctx, "select count(*) from message_events")
 	require.NoError(t, err)
-	require.Equal(t, "2", rows[0][0])
+	require.Equal(t, "1", rows[0][0])
 	_, rows, err = dst.ReadOnlyQuery(ctx, "select count(*) from member_fts where member_fts match 'delta'")
 	require.NoError(t, err)
 	require.Equal(t, "1", rows[0][0])
 }
 
-func TestImportIfChangedInfersLegacyManifestFilesFromGit(t *testing.T) {
+func TestMergeIfChangedInfersLegacyManifestFilesFromGit(t *testing.T) {
 	ctx := context.Background()
 	src := seedStore(t, filepath.Join(t.TempDir(), "src.db"))
 	defer func() { _ = src.Close() }()
@@ -1103,7 +1069,7 @@ func TestImportIfChangedInfersLegacyManifestFilesFromGit(t *testing.T) {
 	dst, err := store.Open(ctx, filepath.Join(t.TempDir(), "dst.db"))
 	require.NoError(t, err)
 	defer func() { _ = dst.Close() }()
-	_, changed, err := ImportIfChanged(ctx, dst, Options{RepoPath: repo, Branch: "main"})
+	_, changed, err := MergeIfChanged(ctx, dst, Options{RepoPath: repo, Branch: "main"})
 	require.NoError(t, err)
 	require.True(t, changed)
 
@@ -1129,21 +1095,21 @@ func TestImportIfChangedInfersLegacyManifestFilesFromGit(t *testing.T) {
 	require.NoError(t, exec.CommandContext(ctx, "git", "-C", repo, "add", ".").Run())
 	require.NoError(t, exec.CommandContext(ctx, "git", "-C", repo, "commit", "-m", "tail snapshot").Run())
 
-	previous, ok := PreviousImportedManifest(ctx, dst, Options{RepoPath: repo, Branch: "main"})
+	previous, ok := PreviousMergedManifest(ctx, dst, Options{RepoPath: repo, Branch: "main"})
 	require.True(t, ok)
-	planned, supported := shareIncrementalPlan(snapshot.PlanIncrementalImport(snapshotManifest(previous), snapshotManifest(enrichManifestFromGit(ctx, repo, "HEAD", stripFileManifests(updated)))))
-	require.True(t, supported, "%+v", planned)
+	planned, err := shareMergePlan(snapshot.PlanMergeImport(snapshotManifest(previous), snapshotManifest(enrichManifestFromGit(ctx, repo, "HEAD", stripFileManifests(updated)))), false)
+	require.NoError(t, err)
 	require.True(t, planned.Changed(), "%+v", planned)
 
 	var progress []ImportProgress
-	_, changed, err = ImportIfChanged(ctx, dst, Options{
+	_, changed, err = MergeIfChanged(ctx, dst, Options{
 		RepoPath: repo,
 		Branch:   "main",
 		Progress: func(p ImportProgress) { progress = append(progress, p) },
 	})
 	require.NoError(t, err)
 	require.True(t, changed)
-	require.Contains(t, progressPhases(progress), "rebuild_fts")
+	require.NotContains(t, progressPhases(progress), "rebuild_fts")
 	results, err := dst.SearchMessages(ctx, store.SearchOptions{Query: "legacy git delta", Limit: 10})
 	require.NoError(t, err)
 	require.Len(t, results, 1)
@@ -1569,7 +1535,7 @@ func TestImportEmbeddingsFiltersByConfiguredIdentity(t *testing.T) {
 	require.Equal(t, "0", rows[0][0])
 }
 
-func TestImportIfChangedSkipsSameManifest(t *testing.T) {
+func TestMergeIfChangedSkipsSameManifest(t *testing.T) {
 	ctx := context.Background()
 	src := seedStore(t, filepath.Join(t.TempDir(), "src.db"))
 	defer func() { _ = src.Close() }()
@@ -1582,7 +1548,7 @@ func TestImportIfChangedSkipsSameManifest(t *testing.T) {
 	require.NoError(t, err)
 	defer func() { _ = dst.Close() }()
 
-	importedManifest, imported, err := ImportIfChanged(ctx, dst, Options{RepoPath: repo, Branch: "main"})
+	importedManifest, imported, err := MergeIfChanged(ctx, dst, Options{RepoPath: repo, Branch: "main"})
 	require.NoError(t, err)
 	require.True(t, imported)
 	require.Equal(t, manifest.GeneratedAt, importedManifest.GeneratedAt)
@@ -1601,7 +1567,7 @@ func TestImportIfChangedSkipsSameManifest(t *testing.T) {
 		RawJSON:           `{}`,
 	}))
 
-	_, imported, err = ImportIfChanged(ctx, dst, Options{RepoPath: repo, Branch: "main"})
+	_, imported, err = MergeIfChanged(ctx, dst, Options{RepoPath: repo, Branch: "main"})
 	require.NoError(t, err)
 	require.False(t, imported)
 	results, err := dst.SearchMessages(ctx, store.SearchOptions{Query: "live delta", Limit: 10})
@@ -2086,11 +2052,11 @@ func TestManifestStateAndReadEdges(t *testing.T) {
 	require.True(t, ManifestAlreadyImported(ctx, s, manifest))
 
 	require.False(t, NeedsImport(ctx, s, 15*time.Minute))
-	require.NoError(t, s.SetSyncState(ctx, LastImportSyncScope, "bad-time"))
+	require.NoError(t, s.SetSyncState(ctx, LastCheckSyncScope, "bad-time"))
 	require.True(t, NeedsImport(ctx, s, 15*time.Minute))
-	require.NoError(t, s.SetSyncState(ctx, LastImportSyncScope, time.Now().UTC().Add(-20*time.Minute).Format(time.RFC3339Nano)))
+	require.NoError(t, s.SetSyncState(ctx, LastCheckSyncScope, time.Now().UTC().Add(-20*time.Minute).Format(time.RFC3339Nano)))
 	require.True(t, NeedsImport(ctx, s, 15*time.Minute))
-	require.NoError(t, s.SetSyncState(ctx, LastImportSyncScope, time.Now().UTC().Format(time.RFC3339Nano)))
+	require.NoError(t, s.SetSyncState(ctx, LastCheckSyncScope, time.Now().UTC().Format(time.RFC3339Nano)))
 	require.False(t, NeedsImport(ctx, s, 0))
 }
 


### PR DESCRIPTION
## What Problem This Solves

Routine `discrawl update` and auto-update could treat a changed snapshot shard as an exact replacement. A changed tail file therefore cleared public cache tables, replayed roughly the whole archive, rebuilt FTS, and discarded locally crawled rows that were absent from the Git snapshot.

## Why This Change Was Made

- Use Crawlkit v0.13.2 monotonic merge plans for normal subscribe/update/auto-update paths.
- Upsert changed canonical shards without deleting destination-only rows, and refuse removed-shard/schema replacements unless the caller passes `--force`.
- Keep exact reconciliation as one explicit full-replace path; require `--force` for historical `--ref` restores and make `sync --update=force` exact.
- Preserve newer same-ID local rows by comparing `updated_at`, preserve local attachment text/media state, and update message FTS row-by-row instead of rebuilding it for message-tail changes.
- Track last checked, last merged, and pending replacement state separately from the last exact import.
- Skip generated event replay and remote sync cursors during routine merges; bootstrap event history only into empty event tables.

## User Impact

`discrawl update`, read-command auto-update, and `sync --update=auto` no longer throw away local cache rows. If an exact replacement is required, Discrawl keeps the current database and asks for `discrawl update --force`. `update --ref` now requires `--force`.

## Evidence

- `GOWORK=off go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run`
- `GOWORK=off go vet ./...`
- `GOWORK=off go test -count=1 ./... -coverprofile=/tmp/discrawl-coverage.out` (85.8% after generated-store exclusion)
- `GOWORK=off go test -count=1 -race ./...`
- `GOWORK=off go build -o /tmp/discrawl ./cmd/discrawl`
- `GOWORK=off go mod verify`
- `git diff --check`
- Regression coverage proves destination-only rows and newer same-ID local rows survive routine merges, normal tail refreshes avoid full message FTS rebuilds, generated events are not replayed, attachment-local state survives, and `--force` reconciles even when the manifest is unchanged.
- Crawlkit dependency: openclaw/crawlkit#42, released as v0.13.2 and verified through the Go proxy.

Autoreview was invoked repeatedly with the Codex engine, but the nested engine terminated after starting without emitting a verdict; the supported fallbacks were unavailable due local authentication/version gates. An equivalent exhaustive manual review found and fixed the newer-local-row overwrite before the final gates above.
