### PR TITLE
build(deps): bump actions/setup-node to v7

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -33,7 +33,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Set up Node
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24
 


### PR DESCRIPTION
## Summary

- update the Pages workflow's immutable `actions/setup-node` pin from v6.4.0 to v7.0.0
- align the inline annotation with the pinned v7.0.0 release

Maintainer replacement for #141.

## Focused proof

- `actionlint .github/workflows/pages.yml`
- exact `actions/setup-node` SHA `820762786026740c76f36085b0efc47a31fe5020` executed in an isolated tool cache with `node-version: 24`; it downloaded, cached, and exposed Node 24.18.0 arm64
- Node 24.18.0: `node scripts/build-docs-site.mjs` built 47 Pages files
- built `index.html` and `commands/search.html` served locally with HTTP 200
- `CNAME` remained `discrawl.sh`; `.nojekyll` present
- AutoReview clean: no accepted/actionable findings

The `github-pages` environment permits deployment only from `main` and `gh-pages`, so no pre-merge branch publication was attempted. Exact-head hosted checks remain the merge gate.
