### PR TITLE
ci(release): let unified workflow own tags

### DIFF
--- a/.github/release-allowed-signers
+++ b/.github/release-allowed-signers
@@ -1,1 +1,0 @@
-steipete@gmail.com ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAII9XsaCcr8TInPnHcuTVfvXXcsoUFrOE7menfbEIHFW9 steipete@gmail.com

--- a/.github/workflows/release-unified.yml
+++ b/.github/workflows/release-unified.yml
@@ -28,7 +28,6 @@ jobs:
       checksum-filename: checksums.txt
       nfpm: auto
       stable-identifier: org.openclaw.discrawl
-      require-signed-tag: true
       darwin-universal: disabled
       ci-check-events: '["push","pull_request"]'
     secrets:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 0.12.0 - 2026-08-02
 
 ### Changes
 
@@ -10,6 +10,7 @@
 
 - Update Crawlkit to v0.14.4, Alpine to 3.24, and refresh the SQLite, libc, terminal width, and terminal detection dependency stack.
 - Update CodeQL Action to v4.37.4 and actions/stale to v11 while preserving the existing security-scan and stale-item policies.
+- Let the unified release workflow own version tags and organization-managed signing, notarization, publication, and Homebrew delivery.
 
 ## 0.11.10 - 2026-07-27
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -4,7 +4,7 @@ summary: "Official Discrawl releases through the shared GitHub Actions pipeline"
 
 # Releasing `discrawl`
 
-`.github/workflows/release-unified.yml` is the only official release path. It calls `openclaw/release-workflows@v1` from protected `main`, requires the existing SSH-signed version tag, builds the exact GoReleaser matrix, signs and notarizes both thin macOS binaries as `org.openclaw.discrawl`, verifies the complete asset inventory independently on arm64 and Intel macOS, publishes `checksums.txt`, and waits for the `openclaw/homebrew-tap` handoff to succeed.
+`.github/workflows/release-unified.yml` is the only official release path. It calls `openclaw/release-workflows@v1` from protected `main`, creates and freezes the annotated version tag, builds the exact GoReleaser matrix, signs and notarizes both thin macOS binaries as `org.openclaw.discrawl`, verifies the complete asset inventory independently on arm64 and Intel macOS, publishes `checksums.txt`, and waits for the `openclaw/homebrew-tap` handoff to succeed.
 
 The public compatibility contract remains:
 
@@ -18,16 +18,15 @@ The shared pipeline also publishes verifier control assets (`ASSET-INVENTORY.jso
 
 ## Release
 
-Prepare a dated changelog section and land it on protected `main`. The signing key configured by `user.signingkey` must be the SSH key listed for your principal in `.github/release-allowed-signers`. Create and push an annotated SSH-signed tag whose commit is reachable from `main`, verify it explicitly against the repository allowlist, then dispatch the workflow:
+Prepare a dated changelog section and land it on protected `main`, then dispatch the workflow from that exact head:
 
 ```sh
-git -c gpg.format=ssh tag -s vX.Y.Z -m "Release X.Y.Z"
-git -c gpg.format=ssh -c gpg.ssh.allowedSignersFile=.github/release-allowed-signers tag -v vX.Y.Z
-git push origin vX.Y.Z
 gh workflow run release-unified.yml --repo openclaw/discrawl -f version=X.Y.Z
 ```
 
-Watch the exact run through publication and Homebrew handoff. The release is complete only when the GitHub Release contains the full asset set, both native macOS verification jobs pass, and the tap's `update-formula.yml` run is green.
+The shared workflow owns tag creation, signing, notarization, GitHub Release publication, and Homebrew handoff. Release operators never use local signing, notarization, App Store Connect, or tap credentials. On retries, an existing annotated version tag freezes the original release commit and is never moved.
+
+Watch the exact run through publication and Homebrew handoff. The release is complete only when the GitHub Release contains the full asset set, both native macOS verification jobs pass, and the tap's `update-formula.yml` run is green. The workflow then opens the next `Unreleased` changelog PR.
 
 ## Local diagnostics
 


### PR DESCRIPTION
## Summary

- let `openclaw/release-workflows/.github/workflows/release-go-cli.yml@v1` create and freeze the annotated release tag
- remove the obsolete local SSH signer allowlist and signed-tag instructions
- retain Discrawl's established archive contents, `checksums.txt`, native Darwin archives, signing identifier, and `openclaw/homebrew-tap` formula handoff
- finalize the accumulated additive work as the dated `0.12.0` changelog section

`release-go-cli.yml` is the only reusable release archetype exposed by `@v1`, and it matches this repository's Go module plus GoReleaser matrix. `nfpm: auto` remains binary-only because the current GoReleaser config has no `nfpms` block.

## Validation

- `actionlint .github/workflows/release-unified.yml`
- `GOWORK=off go test ./scripts ./...`
- `make check`
  - module verification and tidiness
  - gofumpt, golangci-lint, vet, staticcheck, gosec, and govulncheck
  - 85.1% coverage and the race suite
  - CLI smoke checks
  - six-platform GoReleaser snapshot
- AutoReview: clean, no accepted/actionable findings

The actual operator behavior will be live-proven by dispatching the merged workflow for `0.12.0`; no local release credential or local tag operation is part of that path.
