### PR TITLE
fix(share): validate imported tombstones

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - Show setup guidance instead of a raw missing-file error when configuration-dependent commands cannot find `config.toml`. Thanks @0xdevalias.
 - Report module build metadata for source-installed binaries instead of a stale hard-coded release version.
+- Reject malformed message tombstone timestamps before either SQLite snapshot import path mutates the archive. Thanks @GrantTheAssistant.
 
 ## 0.11.5 - 2026-07-09
 

--- a/internal/share/share.go
+++ b/internal/share/share.go
@@ -500,7 +500,13 @@ func Import(ctx context.Context, s *store.Store, opts Options) (Manifest, error)
 			})
 		},
 		Filter: func(table string, row map[string]any) (bool, error) {
-			return !isDirectMessageSnapshotRow(table, row), nil
+			if isDirectMessageSnapshotRow(table, row) {
+				return false, nil
+			}
+			if err := validateSnapshotRow(table, row); err != nil {
+				return false, err
+			}
+			return true, nil
 		},
 		BeforeImport: func(ctx context.Context, tx *sql.Tx) error {
 			var err error
@@ -1659,6 +1665,9 @@ func importTableFile(ctx context.Context, stmt *sql.Stmt, repoPath string, table
 		if isDirectMessageSnapshotRow(table.Name, row) {
 			continue
 		}
+		if err := validateSnapshotRow(table.Name, row); err != nil {
+			return count, fmt.Errorf("validate %s: %w", rel, err)
+		}
 		values := make([]any, len(columns))
 		for i, column := range columns {
 			values[i] = importValue(row[column])
@@ -1669,6 +1678,31 @@ func importTableFile(ctx context.Context, stmt *sql.Stmt, repoPath string, table
 		count++
 	}
 	return count, nil
+}
+
+func validateSnapshotRow(table string, row map[string]any) error {
+	if table != "messages" {
+		return nil
+	}
+	raw, ok := row["deleted_at"]
+	if !ok || raw == nil {
+		return nil
+	}
+	value, ok := raw.(string)
+	if !ok {
+		return errors.New("messages.deleted_at must be a string or null")
+	}
+	value = strings.TrimSpace(value)
+	if value == "" {
+		row["deleted_at"] = nil
+		return nil
+	}
+	parsed, err := time.Parse(time.RFC3339Nano, value)
+	if err != nil {
+		return fmt.Errorf("messages.deleted_at must be RFC3339: %w", err)
+	}
+	row["deleted_at"] = parsed.UTC().Format(time.RFC3339Nano)
+	return nil
 }
 
 func repairImportedGuildIDs(ctx context.Context, tx *sql.Tx) error {

--- a/internal/share/share_test.go
+++ b/internal/share/share_test.go
@@ -2275,6 +2275,45 @@ func TestLegacyManifestFileImportAndEmbeddingDecodeErrors(t *testing.T) {
 	require.NoError(t, tx.Rollback())
 }
 
+func TestValidateSnapshotRowRejectsMalformedDeletedAtBeforeImport(t *testing.T) {
+	require.NoError(t, validateSnapshotRow("messages", map[string]any{"deleted_at": nil}))
+	blank := map[string]any{"deleted_at": "  "}
+	require.NoError(t, validateSnapshotRow("messages", blank))
+	require.Nil(t, blank["deleted_at"])
+	require.NoError(t, validateSnapshotRow("messages", map[string]any{"deleted_at": "2026-07-14T12:00:00.123456789Z"}))
+	padded := map[string]any{"deleted_at": " 2026-07-14T12:00:00Z "}
+	require.NoError(t, validateSnapshotRow("messages", padded))
+	require.Equal(t, "2026-07-14T12:00:00Z", padded["deleted_at"])
+	require.ErrorContains(t, validateSnapshotRow("messages", map[string]any{"deleted_at": "not-a-timestamp"}), "must be RFC3339")
+	require.ErrorContains(t, validateSnapshotRow("messages", map[string]any{"deleted_at": json.Number("123")}), "must be a string or null")
+	require.NoError(t, validateSnapshotRow("guilds", map[string]any{"deleted_at": "not-a-timestamp"}))
+
+	ctx := context.Background()
+	s, err := store.Open(ctx, filepath.Join(t.TempDir(), "discrawl.db"))
+	require.NoError(t, err)
+	defer func() { _ = s.Close() }()
+	repo := t.TempDir()
+	rel := filepath.ToSlash(filepath.Join("tables", "messages", "tombstones.jsonl.gz"))
+	require.NoError(t, os.MkdirAll(filepath.Dir(filepath.Join(repo, filepath.FromSlash(rel))), 0o755))
+	writeGzipJSONLines(t, filepath.Join(repo, filepath.FromSlash(rel)), []string{
+		`{"id":"m1","guild_id":"g1","channel_id":"c1","author_id":null,"message_type":0,"created_at":"2026-07-14T12:00:00Z","edited_at":null,"deleted_at":null,"content":"one","normalized_content":"one","reply_to_message_id":null,"pinned":0,"has_attachments":0,"raw_json":"{}","updated_at":"2026-07-14T12:00:00Z"}`,
+		`{"id":"m2","guild_id":"g1","channel_id":"c1","author_id":null,"message_type":0,"created_at":"2026-07-14T12:00:00Z","edited_at":null,"deleted_at":"not-a-timestamp","content":"two","normalized_content":"two","reply_to_message_id":null,"pinned":0,"has_attachments":0,"raw_json":"{}","updated_at":"2026-07-14T12:00:00Z"}`,
+	})
+	tx, err := s.DB().BeginTx(ctx, nil)
+	require.NoError(t, err)
+	err = importTable(ctx, tx, Options{RepoPath: repo}, TableManifest{
+		Name: "messages", File: rel,
+		Columns: []string{"id", "guild_id", "channel_id", "author_id", "message_type", "created_at", "edited_at", "deleted_at", "content", "normalized_content", "reply_to_message_id", "pinned", "has_attachments", "raw_json", "updated_at"},
+	})
+	require.ErrorContains(t, err, "messages.deleted_at must be RFC3339")
+	var count int
+	require.NoError(t, tx.QueryRowContext(ctx, `select count(*) from messages`).Scan(&count))
+	require.Equal(t, 1, count)
+	require.NoError(t, tx.Rollback())
+	require.NoError(t, s.DB().QueryRowContext(ctx, `select count(*) from messages`).Scan(&count))
+	require.Zero(t, count)
+}
+
 func TestImportEmbeddingsRejectsUnsafeManifestFiles(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- Validate `messages.deleted_at` before either supported SQLite snapshot import path mutates the archive.
- Accept null, empty, and RFC3339Nano tombstones; reject non-string or malformed timestamps with an actionable field error.
- Leave unrelated tables untouched by this message-specific validation.

Extracted from the generic SQLite/tombstone hardening in #131. Thanks @GrantTheAssistant; contributor credit is preserved in the commit and changelog.

## Proof

- `go test ./... -count=1`
- `go test -race ./internal/share -count=1`
- `golangci-lint run ./...`
- `go vet ./...`
- `staticcheck ./...`
- `gosec -exclude=G101,G115,G202,G301,G304 ./...`
- `govulncheck ./...`
- `go mod verify`
- `go mod tidy -diff`

The regression exercises valid nanosecond tombstones, null/empty compatibility, malformed timestamp rejection, non-string rejection, and table scoping. Full share integration tests exercise both import engines with the validator installed at their pre-insert boundary.
