### PR TITLE
feat: queue embeddings for live Discord events

### DIFF
--- a/README.md
+++ b/README.md
@@ -818,6 +818,8 @@ enabled = false
 provider = "openai"
 model = "text-embedding-3-small"
 api_key_env = "OPENAI_API_KEY"
+# Optional OpenAI projection. Leave unset for the provider default.
+dimensions = 512
 batch_size = 64
 
 [share]
@@ -882,6 +884,8 @@ Embedding creation has two phases:
 During drain, `discrawl` claims jobs with a short lock so overlapping runs do not process the same batch. Rate limits requeue the batch and stop that drain run cleanly. Provider or validation failures retry up to three attempts before the job is marked failed. Messages with no normalized text are marked done and any stale vector for that message is removed.
 
 The provider/model/input-version identity is stored on each job and vector. If you change provider or model, pending jobs are retargeted to the new identity and prior attempts are reset. Existing vectors for another identity remain in SQLite, but semantic search only reads vectors compatible with the current config.
+
+OpenAI `text-embedding-3-small` supports `dimensions` to project vectors to a smaller size. Leave it unset for the provider default, or set a positive value such as `512` to reduce local vector storage. Changing it requires `--rebuild` so the stored vectors match future query vectors.
 
 Use `--rebuild` when changing provider, model, or input settings and you want to regenerate vectors for the existing archive:
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -82,6 +82,7 @@ enabled = false
 provider = "openai"
 model = "text-embedding-3-small"
 api_key_env = "OPENAI_API_KEY"
+dimensions = 512 # optional OpenAI projection; omit for provider default
 batch_size = 64
 max_input_chars = 12000
 request_timeout = "2m"
@@ -139,6 +140,7 @@ Set `discord.token_source = "keyring"` if you want to require keyring lookup and
 - `sync.exclude_channel_kinds` accepts Discrawl kinds such as `text`, `announcement`, `forum`, `thread_public`, `thread_private`, and `thread_announcement`
 - a non-zero `sync.repair_offset` aligns periodic repairs to local wall-clock boundaries; for example, `repair_every = "6h"` with `repair_offset = "2h"` targets 02:00, 08:00, 14:00, and 20:00 local time
 - changing `[search.embeddings]` provider/model/input version retargets pending jobs and resets prior attempts; existing vectors for another identity remain in SQLite but are not used for semantic search
+- `[search.embeddings].dimensions` is an optional positive OpenAI projection size. Changing it requires `embed --rebuild` so stored message vectors and query vectors use the same dimensions.
 - `[search.embeddings].vector_backend` accepts `exact` or optional `turbovec`; turbovec requires Python plus the `turbovec` package and embedding dimensions divisible by 8.
 - changing `db_path` does not migrate existing data; copy the file yourself if you want to keep history
 - `sync.attachment_media = true` makes `sync` behave like `sync --with-media`; media bytes are cached under `cache_dir/media`, and CDN `404`/other fetch failures are recorded on attachment rows

--- a/docs/guides/embeddings.md
+++ b/docs/guides/embeddings.md
@@ -38,6 +38,8 @@ Use `--rebuild` when you want to regenerate vectors for the existing archive aft
 discrawl embed --rebuild --limit 1000
 ```
 
+For OpenAI `text-embedding-3-small`, `dimensions` can project vectors to a smaller size. Leave it unset for the provider default, or use a positive value such as `512` to reduce local vector storage. Run `embed --rebuild` after changing it.
+
 ## Local provider example
 
 ```toml

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -278,6 +278,7 @@ func crawlkitEmbeddingConfig(cfg config.EmbeddingsConfig) embed.Config {
 		Model:          cfg.Model,
 		BaseURL:        cfg.BaseURL,
 		APIKeyEnv:      cfg.APIKeyEnv,
+		Dimensions:     cfg.Dimensions,
 		RequestTimeout: cfg.RequestTimeout,
 		MaxInputChars:  cfg.MaxInputChars,
 	}
@@ -298,6 +299,10 @@ type syncService interface {
 
 type tailReadyConfigurer interface {
 	SetTailReadyCallback(func(context.Context) error)
+}
+
+type tailEmbeddingsConfigurer interface {
+	SetTailEmbeddings(bool)
 }
 
 type tailMessageFailureReplayer interface {
@@ -777,6 +782,9 @@ func (r *runtime) ensureDiscordServices() error {
 	r.syncer = syncerFactory(r.client, r.store, r.logger)
 	if configurable, ok := r.syncer.(attachmentTextConfigurer); ok {
 		configurable.SetAttachmentTextEnabled(r.cfg.AttachmentTextEnabled())
+	}
+	if configurable, ok := r.syncer.(tailEmbeddingsConfigurer); ok {
+		configurable.SetTailEmbeddings(r.cfg.Search.Embeddings.Enabled)
 	}
 	if configurable, ok := r.syncer.(channelExclusionConfigurer); ok {
 		configurable.SetChannelExclusions(r.cfg.Sync.ExcludeChannelIDs, r.cfg.Sync.ExcludeChannelKinds)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -91,6 +91,7 @@ type EmbeddingsConfig struct {
 	Model          string `toml:"model"`
 	BaseURL        string `toml:"base_url"`
 	APIKeyEnv      string `toml:"api_key_env"`
+	Dimensions     int    `toml:"dimensions"`
 	BatchSize      int    `toml:"batch_size"`
 	MaxInputChars  int    `toml:"max_input_chars"`
 	RequestTimeout string `toml:"request_timeout"`
@@ -320,6 +321,9 @@ func (c *Config) Normalize() error {
 	}
 	if c.Search.Embeddings.BatchSize <= 0 {
 		c.Search.Embeddings.BatchSize = 64
+	}
+	if c.Search.Embeddings.Dimensions < 0 {
+		return errors.New("search.embeddings.dimensions must not be negative")
 	}
 	if c.Share.RepoPath == "" {
 		c.Share.RepoPath = Default().Share.RepoPath

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -43,6 +43,7 @@ func TestNormalizeFillsDefaults(t *testing.T) {
 	require.Equal(t, "text-embedding-3-small", cfg.Search.Embeddings.Model)
 	require.Empty(t, cfg.Search.Embeddings.BaseURL)
 	require.Equal(t, "OPENAI_API_KEY", cfg.Search.Embeddings.APIKeyEnv)
+	require.Zero(t, cfg.Search.Embeddings.Dimensions)
 	require.Equal(t, 64, cfg.Search.Embeddings.BatchSize)
 	require.Equal(t, 12000, cfg.Search.Embeddings.MaxInputChars)
 	require.Equal(t, "2m", cfg.Search.Embeddings.RequestTimeout)
@@ -453,6 +454,14 @@ func TestNormalizeRejectsInvalidEmbeddingTimeout(t *testing.T) {
 	cfg = Default()
 	cfg.Search.Embeddings.RequestTimeout = "soon"
 	require.ErrorContains(t, cfg.Normalize(), "parse search.embeddings.request_timeout")
+}
+
+func TestNormalizeRejectsNegativeEmbeddingDimensions(t *testing.T) {
+	t.Parallel()
+
+	cfg := Default()
+	cfg.Search.Embeddings.Dimensions = -1
+	require.ErrorContains(t, cfg.Normalize(), "search.embeddings.dimensions must not be negative")
 }
 
 func TestAttachmentTextExplicitFalseSurvivesNormalize(t *testing.T) {

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -502,6 +502,7 @@ func (s *Store) applyBaselineSchema(ctx context.Context) error {
 		`create index if not exists idx_mentions_target on mention_events(target_type, target_id, event_at);`,
 		`create index if not exists idx_mentions_author on mention_events(author_id, event_at);`,
 		`create index if not exists idx_embedding_jobs_state_updated on embedding_jobs(state, updated_at);`,
+		`create index if not exists idx_embedding_jobs_pending_order on embedding_jobs(state, updated_at, message_id);`,
 		`create index if not exists idx_message_embeddings_identity on message_embeddings(provider, model, input_version, dimensions);`,
 		`create index if not exists idx_failure_ledger_unresolved on failure_ledger(resolved_at, last_seen_at desc);`,
 		`create index if not exists idx_failure_ledger_scope on failure_ledger(guild_id, channel_id, message_id);`,
@@ -661,6 +662,7 @@ func (s *Store) applyQueryIndexMigration(ctx context.Context) error {
 		`create index if not exists idx_mentions_guild_event on mention_events(guild_id, event_at, event_id);`,
 		`create index if not exists idx_mentions_channel_event on mention_events(channel_id, event_at, event_id);`,
 		`create index if not exists idx_embedding_jobs_state_updated on embedding_jobs(state, updated_at);`,
+		`create index if not exists idx_embedding_jobs_pending_order on embedding_jobs(state, updated_at, message_id);`,
 		`create index if not exists idx_message_embeddings_identity on message_embeddings(provider, model, input_version, dimensions);`,
 	}
 	for _, stmt := range stmts {

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -22,6 +22,23 @@ func TestDefaultEmbedLimit(t *testing.T) {
 	require.Equal(t, 1000, DefaultEmbedLimit())
 }
 
+func TestEmbeddingPendingOrderIndex(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	s, err := Open(ctx, filepath.Join(t.TempDir(), "discrawl.db"))
+	require.NoError(t, err)
+	defer func() { _ = s.Close() }()
+
+	var definition string
+	require.NoError(t, s.DB().QueryRowContext(ctx, `
+		select sql
+		from sqlite_master
+		where type = 'index' and name = 'idx_embedding_jobs_pending_order'
+	`).Scan(&definition))
+	require.Contains(t, definition, "embedding_jobs(state, updated_at, message_id)")
+}
+
 func TestQueryHelpersAndEmbeddingPresence(t *testing.T) {
 	t.Parallel()
 

--- a/internal/syncer/channel_exclusions_test.go
+++ b/internal/syncer/channel_exclusions_test.go
@@ -262,9 +262,10 @@ func TestTailRepairOffsetScheduling(t *testing.T) {
 func TestTailRepairUsesIncrementalScope(t *testing.T) {
 	t.Parallel()
 
-	opts := tailRepairSyncOptions([]string{"g1"})
+	opts := tailRepairSyncOptions([]string{"g1"}, true)
 	require.Equal(t, []string{"g1"}, opts.GuildIDs)
 	require.False(t, opts.Full)
+	require.True(t, opts.Embeddings)
 	require.True(t, opts.SkipMembers)
 	require.True(t, opts.LatestOnly)
 	require.Equal(t, "tail_repair", opts.RepairReason)

--- a/internal/syncer/syncer.go
+++ b/internal/syncer/syncer.go
@@ -49,6 +49,7 @@ type Syncer struct {
 	tailRepairMu          sync.Mutex
 	tailRepairOffsetMu    sync.RWMutex
 	tailRepairOffset      time.Duration
+	tailEmbeddings        bool
 	channelExclusions     channelExclusions
 }
 
@@ -95,6 +96,13 @@ func (s *Syncer) SetRepairOffset(offset time.Duration) {
 	s.tailRepairOffsetMu.Lock()
 	s.tailRepairOffset = offset
 	s.tailRepairOffsetMu.Unlock()
+}
+
+func (s *Syncer) SetTailEmbeddings(enabled bool) {
+	if s == nil {
+		return
+	}
+	s.tailEmbeddings = enabled
 }
 
 func (s *Syncer) repairOffset() time.Duration {

--- a/internal/syncer/syncer_tail_test.go
+++ b/internal/syncer/syncer_tail_test.go
@@ -152,6 +152,36 @@ func TestTailHandlerWritesEvents(t *testing.T) {
 	require.Equal(t, "10", cursor)
 }
 
+func TestTailHandlerQueuesEmbeddingsWhenEnabled(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	s, err := store.Open(ctx, filepath.Join(t.TempDir(), "discrawl.db"))
+	require.NoError(t, err)
+	defer func() { _ = s.Close() }()
+
+	handler := &tailHandler{
+		guilds:            makeGuildSet([]string{"g1"}),
+		store:             s,
+		enqueueEmbeddings: true,
+	}
+	require.NoError(t, handler.OnMessageCreate(ctx, &discordgo.Message{
+		ID:        "100000000000000001",
+		GuildID:   "g1",
+		ChannelID: "c1",
+		Content:   "queue this live message",
+		Timestamp: time.Now().UTC(),
+		Author:    &discordgo.User{ID: "u1", Username: "user"},
+	}))
+
+	var jobs int
+	require.NoError(t, s.DB().QueryRowContext(
+		ctx,
+		`select count(*) from embedding_jobs where message_id = '100000000000000001'`,
+	).Scan(&jobs))
+	require.Equal(t, 1, jobs)
+}
+
 func TestTailHandlerMessageUpdateFetchesFullMessageBeforeUpsert(t *testing.T) {
 	t.Parallel()
 

--- a/internal/syncer/tail.go
+++ b/internal/syncer/tail.go
@@ -22,6 +22,7 @@ func (s *Syncer) RunTail(ctx context.Context, guildIDs []string, repairEvery tim
 		store:                  s.store,
 		client:                 s.client,
 		attachmentTextEnabled:  s.attachmentTextEnabled,
+		enqueueEmbeddings:      s.tailEmbeddings,
 		onReady:                s.tailReady,
 		logger:                 s.logger,
 		exclusions:             s.channelExclusions,
@@ -131,15 +132,16 @@ func (s *Syncer) startTailRepair(ctx context.Context, guildIDs []string) *tailRe
 	startedAt := time.Now()
 	go func() {
 		defer s.tailRepairMu.Unlock()
-		_, err := s.runTailRepair(repairCtx, tailRepairSyncOptions(guildIDs))
+		_, err := s.runTailRepair(repairCtx, tailRepairSyncOptions(guildIDs, s.tailEmbeddings))
 		done <- tailRepairResult{err: err, elapsed: time.Since(startedAt)}
 	}()
 	return &tailRepairRun{cancel: cancel, done: done}
 }
 
-func tailRepairSyncOptions(guildIDs []string) SyncOptions {
+func tailRepairSyncOptions(guildIDs []string, embeddings bool) SyncOptions {
 	return SyncOptions{
 		GuildIDs:     append([]string(nil), guildIDs...),
+		Embeddings:   embeddings,
 		SkipMembers:  true,
 		LatestOnly:   true,
 		RepairReason: "tail_repair",
@@ -207,6 +209,7 @@ type tailHandler struct {
 	store                  *store.Store
 	client                 Client
 	attachmentTextEnabled  bool
+	enqueueEmbeddings      bool
 	failureLedgerTimeout   time.Duration
 	onReady                func(context.Context) error
 	logger                 *slog.Logger
@@ -252,7 +255,7 @@ func (t *tailHandler) OnMessageCreate(ctx context.Context, msg *discordgo.Messag
 		return nil
 	}
 	discordclient.UpdateTailFailureStage(ctx, discordclient.TailFailureStageMessageBuild)
-	mutation, err := buildMessageMutation(ctx, msg, "", "", false, t.attachmentTextEnabled)
+	mutation, err := buildMessageMutation(ctx, msg, "", "", t.enqueueEmbeddings, t.attachmentTextEnabled)
 	if err != nil {
 		return err
 	}
@@ -292,7 +295,7 @@ func (t *tailHandler) OnMessageUpdate(ctx context.Context, msg *discordgo.Messag
 		return nil
 	}
 	discordclient.UpdateTailFailureStage(ctx, discordclient.TailFailureStageMessageBuild)
-	mutation, err := buildMessageMutation(ctx, msg, "", "", false, t.attachmentTextEnabled)
+	mutation, err := buildMessageMutation(ctx, msg, "", "", t.enqueueEmbeddings, t.attachmentTextEnabled)
 	if err != nil {
 		return err
 	}

--- a/internal/syncer/tail_replay.go
+++ b/internal/syncer/tail_replay.go
@@ -136,7 +136,7 @@ func (s *Syncer) replayTailMessageFailures(ctx context.Context, guildIDs []strin
 		if message.GuildID == "" {
 			message.GuildID = failure.GuildID
 		}
-		mutation, err := buildMessageMutation(ctx, message, "", failure.GuildID, false, s.attachmentTextEnabled)
+		mutation, err := buildMessageMutation(ctx, message, "", failure.GuildID, s.tailEmbeddings, s.attachmentTextEnabled)
 		if err != nil {
 			if ctxErr := ctx.Err(); ctxErr != nil {
 				return stats, ctxErr


### PR DESCRIPTION
## Summary
- propagate configured embedding dimensions to Crawlkit
- queue embeddings for live tail messages, replayed failures, and tail repair
- add an ordered pending-job index so large embedding backlogs drain without a full sort

## Validation
- `go test ./...`
- `go vet ./...`