### PR TITLE
fix(release): ignore unrelated scheduled checks

### DIFF
--- a/.github/workflows/release-unified.yml
+++ b/.github/workflows/release-unified.yml
@@ -30,6 +30,7 @@ jobs:
       stable-identifier: org.openclaw.discrawl
       require-signed-tag: true
       darwin-universal: disabled
+      ci-check-events: '["push","pull_request"]'
     secrets:
       MACOS_SIGNING_P12: ${{ secrets.MACOS_SIGNING_P12 }}
       MACOS_SIGNING_P12_PASSWORD: ${{ secrets.MACOS_SIGNING_P12_PASSWORD }}


### PR DESCRIPTION
## Summary

- scope Discrawl's shared release CI evidence to `push` and `pull_request` Actions runs
- keep unresolved/non-Actions checks and commit statuses in the release gate

## Live proof

The first `v0.11.10` attempt failed closed before signing because a 15-minute scheduled archive publisher was still in progress on the same frozen SHA. `openclaw/release-workflows@v1` now provides this opt-in filter; its empty default is unchanged.

## Proof

- `actionlint .github/workflows/*.yml`
- autoreview clean, no accepted/actionable findings
