### PR TITLE
chore: open next Unreleased section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## Unreleased
+
 ## 0.11.10 - 2026-07-27
 
 ### Maintenance


### PR DESCRIPTION
Opens the next Unreleased changelog section after the verified v0.11.10 release.

The shared release workflow created and pushed this commit; repository policy blocked only its automatic PR creation. Release publication, both native verifier jobs, checksum binding, and the Homebrew handoff already succeeded.
