### PR TITLE
Fix targeted archived thread sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## 0.11.5 - Unreleased
 
+### Fixes
+
+- Resolve targeted channel/thread sync requests directly before falling back to
+  broad thread catalog crawls, so archived thread syncs do not wait on unrelated
+  guild thread endpoints.
+
 ## 0.11.4 - 2026-07-02
 
 ### Changes

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -3572,6 +3572,10 @@ func (f *fakeDiscordClient) Guild(context.Context, string) (*discordgo.Guild, er
 	return &discordgo.Guild{}, nil
 }
 
+func (f *fakeDiscordClient) Channel(context.Context, string) (*discordgo.Channel, error) {
+	return nil, nil
+}
+
 func (f *fakeDiscordClient) GuildChannels(context.Context, string) ([]*discordgo.Channel, error) {
 	return nil, nil
 }

--- a/internal/discord/client.go
+++ b/internal/discord/client.go
@@ -91,6 +91,12 @@ func (c *Client) Guild(ctx context.Context, guildID string) (*discordgo.Guild, e
 	return c.session.Guild(guildID, discordgo.WithContext(reqCtx))
 }
 
+func (c *Client) Channel(ctx context.Context, channelID string) (*discordgo.Channel, error) {
+	reqCtx, cancel := c.requestContext(ctx)
+	defer cancel()
+	return c.session.Channel(channelID, discordgo.WithContext(reqCtx))
+}
+
 func (c *Client) GuildChannels(ctx context.Context, guildID string) ([]*discordgo.Channel, error) {
 	reqCtx, cancel := c.requestContext(ctx)
 	defer cancel()

--- a/internal/syncer/channel_catalog.go
+++ b/internal/syncer/channel_catalog.go
@@ -60,12 +60,44 @@ func (s *Syncer) channelList(ctx context.Context, guildID string, requested []st
 	}
 
 	if unresolvedRequestedIDs(selected, requestedSet) > 0 {
+		if err := s.appendDirectRequestedChannels(ctx, guildID, allChannels, requestedSet); err != nil {
+			return nil, false, err
+		}
+		selected = selectRequestedChannels(allChannels, storedByID, requestedSet)
+	}
+
+	if unresolvedRequestedIDs(selected, requestedSet) > 0 {
 		if err := s.appendThreadCatalog(ctx, allChannels, threadParentIDs(topLevel)); err != nil {
 			return nil, false, err
 		}
 		selected = selectRequestedChannels(allChannels, storedByID, requestedSet)
 	}
 	return selected, true, nil
+}
+
+func (s *Syncer) appendDirectRequestedChannels(
+	ctx context.Context,
+	guildID string,
+	allChannels map[string]*discordgo.Channel,
+	requested map[string]struct{},
+) error {
+	for requestedID := range requested {
+		if _, ok := allChannels[requestedID]; ok {
+			continue
+		}
+		channel, err := s.client.Channel(ctx, requestedID)
+		if err != nil {
+			return fmt.Errorf("fetch requested channel %s: %w", requestedID, err)
+		}
+		if channel == nil || channel.ID == "" {
+			continue
+		}
+		if channel.GuildID != "" && guildID != "" && channel.GuildID != guildID {
+			return fmt.Errorf("requested channel %s belongs to guild %s, not %s", channel.ID, channel.GuildID, guildID)
+		}
+		allChannels[channel.ID] = channel
+	}
+	return nil
 }
 
 func (s *Syncer) liveChannelList(ctx context.Context, guildID string, mode channelCatalogMode) ([]*discordgo.Channel, error) {

--- a/internal/syncer/channel_catalog_test.go
+++ b/internal/syncer/channel_catalog_test.go
@@ -123,6 +123,76 @@ func TestSyncChannelSubsetExpandsRequestedForumThreads(t *testing.T) {
 	require.Equal(t, "t1", results[0].ChannelID)
 }
 
+func TestSyncChannelSubsetFetchesRequestedArchivedThreadDirectly(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	s, err := store.Open(ctx, filepath.Join(t.TempDir(), "discrawl.db"))
+	require.NoError(t, err)
+	defer func() { _ = s.Close() }()
+
+	require.NoError(t, s.UpsertGuild(ctx, store.GuildRecord{ID: "g1", Name: "Guild", RawJSON: `{}`}))
+
+	archiveAt := time.Now().UTC().Add(-time.Hour)
+	client := &fakeClient{
+		guilds: []*discordgo.UserGuild{{ID: "g1", Name: "Guild"}},
+		guildByID: map[string]*discordgo.Guild{
+			"g1": {ID: "g1", Name: "Guild"},
+		},
+		channels: map[string][]*discordgo.Channel{
+			"g1": {
+				{ID: "f1", GuildID: "g1", Name: "support", Type: discordgo.ChannelTypeGuildForum},
+				{ID: "c2", GuildID: "g1", Name: "random", Type: discordgo.ChannelTypeGuildText},
+			},
+		},
+		channelByID: map[string]*discordgo.Channel{
+			"t-archived": {
+				ID:       "t-archived",
+				GuildID:  "g1",
+				ParentID: "f1",
+				Name:     "archived support thread",
+				Type:     discordgo.ChannelTypeGuildPublicThread,
+				ThreadMetadata: &discordgo.ThreadMetadata{
+					Archived:         true,
+					ArchiveTimestamp: archiveAt,
+				},
+				LastMessageID: "10",
+			},
+		},
+		messages: map[string][]*discordgo.Message{
+			"t-archived": {{
+				ID:        "10",
+				GuildID:   "g1",
+				ChannelID: "t-archived",
+				Content:   "archived support body",
+				Timestamp: archiveAt,
+				Author:    &discordgo.User{ID: "u1", Username: "user"},
+			}},
+		},
+	}
+
+	svc := New(client, s, nil)
+	stats, err := svc.Sync(ctx, SyncOptions{
+		Full:       true,
+		GuildIDs:   []string{"g1"},
+		ChannelIDs: []string{"t-archived"},
+	})
+	require.NoError(t, err)
+	require.Equal(t, 1, stats.Channels)
+	require.Equal(t, 1, stats.Threads)
+	require.Equal(t, 1, stats.Messages)
+	require.Equal(t, 1, client.guildChanCalls)
+	require.Equal(t, 1, client.channelCalls["t-archived"])
+	require.Zero(t, client.threadCalls)
+	require.Empty(t, client.archivedCalls)
+	require.Equal(t, 1, client.messageCalls["t-archived"])
+
+	results, err := s.SearchMessages(ctx, store.SearchOptions{Query: "archived support"})
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	require.Equal(t, "t-archived", results[0].ChannelID)
+}
+
 func TestSyncToleratesArchivedThread403(t *testing.T) {
 	t.Parallel()
 

--- a/internal/syncer/syncer.go
+++ b/internal/syncer/syncer.go
@@ -17,6 +17,7 @@ type Client interface {
 	Self(context.Context) (*discordgo.User, error)
 	Guilds(context.Context) ([]*discordgo.UserGuild, error)
 	Guild(context.Context, string) (*discordgo.Guild, error)
+	Channel(context.Context, string) (*discordgo.Channel, error)
 	GuildChannels(context.Context, string) ([]*discordgo.Channel, error)
 	ThreadsActive(context.Context, string) ([]*discordgo.Channel, error)
 	GuildThreadsActive(context.Context, string) ([]*discordgo.Channel, error)

--- a/internal/syncer/syncer_test.go
+++ b/internal/syncer/syncer_test.go
@@ -18,6 +18,7 @@ import (
 type fakeClient struct {
 	guilds           []*discordgo.UserGuild
 	guildByID        map[string]*discordgo.Guild
+	channelByID      map[string]*discordgo.Channel
 	channels         map[string][]*discordgo.Channel
 	activeThreads    map[string][]*discordgo.Channel
 	guildThreads     map[string][]*discordgo.Channel
@@ -40,6 +41,7 @@ type fakeClient struct {
 	tailCalls        int
 	tailHandled      chan struct{}
 	messageDelay     time.Duration
+	channelCalls     map[string]int
 	guildChanCalls   int
 	threadCalls      int
 	guildThreadCalls int
@@ -65,6 +67,14 @@ func (f *fakeClient) Guilds(context.Context) ([]*discordgo.UserGuild, error) {
 
 func (f *fakeClient) Guild(_ context.Context, guildID string) (*discordgo.Guild, error) {
 	return f.guildByID[guildID], nil
+}
+
+func (f *fakeClient) Channel(_ context.Context, channelID string) (*discordgo.Channel, error) {
+	if f.channelCalls == nil {
+		f.channelCalls = make(map[string]int)
+	}
+	f.channelCalls[channelID]++
+	return f.channelByID[channelID], nil
 }
 
 func (f *fakeClient) GuildChannels(_ context.Context, guildID string) ([]*discordgo.Channel, error) {


### PR DESCRIPTION
## Summary

- resolve requested channel/thread ids directly with `GET /channels/{id}` before falling back to broad thread-catalog discovery
- prevent targeted `messages --sync --channel <archived-thread>` and `sync --channels <archived-thread>` from crawling unrelated guild thread parents
- add a regression for syncing an archived thread id that is not already present in the local channel table

## Minekube reproduction

Before this change, targeted sync for archived support thread `1522179061521186937` hung and cancelled while waiting on unrelated guild thread endpoints, e.g. `channels/1067106460674314331/threads/active`.

With this branch built locally:

```bash
perl -e 'alarm shift; exec @ARGV' 45 /tmp/discrawl-targeted-thread-sync \\\n  messages --sync \\\n  --guild 633708750032863232 \\\n  --channel 1522179061521186937 \\\n  --limit 200 \\\n  --include-empty\n```\n\nResult: completed in about 2 seconds, synced exactly one channel, wrote 2 messages, and did not crawl unrelated thread catalogs.\n\nThe Minekube support audit then passed:\n\n```text\nactionable_missing=0\nfatal_inaccessible_catalogs=0\nfatal_truncated_catalogs=0\nstatus=ok\n```\n\n## Verification\n\n- `go test ./internal/syncer -run 'TestSyncChannelSubsetFetchesRequestedArchivedThreadDirectly|TestSyncChannelSubsetExpandsRequestedForumThreads' -count=1`\n- `go test ./...`\n- `git diff --check`\n- local live targeted sync against Minekube archived support thread `1522179061521186937`\n