### PR TITLE
fix(media): constrain attachment redirects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - Show setup guidance instead of a raw missing-file error when configuration-dependent commands cannot find `config.toml`. Thanks @0xdevalias.
 - Report module build metadata for source-installed binaries instead of a stale hard-coded release version.
+- Reject attachment redirects whose final URL leaves Discord's allowlisted CDN hosts. Thanks @GrantTheAssistant.
 
 ## 0.11.5 - 2026-07-09
 

--- a/internal/media/cache.go
+++ b/internal/media/cache.go
@@ -50,9 +50,7 @@ func Fetch(ctx context.Context, s *store.Store, opts FetchOptions) (FetchStats, 
 	if opts.MaxBytes <= 0 {
 		opts.MaxBytes = DefaultMaxBytes
 	}
-	if opts.HTTPClient == nil {
-		opts.HTTPClient = &http.Client{Timeout: 30 * time.Second}
-	}
+	opts.HTTPClient = attachmentHTTPClient(opts.HTTPClient)
 	if opts.Now == nil {
 		opts.Now = time.Now
 	}
@@ -131,6 +129,29 @@ func Fetch(ctx context.Context, s *store.Store, opts FetchOptions) (FetchStats, 
 		}
 	}
 	return stats, nil
+}
+
+func attachmentHTTPClient(client *http.Client) *http.Client {
+	if client == nil {
+		client = &http.Client{Timeout: 30 * time.Second}
+	}
+	clone := *client
+	previous := clone.CheckRedirect
+	clone.CheckRedirect = func(req *http.Request, via []*http.Request) error {
+		if len(via) >= 3 || !isAllowedAttachmentURL(req.URL.String()) {
+			return errors.New("attachment redirect denied")
+		}
+		if previous != nil {
+			if err := previous(req, via); err != nil {
+				return err
+			}
+			if !isAllowedAttachmentURL(req.URL.String()) {
+				return errors.New("attachment redirect denied")
+			}
+		}
+		return nil
+	}
+	return &clone
 }
 
 func attachmentFailureRef(attachment store.AttachmentRow) store.FailureRef {
@@ -234,6 +255,11 @@ func fetchURL(ctx context.Context, opts FetchOptions, attachment store.Attachmen
 		}
 	}
 	defer func() { _ = resp.Body.Close() }()
+	// Injected clients can supply their own redirect policy, so validate the
+	// final response URL at the fetch boundary as well.
+	if resp.Request == nil || resp.Request.URL == nil || !isAllowedAttachmentURL(resp.Request.URL.String()) {
+		return fetchResult{}, errors.New("attachment response URL denied")
+	}
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		return fetchResult{}, fmt.Errorf("attachment fetch returned HTTP %d", resp.StatusCode)
 	}

--- a/internal/media/cache_test.go
+++ b/internal/media/cache_test.go
@@ -8,9 +8,11 @@ import (
 	"errors"
 	"io"
 	"net/http"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -468,6 +470,60 @@ func TestMediaPathHelpers(t *testing.T) {
 	require.False(t, isAllowedAttachmentURL("https://cdn.discordapp.com:444/attachments/c/file.png"))
 	require.False(t, isAllowedAttachmentURL("https://cdn.discordapp.com.evil.test/attachments/c/file.png"))
 	require.False(t, isAllowedAttachmentURL("https://user@cdn.discordapp.com/attachments/c/file.png"))
+}
+
+func TestFetchURLRejectsAllowedCDNRedirectToMetadataHost(t *testing.T) {
+	t.Parallel()
+	var calls atomic.Int32
+	client := attachmentHTTPClient(&http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		calls.Add(1)
+		headers := make(http.Header)
+		headers.Set("Location", "http://169.254.169.254/computeMetadata/v1/")
+		return &http.Response{
+			StatusCode: http.StatusFound,
+			Header:     headers,
+			Body:       io.NopCloser(strings.NewReader("redirect")),
+			Request:    req,
+		}, nil
+	})})
+	request, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "https://cdn.discordapp.com/attachments/c/x.txt", nil)
+	require.NoError(t, err)
+	response, err := client.Do(request)
+	if response != nil {
+		_ = response.Body.Close()
+	}
+	require.ErrorContains(t, err, "attachment redirect denied")
+	require.EqualValues(t, 1, calls.Load())
+}
+
+func TestAttachmentHTTPClientRejectsRedirectCallbackURLMutation(t *testing.T) {
+	t.Parallel()
+	var calls atomic.Int32
+	client := attachmentHTTPClient(&http.Client{
+		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			calls.Add(1)
+			headers := make(http.Header)
+			headers.Set("Location", "https://media.discordapp.net/attachments/c/next.txt")
+			return &http.Response{
+				StatusCode: http.StatusFound,
+				Header:     headers,
+				Body:       io.NopCloser(strings.NewReader("redirect")),
+				Request:    req,
+			}, nil
+		}),
+		CheckRedirect: func(req *http.Request, _ []*http.Request) error {
+			req.URL = &url.URL{Scheme: "http", Host: "169.254.169.254", Path: "/computeMetadata/v1/"}
+			return nil
+		},
+	})
+	request, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "https://cdn.discordapp.com/attachments/c/x.txt", nil)
+	require.NoError(t, err)
+	response, err := client.Do(request)
+	if response != nil {
+		_ = response.Body.Close()
+	}
+	require.ErrorContains(t, err, "attachment redirect denied")
+	require.EqualValues(t, 1, calls.Load())
 }
 
 func TestMediaTargetNeedsWrite(t *testing.T) {


### PR DESCRIPTION
## Summary

- Reject default-client redirects after three hops or when the destination leaves Discrawl's existing Discord CDN allowlist.
- Revalidate the final response URL even when callers inject an HTTP client with a different redirect policy.
- Add regression coverage for an allowed initial Discord CDN URL whose final response points at a link-local metadata endpoint.

Extracted from the generic attachment hardening in #131. Thanks @GrantTheAssistant; contributor credit is preserved in the commit and changelog.

## Proof

- `go test ./... -count=1`
- `go test -count=1 -race ./internal/media`
- `golangci-lint run ./...`
- `go vet ./...`
- `staticcheck ./...`
- `gosec -exclude=G101,G115,G202,G301,G304 ./...`
- `govulncheck ./...`
- `go mod verify`
- `go mod tidy -diff`

The integration regression drives the production `fetchURL` boundary through a real `http.Client`/`RoundTripper`: an allowlisted Discord request returns a final link-local response URL, and Discrawl rejects it before reading or writing the response body.
