### PR TITLE
feat(catalog): surface incomplete channel metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Changes
+
+- Surface stored message-to-channel catalog integrity in diagnostics, annotate output whose channel metadata is missing, and warn when zero-row SQL results may hide orphaned messages. Thanks @htydev.
+
 ## 0.12.0 - 2026-08-02
 
 ### Changes

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,8 @@ test:
 	GOWORK=off go test -count=1 ./...
 
 test-large:
-	@output_file="$$(mktemp)"; trap 'rm -f "$$output_file"' EXIT; \
+	@command -v jq >/dev/null || { echo 'test-large requires jq'; exit 1; }; \
+	output_file="$$(mktemp)"; trap 'rm -f "$$output_file"' EXIT; \
 	DISCRAWL_TEST_LARGE=1 GOWORK=off go test -json -count=1 -run '^TestCatalogIntegrityProbeLargeCompleteFixture$$' -timeout=30m ./internal/store >"$$output_file"; \
 	cat "$$output_file"; \
 	jq -e 'select(.Action == "pass" and .Test == "TestCatalogIntegrityProbeLargeCompleteFixture")' "$$output_file" >/dev/null

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,10 @@ test:
 	GOWORK=off go test -count=1 ./...
 
 test-large:
-	DISCRAWL_TEST_LARGE=1 GOWORK=off go test -count=1 -run '^TestCatalogIntegrityProbeLargeCompleteFixture$$' -timeout=30m ./internal/store
+	@output_file="$$(mktemp)"; trap 'rm -f "$$output_file"' EXIT; \
+	DISCRAWL_TEST_LARGE=1 GOWORK=off go test -json -count=1 -run '^TestCatalogIntegrityProbeLargeCompleteFixture$$' -timeout=30m ./internal/store >"$$output_file"; \
+	cat "$$output_file"; \
+	jq -e 'select(.Action == "pass" and .Test == "TestCatalogIntegrityProbeLargeCompleteFixture")' "$$output_file" >/dev/null
 
 test-race:
 	GOWORK=off go test -count=1 -race ./...

--- a/Makefile
+++ b/Makefile
@@ -34,8 +34,10 @@ test:
 test-large:
 	@command -v jq >/dev/null || { echo 'test-large requires jq'; exit 1; }; \
 	output_file="$$(mktemp)"; trap 'rm -f "$$output_file"' EXIT; \
-	DISCRAWL_TEST_LARGE=1 GOWORK=off go test -json -count=1 -run '^TestCatalogIntegrityProbeLargeCompleteFixture$$' -timeout=30m ./internal/store >"$$output_file"; \
+	test_status=0; \
+	DISCRAWL_TEST_LARGE=1 GOWORK=off go test -json -count=1 -run '^TestCatalogIntegrityProbeLargeCompleteFixture$$' -timeout=30m ./internal/store >"$$output_file" || test_status=$$?; \
 	cat "$$output_file"; \
+	[ "$$test_status" -eq 0 ] || exit "$$test_status"; \
 	jq -e 'select(.Action == "pass" and .Test == "TestCatalogIntegrityProbeLargeCompleteFixture")' "$$output_file" >/dev/null
 
 test-race:

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ ARTIFACT_DIR ?= dist
 
 .DEFAULT_GOAL := help
 
-.PHONY: help build test test-race test-coverage fmt lint tidy-check smoke check snapshot release verify-release release-artifacts release-snapshot generate-sqlc clean
+.PHONY: help build test test-large test-race test-coverage fmt lint tidy-check smoke check snapshot release verify-release release-artifacts release-snapshot generate-sqlc clean
 
 help:
 	@printf '%s\n' \
@@ -12,6 +12,7 @@ help:
 		'  help              Print available targets (default).' \
 		'  build             Build the CLI into $(BINARY).' \
 		'  test              Run the full Go test suite.' \
+		'  test-large        Run the opt-in catalog-integrity calibration fixture.' \
 		'  fmt               Check Go formatting.' \
 		'  lint              Run the static-analysis and vulnerability gates.' \
 		'  check             Run every local gate enforced by CI.' \
@@ -29,6 +30,9 @@ build:
 
 test:
 	GOWORK=off go test -count=1 ./...
+
+test-large:
+	DISCRAWL_TEST_LARGE=1 GOWORK=off go test -count=1 -run '^TestCatalogIntegrityProbeLargeCompleteFixture$$' -timeout=30m ./internal/store
 
 test-race:
 	GOWORK=off go test -count=1 -race ./...

--- a/docs/commands/diagnostics.md
+++ b/docs/commands/diagnostics.md
@@ -19,6 +19,7 @@ discrawl diagnostics --json
 - sync-lock path and whether its operating-system file lock is held
 - active writer PID, operation, phase, and timestamps from Discrawl lock metadata
 - whether the archive passed integrity checks and is safe for read-only inspection
+- orphaned message-to-channel references and whether identity-filtered queries are safe to treat as authoritative
 
 An active writer can be `sync`, `tail`, `wiretap`, an import, or another
 Discrawl operation. The operation and phase come from the same lock metadata
@@ -35,6 +36,12 @@ The command does not create a missing database or lock file.
 SQLite integrity is checked independently of Discrawl's schema version, so a
 healthy older or newer archive can still report `integrity: "ok"`; freshness
 fields carry a separate compatibility error when this binary cannot read them.
+
+`safe_for_read_only_inspection` reports SQLite-byte integrity only. It does not
+prove every message has a channel record. `safe_for_identity_queries` is false
+when the catalog has orphaned message/channel references or catalog completeness
+cannot be determined; inspect the `catalog` counts before relying on a zero-row
+identity query.
 
 ## See also
 

--- a/docs/commands/diagnostics.md
+++ b/docs/commands/diagnostics.md
@@ -39,9 +39,9 @@ fields carry a separate compatibility error when this binary cannot read them.
 
 `safe_for_read_only_inspection` reports SQLite-byte integrity only. It does not
 prove every message has a channel record. `safe_for_identity_queries` is false
-when the catalog has orphaned message/channel references or catalog completeness
-cannot be determined; inspect the `catalog` counts before relying on a zero-row
-identity query.
+when the catalog has orphaned message/channel references, catalog completeness
+cannot be determined, or the archive freshness metadata cannot be read; inspect
+the `catalog` counts before relying on a zero-row identity query.
 
 ## See also
 

--- a/docs/commands/diagnostics.md
+++ b/docs/commands/diagnostics.md
@@ -19,7 +19,7 @@ discrawl diagnostics --json
 - sync-lock path and whether its operating-system file lock is held
 - active writer PID, operation, phase, and timestamps from Discrawl lock metadata
 - whether the archive passed integrity checks and is safe for read-only inspection
-- orphaned message-to-channel references and whether identity-filtered queries are safe to treat as authoritative
+- orphaned message-to-channel references in the stored archive
 
 An active writer can be `sync`, `tail`, `wiretap`, an import, or another
 Discrawl operation. The operation and phase come from the same lock metadata
@@ -38,11 +38,10 @@ healthy older or newer archive can still report `integrity: "ok"`; freshness
 fields carry a separate compatibility error when this binary cannot read them.
 
 `safe_for_read_only_inspection` reports SQLite-byte integrity only. It does not
-prove every message has a channel record. `safe_for_identity_queries` is false
-when the catalog has orphaned message/channel references, catalog completeness
-cannot be determined, or the archive freshness metadata cannot be read; require
-`catalog.state: "complete"` and inspect the counts before relying on a zero-row
-identity query.
+prove every message has a channel record. `catalog.state: "consistent"` means
+every stored message has a stored channel record; it does not prove that a sync
+captured every source channel or message. A zero-row query therefore describes
+the local snapshot, not authoritative absence from Discord.
 
 ## See also
 

--- a/docs/commands/diagnostics.md
+++ b/docs/commands/diagnostics.md
@@ -40,8 +40,9 @@ fields carry a separate compatibility error when this binary cannot read them.
 `safe_for_read_only_inspection` reports SQLite-byte integrity only. It does not
 prove every message has a channel record. `safe_for_identity_queries` is false
 when the catalog has orphaned message/channel references, catalog completeness
-cannot be determined, or the archive freshness metadata cannot be read; inspect
-the `catalog` counts before relying on a zero-row identity query.
+cannot be determined, or the archive freshness metadata cannot be read; require
+`catalog.state: "complete"` and inspect the counts before relying on a zero-row
+identity query.
 
 ## See also
 

--- a/docs/commands/sql.md
+++ b/docs/commands/sql.md
@@ -36,7 +36,9 @@ where m.guild_id = 'GUILD_ID'
 `join channels` intentionally drops messages whose channel metadata is
 incomplete. `discrawl sql` warns on zero-row output when it can confirm such
 orphaned references; an `undetermined` note means the catalog probe exceeded
-its bounded budget, not that completeness was established.
+its bounded two-second budget, not that completeness was established. The
+warning covers empty results only: a non-empty inner join can still omit
+orphaned messages, so use the left join or check diagnostics first.
 
 ## See also
 

--- a/docs/commands/sql.md
+++ b/docs/commands/sql.md
@@ -35,8 +35,9 @@ where m.guild_id = 'GUILD_ID'
 
 `join channels` intentionally drops messages whose channel metadata is
 incomplete. `discrawl sql` warns on zero-row output when it can confirm such
-orphaned references; an `undetermined` note means the catalog probe exceeded
-its bounded two-second budget, not that completeness was established. The
+orphaned references; an `undetermined` note means the catalog probe did not
+complete within its bounded two-second budget or encountered a probe error, not
+that completeness was established. The
 warning covers empty results only: a non-empty inner join can still omit
 orphaned messages, so use the left join or check diagnostics first.
 

--- a/docs/commands/sql.md
+++ b/docs/commands/sql.md
@@ -18,6 +18,25 @@ echo 'select guild_id, count(*) from messages group by guild_id' | discrawl sql 
 - the schema is multi-guild ready; threads are stored as channels because that matches the Discord model
 - proven DMs use the synthetic guild id `@me`
 - SQLite schema migrations are versioned with `PRAGMA user_version`; startup fails fast when a local DB schema is newer than the supported binary
+- before treating a zero-row identity query as authoritative, run `discrawl diagnostics --json` and require `safe_for_identity_queries: true`
+
+Message queries that need channel metadata must start from `messages` and use a
+left join so incomplete channel metadata does not silently discard archived
+messages:
+
+```sql
+select m.id, m.created_at, m.channel_id, c.name as channel_name, m.content
+from messages m
+left join channels c on c.id = m.channel_id
+where m.guild_id = 'GUILD_ID'
+  and m.author_id = 'AUTHOR_ID'
+  and m.content = 'EXACT PHRASE';
+```
+
+`join channels` intentionally drops messages whose channel metadata is
+incomplete. `discrawl sql` warns on zero-row output when it can confirm such
+orphaned references; an `undetermined` note means the catalog probe exceeded
+its bounded budget, not that completeness was established.
 
 ## See also
 

--- a/docs/commands/sql.md
+++ b/docs/commands/sql.md
@@ -18,7 +18,7 @@ echo 'select guild_id, count(*) from messages group by guild_id' | discrawl sql 
 - the schema is multi-guild ready; threads are stored as channels because that matches the Discord model
 - proven DMs use the synthetic guild id `@me`
 - SQLite schema migrations are versioned with `PRAGMA user_version`; startup fails fast when a local DB schema is newer than the supported binary
-- before treating a zero-row identity query as authoritative, run `discrawl diagnostics --json` and require `safe_for_identity_queries: true`
+- a zero-row query describes the local snapshot; it cannot prove authoritative absence from Discord
 
 Message queries that need channel metadata must start from `messages` and use a
 left join so incomplete channel metadata does not silently discard archived
@@ -37,9 +37,11 @@ where m.guild_id = 'GUILD_ID'
 incomplete. `discrawl sql` warns on zero-row output when it can confirm such
 orphaned references; an `undetermined` note means the catalog probe did not
 complete within its bounded two-second budget or encountered a probe error, not
-that completeness was established. The
-warning covers empty results only: a non-empty inner join can still omit
-orphaned messages, so use the left join or check diagnostics first.
+that referential integrity was established. The warning covers empty results
+only: a non-empty inner join can still omit orphaned messages, so use the left
+join or check diagnostics first. Even a `catalog.state` of `consistent` only
+proves that stored messages resolve to stored channels; it does not prove source
+archive coverage.
 
 ## See also
 

--- a/internal/cli/catalog_integrity_test.go
+++ b/internal/cli/catalog_integrity_test.go
@@ -1,0 +1,91 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/openclaw/discrawl/internal/store"
+)
+
+func TestDiagnosticsReportsCatalogIncompletenessWithoutChangingSQLiteSafety(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	cfg, cfgPath := writeTestConfig(t, dir)
+	s, err := store.Open(ctx, cfg.DBPath)
+	require.NoError(t, err)
+	require.NoError(t, s.UpsertMessage(ctx, store.MessageRecord{
+		ID:                "orphan-message",
+		GuildID:           "guild-1",
+		ChannelID:         "missing-thread",
+		MessageType:       0,
+		CreatedAt:         time.Date(2026, 8, 2, 12, 0, 0, 0, time.UTC).Format(time.RFC3339Nano),
+		Content:           "catalog witness",
+		NormalizedContent: "catalog witness",
+		RawJSON:           `{}`,
+	}))
+	require.NoError(t, s.Close())
+
+	var out bytes.Buffer
+	require.NoError(t, Run(ctx, []string{"--config", cfgPath, "diagnostics", "--json"}, &out, &bytes.Buffer{}))
+	var report diagnosticsReport
+	require.NoError(t, json.Unmarshal(out.Bytes(), &report))
+	require.Equal(t, "warning", report.Status)
+	require.True(t, report.SafeForReadOnlyInspection)
+	require.False(t, report.SafeForIdentityQueries)
+	require.Equal(t, 1, report.Catalog.OrphanedMessageCount)
+	require.Equal(t, 1, report.Catalog.OrphanedChannelCount)
+	require.NotEmpty(t, report.Catalog.OldestAffectedAt)
+	require.NotEmpty(t, report.Catalog.NewestAffectedAt)
+}
+
+func TestZeroRowSQLWarnsWhenCatalogIsIncomplete(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	cfg, cfgPath := writeTestConfig(t, dir)
+	s, err := store.Open(ctx, cfg.DBPath)
+	require.NoError(t, err)
+	require.NoError(t, s.UpsertMessage(ctx, store.MessageRecord{
+		ID:                "orphan-message",
+		GuildID:           "guild-1",
+		ChannelID:         "missing-thread",
+		MessageType:       0,
+		CreatedAt:         time.Now().UTC().Format(time.RFC3339Nano),
+		Content:           "catalog witness",
+		NormalizedContent: "catalog witness",
+		RawJSON:           `{}`,
+	}))
+	require.NoError(t, s.Close())
+
+	var stdout, stderr bytes.Buffer
+	require.NoError(t, Run(ctx, []string{"--config", cfgPath, "sql", "select id from messages where id = 'absent'"}, &stdout, &stderr))
+	require.Contains(t, stdout.String(), "id")
+	require.Contains(t, stderr.String(), "identity joins may be incomplete")
+}
+
+func TestZeroRowSQLReportsUndeterminedCatalogWithoutChangingSuccessOutput(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	dir := t.TempDir()
+	cfg, _ := writeTestConfig(t, dir)
+	s, err := store.Open(context.Background(), cfg.DBPath)
+	require.NoError(t, err)
+	defer func() { _ = s.Close() }()
+	var stderr bytes.Buffer
+	r := &runtime{ctx: ctx, store: s, stderr: &stderr}
+	cancel()
+
+	r.warnOnZeroRowSQL(nil)
+	require.Contains(t, stderr.String(), "catalog completeness not determined")
+}
+
+func TestHumanOutputShowsChannelIDWhenMetadataIsMissing(t *testing.T) {
+	var out bytes.Buffer
+	require.NoError(t, printHuman(&out, []store.SearchResult{{
+		GuildID: "guild-1", ChannelID: "missing-thread", AuthorName: "author", Content: "catalog witness",
+	}}))
+	require.Contains(t, out.String(), "channel:missing-thread (metadata missing)")
+}

--- a/internal/cli/catalog_integrity_test.go
+++ b/internal/cli/catalog_integrity_test.go
@@ -67,6 +67,39 @@ func TestZeroRowSQLWarnsWhenCatalogIsIncomplete(t *testing.T) {
 	require.Contains(t, stderr.String(), "identity joins may be incomplete")
 }
 
+func TestZeroRowSQLDoesNotWarnForCompleteCatalogAndPreservesJSON(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	cfg, cfgPath := writeTestConfig(t, dir)
+	s, err := store.Open(ctx, cfg.DBPath)
+	require.NoError(t, err)
+	require.NoError(t, s.UpsertChannel(ctx, store.ChannelRecord{
+		ID: "known-thread", GuildID: "guild-1", Kind: "thread_public", Name: "known-thread", RawJSON: `{}`,
+	}))
+	require.NoError(t, s.UpsertMessage(ctx, store.MessageRecord{
+		ID:                "known-message",
+		GuildID:           "guild-1",
+		ChannelID:         "known-thread",
+		MessageType:       0,
+		CreatedAt:         time.Now().UTC().Format(time.RFC3339Nano),
+		Content:           "catalog witness",
+		NormalizedContent: "catalog witness",
+		RawJSON:           `{}`,
+	}))
+	require.NoError(t, s.Close())
+
+	var stdout, stderr bytes.Buffer
+	require.NoError(t, Run(ctx, []string{"--config", cfgPath, "--json", "sql", "select id from messages where id = 'absent'"}, &stdout, &stderr))
+	require.Empty(t, stderr.String())
+	var result struct {
+		Columns []string   `json:"columns"`
+		Rows    [][]string `json:"rows"`
+	}
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &result))
+	require.Equal(t, []string{"id"}, result.Columns)
+	require.Empty(t, result.Rows)
+}
+
 func TestZeroRowSQLReportsUndeterminedCatalogWithoutChangingSuccessOutput(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	dir := t.TempDir()

--- a/internal/cli/catalog_integrity_test.go
+++ b/internal/cli/catalog_integrity_test.go
@@ -36,7 +36,6 @@ func TestDiagnosticsReportsCatalogIncompletenessWithoutChangingSQLiteSafety(t *t
 	require.NoError(t, json.Unmarshal(out.Bytes(), &report))
 	require.Equal(t, "warning", report.Status)
 	require.True(t, report.SafeForReadOnlyInspection)
-	require.False(t, report.SafeForIdentityQueries)
 	require.Equal(t, store.CatalogIncomplete, report.Catalog.State)
 	require.Equal(t, 1, report.Catalog.OrphanedMessageCount)
 	require.Equal(t, 1, report.Catalog.OrphanedChannelCount)
@@ -44,7 +43,7 @@ func TestDiagnosticsReportsCatalogIncompletenessWithoutChangingSQLiteSafety(t *t
 	require.NotEmpty(t, report.Catalog.NewestAffectedAt)
 }
 
-func TestDiagnosticsReportsIdentityQueriesSafeForCompleteCatalog(t *testing.T) {
+func TestDiagnosticsReportsConsistentStoredCatalog(t *testing.T) {
 	ctx := context.Background()
 	dir := t.TempDir()
 	cfg, cfgPath := writeTestConfig(t, dir)
@@ -64,8 +63,7 @@ func TestDiagnosticsReportsIdentityQueriesSafeForCompleteCatalog(t *testing.T) {
 	var report diagnosticsReport
 	require.NoError(t, json.Unmarshal(out.Bytes(), &report))
 	require.Equal(t, "ok", report.Status)
-	require.True(t, report.SafeForIdentityQueries)
-	require.Equal(t, store.CatalogComplete, report.Catalog.State)
+	require.Equal(t, store.CatalogConsistent, report.Catalog.State)
 	require.Empty(t, report.Warnings)
 	require.Empty(t, report.Freshness.Error)
 }
@@ -139,7 +137,7 @@ func TestWarnOnZeroRowSQLReportsUndeterminedCatalog(t *testing.T) {
 	cancel()
 
 	r.warnOnZeroRowSQL(nil)
-	require.Contains(t, stderr.String(), "catalog completeness not determined")
+	require.Contains(t, stderr.String(), "catalog integrity not determined")
 }
 
 func TestHumanOutputShowsChannelIDWhenMetadataIsMissing(t *testing.T) {
@@ -153,4 +151,25 @@ func TestHumanOutputShowsChannelIDWhenMetadataIsMissing(t *testing.T) {
 		GuildID: "guild-1", ChannelID: "missing-thread", AuthorName: "author", Content: "catalog witness",
 	}}))
 	require.Contains(t, out.String(), "channel:missing-thread (metadata missing)")
+
+	out.Reset()
+	require.NoError(t, printHuman(&out, []store.SearchResult{{
+		GuildID: "guild-1", ChannelID: "missing-thread", ChannelName: "stale-name", AuthorName: "author", Content: "catalog witness",
+	}}))
+	require.Contains(t, out.String(), "channel:missing-thread (metadata missing)")
+	require.NotContains(t, out.String(), "stale-name")
+
+	out.Reset()
+	require.NoError(t, printHuman(&out, []store.SearchResult{{
+		GuildID: "guild-1", ChannelID: "dm-channel", ChannelMetadataPresent: true, AuthorName: "author", Content: "catalog witness",
+	}}))
+	require.Contains(t, out.String(), "channel:dm-channel")
+	require.NotContains(t, out.String(), "metadata missing")
+
+	out.Reset()
+	require.NoError(t, printHuman(&out, []store.MessageRow{{
+		GuildID: "guild-1", ChannelID: "dm-channel", ChannelMetadataPresent: true, AuthorName: "author", Content: "catalog witness",
+	}}))
+	require.Contains(t, out.String(), "channel:dm-channel")
+	require.NotContains(t, out.String(), "metadata missing")
 }

--- a/internal/cli/catalog_integrity_test.go
+++ b/internal/cli/catalog_integrity_test.go
@@ -37,10 +37,37 @@ func TestDiagnosticsReportsCatalogIncompletenessWithoutChangingSQLiteSafety(t *t
 	require.Equal(t, "warning", report.Status)
 	require.True(t, report.SafeForReadOnlyInspection)
 	require.False(t, report.SafeForIdentityQueries)
+	require.Equal(t, store.CatalogIncomplete, report.Catalog.State)
 	require.Equal(t, 1, report.Catalog.OrphanedMessageCount)
 	require.Equal(t, 1, report.Catalog.OrphanedChannelCount)
 	require.NotEmpty(t, report.Catalog.OldestAffectedAt)
 	require.NotEmpty(t, report.Catalog.NewestAffectedAt)
+}
+
+func TestDiagnosticsReportsIdentityQueriesSafeForCompleteCatalog(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	cfg, cfgPath := writeTestConfig(t, dir)
+	s, err := store.Open(ctx, cfg.DBPath)
+	require.NoError(t, err)
+	require.NoError(t, s.UpsertChannel(ctx, store.ChannelRecord{
+		ID: "known-thread", GuildID: "guild-1", Kind: "thread_public", Name: "known-thread", RawJSON: `{}`,
+	}))
+	require.NoError(t, s.UpsertMessage(ctx, store.MessageRecord{
+		ID: "known-message", GuildID: "guild-1", ChannelID: "known-thread", MessageType: 0,
+		CreatedAt: time.Now().UTC().Format(time.RFC3339Nano), RawJSON: `{}`,
+	}))
+	require.NoError(t, s.Close())
+
+	var out bytes.Buffer
+	require.NoError(t, Run(ctx, []string{"--config", cfgPath, "diagnostics", "--json"}, &out, &bytes.Buffer{}))
+	var report diagnosticsReport
+	require.NoError(t, json.Unmarshal(out.Bytes(), &report))
+	require.Equal(t, "ok", report.Status)
+	require.True(t, report.SafeForIdentityQueries)
+	require.Equal(t, store.CatalogComplete, report.Catalog.State)
+	require.Empty(t, report.Warnings)
+	require.Empty(t, report.Freshness.Error)
 }
 
 func TestZeroRowSQLWarnsWhenCatalogIsIncomplete(t *testing.T) {
@@ -100,7 +127,7 @@ func TestZeroRowSQLDoesNotWarnForCompleteCatalogAndPreservesJSON(t *testing.T) {
 	require.Empty(t, result.Rows)
 }
 
-func TestZeroRowSQLReportsUndeterminedCatalogWithoutChangingSuccessOutput(t *testing.T) {
+func TestWarnOnZeroRowSQLReportsUndeterminedCatalog(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	dir := t.TempDir()
 	cfg, _ := writeTestConfig(t, dir)
@@ -118,6 +145,11 @@ func TestZeroRowSQLReportsUndeterminedCatalogWithoutChangingSuccessOutput(t *tes
 func TestHumanOutputShowsChannelIDWhenMetadataIsMissing(t *testing.T) {
 	var out bytes.Buffer
 	require.NoError(t, printHuman(&out, []store.SearchResult{{
+		GuildID: "guild-1", ChannelID: "missing-thread", AuthorName: "author", Content: "catalog witness",
+	}}))
+	require.Contains(t, out.String(), "channel:missing-thread (metadata missing)")
+	out.Reset()
+	require.NoError(t, printHuman(&out, []store.MessageRow{{
 		GuildID: "guild-1", ChannelID: "missing-thread", AuthorName: "author", Content: "catalog witness",
 	}}))
 	require.Contains(t, out.String(), "channel:missing-thread (metadata missing)")

--- a/internal/cli/diagnostics.go
+++ b/internal/cli/diagnostics.go
@@ -68,10 +68,11 @@ type diagnosticsFreshness struct {
 }
 
 type diagnosticsCatalog struct {
-	OrphanedMessageCount int    `json:"orphaned_message_count"`
-	OrphanedChannelCount int    `json:"orphaned_channel_count"`
-	OldestAffectedAt     string `json:"oldest_affected_at,omitempty"`
-	NewestAffectedAt     string `json:"newest_affected_at,omitempty"`
+	State                store.CatalogCompleteness `json:"state"`
+	OrphanedMessageCount int                       `json:"orphaned_message_count"`
+	OrphanedChannelCount int                       `json:"orphaned_channel_count"`
+	OldestAffectedAt     string                    `json:"oldest_affected_at,omitempty"`
+	NewestAffectedAt     string                    `json:"newest_affected_at,omitempty"`
 }
 
 func (r *runtime) runDiagnostics(args []string) error {
@@ -100,6 +101,7 @@ func (r *runtime) runDiagnostics(args []string) error {
 			Integrity: "not_checked",
 			WAL:       statDiagnosticsFile(dbPath + "-wal"),
 		},
+		Catalog: diagnosticsCatalog{State: store.CatalogUndetermined},
 		SyncLock: diagnosticsSyncLock{
 			Path:         lockPath,
 			MetadataPath: syncLockMetadataPath(lockPath),
@@ -184,7 +186,12 @@ func (r *runtime) runDiagnostics(args []string) error {
 			report.Warnings = append(report.Warnings, fmt.Sprintf("catalog integrity could not be read: %v", catalogErr))
 		} else {
 			catalogKnown = true
+			state := store.CatalogComplete
+			if catalog.OrphanedMessageCount > 0 {
+				state = store.CatalogIncomplete
+			}
 			report.Catalog = diagnosticsCatalog{
+				State:                state,
 				OrphanedMessageCount: catalog.OrphanedMessageCount,
 				OrphanedChannelCount: catalog.OrphanedChannelCount,
 			}

--- a/internal/cli/diagnostics.go
+++ b/internal/cli/diagnostics.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"errors"
 	"flag"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -18,7 +19,9 @@ type diagnosticsReport struct {
 	Database                  diagnosticsDatabase  `json:"database"`
 	SyncLock                  diagnosticsSyncLock  `json:"sync_lock"`
 	Freshness                 diagnosticsFreshness `json:"freshness"`
+	Catalog                   diagnosticsCatalog   `json:"catalog"`
 	SafeForReadOnlyInspection bool                 `json:"safe_for_read_only_inspection"`
+	SafeForIdentityQueries    bool                 `json:"safe_for_identity_queries"`
 	Warnings                  []string             `json:"warnings,omitempty"`
 }
 
@@ -62,6 +65,13 @@ type diagnosticsFreshness struct {
 	LastSyncAt      string `json:"last_sync_at,omitempty"`
 	LastTailEventAt string `json:"last_tail_event_at,omitempty"`
 	Error           string `json:"error,omitempty"`
+}
+
+type diagnosticsCatalog struct {
+	OrphanedMessageCount int    `json:"orphaned_message_count"`
+	OrphanedChannelCount int    `json:"orphaned_channel_count"`
+	OldestAffectedAt     string `json:"oldest_affected_at,omitempty"`
+	NewestAffectedAt     string `json:"newest_affected_at,omitempty"`
 }
 
 func (r *runtime) runDiagnostics(args []string) error {
@@ -152,6 +162,7 @@ func (r *runtime) runDiagnostics(args []string) error {
 		report.Database.Integrity = "failed"
 		report.Warnings = append(report.Warnings, "SQLite quick_check reported integrity errors")
 	}
+	catalogKnown := false
 	db, openErr := store.OpenReadOnly(r.ctx, dbPath)
 	if openErr != nil {
 		report.Freshness.Error = openErr.Error()
@@ -169,8 +180,27 @@ func (r *runtime) runDiagnostics(args []string) error {
 				report.Freshness.LastTailEventAt = status.LastTailEventAt.UTC().Format(time.RFC3339)
 			}
 		}
+		if catalog, catalogErr := db.CatalogIntegrity(r.ctx); catalogErr != nil {
+			report.Warnings = append(report.Warnings, "catalog integrity could not be read")
+		} else {
+			catalogKnown = true
+			report.Catalog = diagnosticsCatalog{
+				OrphanedMessageCount: catalog.OrphanedMessageCount,
+				OrphanedChannelCount: catalog.OrphanedChannelCount,
+			}
+			if !catalog.OldestAffectedAt.IsZero() {
+				report.Catalog.OldestAffectedAt = catalog.OldestAffectedAt.UTC().Format(time.RFC3339)
+			}
+			if !catalog.NewestAffectedAt.IsZero() {
+				report.Catalog.NewestAffectedAt = catalog.NewestAffectedAt.UTC().Format(time.RFC3339)
+			}
+			if catalog.OrphanedMessageCount > 0 {
+				report.Warnings = append(report.Warnings, fmt.Sprintf("catalog has %d orphaned messages across %d channel IDs", catalog.OrphanedMessageCount, catalog.OrphanedChannelCount))
+			}
+		}
 	}
 	report.SafeForReadOnlyInspection = report.Database.Integrity == "ok"
+	report.SafeForIdentityQueries = report.SafeForReadOnlyInspection && catalogKnown && report.Catalog.OrphanedMessageCount == 0 && report.Catalog.OrphanedChannelCount == 0 && report.Freshness.Error == ""
 	if report.SafeForReadOnlyInspection && len(report.Warnings) == 0 {
 		report.Status = "ok"
 	}

--- a/internal/cli/diagnostics.go
+++ b/internal/cli/diagnostics.go
@@ -181,7 +181,7 @@ func (r *runtime) runDiagnostics(args []string) error {
 			}
 		}
 		if catalog, catalogErr := db.CatalogIntegrity(r.ctx); catalogErr != nil {
-			report.Warnings = append(report.Warnings, "catalog integrity could not be read")
+			report.Warnings = append(report.Warnings, fmt.Sprintf("catalog integrity could not be read: %v", catalogErr))
 		} else {
 			catalogKnown = true
 			report.Catalog = diagnosticsCatalog{

--- a/internal/cli/diagnostics.go
+++ b/internal/cli/diagnostics.go
@@ -21,7 +21,6 @@ type diagnosticsReport struct {
 	Freshness                 diagnosticsFreshness `json:"freshness"`
 	Catalog                   diagnosticsCatalog   `json:"catalog"`
 	SafeForReadOnlyInspection bool                 `json:"safe_for_read_only_inspection"`
-	SafeForIdentityQueries    bool                 `json:"safe_for_identity_queries"`
 	Warnings                  []string             `json:"warnings,omitempty"`
 }
 
@@ -68,11 +67,11 @@ type diagnosticsFreshness struct {
 }
 
 type diagnosticsCatalog struct {
-	State                store.CatalogCompleteness `json:"state"`
-	OrphanedMessageCount int                       `json:"orphaned_message_count"`
-	OrphanedChannelCount int                       `json:"orphaned_channel_count"`
-	OldestAffectedAt     string                    `json:"oldest_affected_at,omitempty"`
-	NewestAffectedAt     string                    `json:"newest_affected_at,omitempty"`
+	State                store.CatalogIntegrityState `json:"state"`
+	OrphanedMessageCount int                         `json:"orphaned_message_count"`
+	OrphanedChannelCount int                         `json:"orphaned_channel_count"`
+	OldestAffectedAt     string                      `json:"oldest_affected_at,omitempty"`
+	NewestAffectedAt     string                      `json:"newest_affected_at,omitempty"`
 }
 
 func (r *runtime) runDiagnostics(args []string) error {
@@ -164,7 +163,6 @@ func (r *runtime) runDiagnostics(args []string) error {
 		report.Database.Integrity = "failed"
 		report.Warnings = append(report.Warnings, "SQLite quick_check reported integrity errors")
 	}
-	catalogKnown := false
 	db, openErr := store.OpenReadOnly(r.ctx, dbPath)
 	if openErr != nil {
 		report.Freshness.Error = openErr.Error()
@@ -185,8 +183,7 @@ func (r *runtime) runDiagnostics(args []string) error {
 		if catalog, catalogErr := db.CatalogIntegrity(r.ctx); catalogErr != nil {
 			report.Warnings = append(report.Warnings, fmt.Sprintf("catalog integrity could not be read: %v", catalogErr))
 		} else {
-			catalogKnown = true
-			state := store.CatalogComplete
+			state := store.CatalogConsistent
 			if catalog.OrphanedMessageCount > 0 {
 				state = store.CatalogIncomplete
 			}
@@ -207,7 +204,6 @@ func (r *runtime) runDiagnostics(args []string) error {
 		}
 	}
 	report.SafeForReadOnlyInspection = report.Database.Integrity == "ok"
-	report.SafeForIdentityQueries = report.SafeForReadOnlyInspection && catalogKnown && report.Catalog.OrphanedMessageCount == 0 && report.Catalog.OrphanedChannelCount == 0 && report.Freshness.Error == ""
 	if report.SafeForReadOnlyInspection && len(report.Warnings) == 0 {
 		report.Status = "ok"
 	}

--- a/internal/cli/output.go
+++ b/internal/cli/output.go
@@ -369,6 +369,13 @@ Writes a read-only cloud archive config. This does not create or import a local 
 `,
 }
 
+func channelDisplayName(channelID, channelName string) string {
+	if strings.TrimSpace(channelName) != "" {
+		return channelName
+	}
+	return fmt.Sprintf("channel:%s (metadata missing)", channelID)
+}
+
 func printRows(w io.Writer, cols []string, rows [][]string) error {
 	tw := tabwriter.NewWriter(w, 2, 4, 2, ' ', 0)
 	_, _ = fmt.Fprintln(tw, strings.Join(cols, "\t"))
@@ -457,11 +464,12 @@ func printHuman(w io.Writer, value any) error {
 			formatTime(v.LastSyncAt), formatTime(v.LastTailEventAt))
 		return err
 	case diagnosticsReport:
-		_, err := fmt.Fprintf(w, "status=%s\ndb=%s\ndb_exists=%t\ndb_bytes=%d\njournal_mode=%s\nschema_version=%d\nwal=%s\nwal_exists=%t\nwal_bytes=%d\nintegrity=%s\nsync_lock=%s\nsync_lock_held=%t\nsync_lock_state=%s\nsafe_for_read_only_inspection=%t\n",
+		_, err := fmt.Fprintf(w, "status=%s\ndb=%s\ndb_exists=%t\ndb_bytes=%d\njournal_mode=%s\nschema_version=%d\nwal=%s\nwal_exists=%t\nwal_bytes=%d\nintegrity=%s\nsync_lock=%s\nsync_lock_held=%t\nsync_lock_state=%s\ncatalog_orphaned_messages=%d\ncatalog_orphaned_channel_ids=%d\nsafe_for_read_only_inspection=%t\nsafe_for_identity_queries=%t\n",
 			v.Status, v.Database.Path, v.Database.Exists, v.Database.Bytes, v.Database.JournalMode,
 			v.Database.SchemaVersion,
 			v.Database.WAL.Path, v.Database.WAL.Exists, v.Database.WAL.Bytes, v.Database.Integrity,
-			v.SyncLock.Path, v.SyncLock.Held, v.SyncLock.State, v.SafeForReadOnlyInspection)
+			v.SyncLock.Path, v.SyncLock.Held, v.SyncLock.State, v.Catalog.OrphanedMessageCount, v.Catalog.OrphanedChannelCount,
+			v.SafeForReadOnlyInspection, v.SafeForIdentityQueries)
 		if err != nil {
 			return err
 		}
@@ -534,14 +542,14 @@ func printHuman(w io.Writer, value any) error {
 		return err
 	case []store.SearchResult:
 		for _, row := range v {
-			if _, err := fmt.Fprintf(w, "[%s/%s] %s %s\n%s\n\n", row.GuildID, row.ChannelName, row.AuthorName, formatTime(row.CreatedAt), row.Content); err != nil {
+			if _, err := fmt.Fprintf(w, "[%s/%s] %s %s\n%s\n\n", row.GuildID, channelDisplayName(row.ChannelID, row.ChannelName), row.AuthorName, formatTime(row.CreatedAt), row.Content); err != nil {
 				return err
 			}
 		}
 		return nil
 	case []store.MessageRow:
 		for _, row := range v {
-			if _, err := fmt.Fprintf(w, "[%s/%s] %s %s\n%s\n\n", row.GuildID, row.ChannelName, row.AuthorName, formatTime(row.CreatedAt), row.Content); err != nil {
+			if _, err := fmt.Fprintf(w, "[%s/%s] %s %s\n%s\n\n", row.GuildID, channelDisplayName(row.ChannelID, row.ChannelName), row.AuthorName, formatTime(row.CreatedAt), row.Content); err != nil {
 				return err
 			}
 		}

--- a/internal/cli/output.go
+++ b/internal/cli/output.go
@@ -369,11 +369,14 @@ Writes a read-only cloud archive config. This does not create or import a local 
 `,
 }
 
-func channelDisplayName(channelID, channelName string) string {
+func channelDisplayName(channelID, channelName string, metadataPresent bool) string {
+	if !metadataPresent {
+		return fmt.Sprintf("channel:%s (metadata missing)", channelID)
+	}
 	if strings.TrimSpace(channelName) != "" {
 		return channelName
 	}
-	return fmt.Sprintf("channel:%s (metadata missing)", channelID)
+	return "channel:" + channelID
 }
 
 func printRows(w io.Writer, cols []string, rows [][]string) error {
@@ -464,12 +467,12 @@ func printHuman(w io.Writer, value any) error {
 			formatTime(v.LastSyncAt), formatTime(v.LastTailEventAt))
 		return err
 	case diagnosticsReport:
-		_, err := fmt.Fprintf(w, "status=%s\ndb=%s\ndb_exists=%t\ndb_bytes=%d\njournal_mode=%s\nschema_version=%d\nwal=%s\nwal_exists=%t\nwal_bytes=%d\nintegrity=%s\nsync_lock=%s\nsync_lock_held=%t\nsync_lock_state=%s\ncatalog_state=%s\ncatalog_orphaned_messages=%d\ncatalog_orphaned_channel_ids=%d\nsafe_for_read_only_inspection=%t\nsafe_for_identity_queries=%t\n",
+		_, err := fmt.Fprintf(w, "status=%s\ndb=%s\ndb_exists=%t\ndb_bytes=%d\njournal_mode=%s\nschema_version=%d\nwal=%s\nwal_exists=%t\nwal_bytes=%d\nintegrity=%s\nsync_lock=%s\nsync_lock_held=%t\nsync_lock_state=%s\ncatalog_state=%s\ncatalog_orphaned_messages=%d\ncatalog_orphaned_channel_ids=%d\nsafe_for_read_only_inspection=%t\n",
 			v.Status, v.Database.Path, v.Database.Exists, v.Database.Bytes, v.Database.JournalMode,
 			v.Database.SchemaVersion,
 			v.Database.WAL.Path, v.Database.WAL.Exists, v.Database.WAL.Bytes, v.Database.Integrity,
 			v.SyncLock.Path, v.SyncLock.Held, v.SyncLock.State, v.Catalog.State, v.Catalog.OrphanedMessageCount, v.Catalog.OrphanedChannelCount,
-			v.SafeForReadOnlyInspection, v.SafeForIdentityQueries)
+			v.SafeForReadOnlyInspection)
 		if err != nil {
 			return err
 		}
@@ -542,14 +545,14 @@ func printHuman(w io.Writer, value any) error {
 		return err
 	case []store.SearchResult:
 		for _, row := range v {
-			if _, err := fmt.Fprintf(w, "[%s/%s] %s %s\n%s\n\n", row.GuildID, channelDisplayName(row.ChannelID, row.ChannelName), row.AuthorName, formatTime(row.CreatedAt), row.Content); err != nil {
+			if _, err := fmt.Fprintf(w, "[%s/%s] %s %s\n%s\n\n", row.GuildID, channelDisplayName(row.ChannelID, row.ChannelName, row.ChannelMetadataPresent), row.AuthorName, formatTime(row.CreatedAt), row.Content); err != nil {
 				return err
 			}
 		}
 		return nil
 	case []store.MessageRow:
 		for _, row := range v {
-			if _, err := fmt.Fprintf(w, "[%s/%s] %s %s\n%s\n\n", row.GuildID, channelDisplayName(row.ChannelID, row.ChannelName), row.AuthorName, formatTime(row.CreatedAt), row.Content); err != nil {
+			if _, err := fmt.Fprintf(w, "[%s/%s] %s %s\n%s\n\n", row.GuildID, channelDisplayName(row.ChannelID, row.ChannelName, row.ChannelMetadataPresent), row.AuthorName, formatTime(row.CreatedAt), row.Content); err != nil {
 				return err
 			}
 		}

--- a/internal/cli/output.go
+++ b/internal/cli/output.go
@@ -464,11 +464,11 @@ func printHuman(w io.Writer, value any) error {
 			formatTime(v.LastSyncAt), formatTime(v.LastTailEventAt))
 		return err
 	case diagnosticsReport:
-		_, err := fmt.Fprintf(w, "status=%s\ndb=%s\ndb_exists=%t\ndb_bytes=%d\njournal_mode=%s\nschema_version=%d\nwal=%s\nwal_exists=%t\nwal_bytes=%d\nintegrity=%s\nsync_lock=%s\nsync_lock_held=%t\nsync_lock_state=%s\ncatalog_orphaned_messages=%d\ncatalog_orphaned_channel_ids=%d\nsafe_for_read_only_inspection=%t\nsafe_for_identity_queries=%t\n",
+		_, err := fmt.Fprintf(w, "status=%s\ndb=%s\ndb_exists=%t\ndb_bytes=%d\njournal_mode=%s\nschema_version=%d\nwal=%s\nwal_exists=%t\nwal_bytes=%d\nintegrity=%s\nsync_lock=%s\nsync_lock_held=%t\nsync_lock_state=%s\ncatalog_state=%s\ncatalog_orphaned_messages=%d\ncatalog_orphaned_channel_ids=%d\nsafe_for_read_only_inspection=%t\nsafe_for_identity_queries=%t\n",
 			v.Status, v.Database.Path, v.Database.Exists, v.Database.Bytes, v.Database.JournalMode,
 			v.Database.SchemaVersion,
 			v.Database.WAL.Path, v.Database.WAL.Exists, v.Database.WAL.Bytes, v.Database.Integrity,
-			v.SyncLock.Path, v.SyncLock.Held, v.SyncLock.State, v.Catalog.OrphanedMessageCount, v.Catalog.OrphanedChannelCount,
+			v.SyncLock.Path, v.SyncLock.Held, v.SyncLock.State, v.Catalog.State, v.Catalog.OrphanedMessageCount, v.Catalog.OrphanedChannelCount,
 			v.SafeForReadOnlyInspection, v.SafeForIdentityQueries)
 		if err != nil {
 			return err

--- a/internal/cli/query_commands.go
+++ b/internal/cli/query_commands.go
@@ -279,7 +279,7 @@ func (r *runtime) warnOnZeroRowSQL(rows [][]string) {
 	}
 	state, err := r.store.HasOrphanedMessageChannels(r.ctx)
 	if err != nil || state == store.CatalogUndetermined {
-		_, _ = fmt.Fprintln(r.stderr, "note: catalog completeness not determined; a zero-row SQL result is not authoritative for identity queries")
+		_, _ = fmt.Fprintln(r.stderr, "note: catalog integrity not determined; a zero-row SQL result is not authoritative for identity queries")
 		return
 	}
 	if state == store.CatalogIncomplete {

--- a/internal/cli/query_commands.go
+++ b/internal/cli/query_commands.go
@@ -244,6 +244,7 @@ func (r *runtime) runSQL(args []string) error {
 		if err != nil {
 			return err
 		}
+		r.warnOnZeroRowSQL(rows)
 		if r.json {
 			return r.print(map[string]any{"columns": cols, "rows": rows})
 		}
@@ -258,6 +259,7 @@ func (r *runtime) runSQL(args []string) error {
 		if err != nil {
 			return err
 		}
+		r.warnOnZeroRowSQL(rows)
 		if r.json {
 			return r.print(map[string]any{"columns": cols, "rows": rows})
 		}
@@ -269,6 +271,20 @@ func (r *runtime) runSQL(args []string) error {
 		return err
 	}
 	return r.print(map[string]any{"rows_affected": affected})
+}
+
+func (r *runtime) warnOnZeroRowSQL(rows [][]string) {
+	if len(rows) != 0 {
+		return
+	}
+	state, err := r.store.HasOrphanedMessageChannels(r.ctx)
+	if err != nil || state == store.CatalogUndetermined {
+		_, _ = fmt.Fprintln(r.stderr, "note: catalog completeness not determined; a zero-row SQL result is not authoritative for identity queries")
+		return
+	}
+	if state == store.CatalogIncomplete {
+		_, _ = fmt.Fprintln(r.stderr, "warning: catalog identity joins may be incomplete; a zero-row SQL result is not authoritative")
+	}
 }
 
 func (r *runtime) runMembers(args []string) error {

--- a/internal/cli/remote_read_commands.go
+++ b/internal/cli/remote_read_commands.go
@@ -42,14 +42,15 @@ func (r *runtime) runRemoteSearch(opts store.SearchOptions, mode string, dm bool
 	out := make([]store.SearchResult, 0, len(result.Values))
 	for _, value := range result.Values {
 		out = append(out, store.SearchResult{
-			MessageID:   remoteString(value, "message_id"),
-			GuildID:     remoteString(value, "guild_id"),
-			ChannelID:   remoteString(value, "channel_id"),
-			ChannelName: remoteString(value, "channel_name"),
-			AuthorID:    remoteString(value, "author_id"),
-			AuthorName:  remoteString(value, "author_username"),
-			Content:     remoteString(value, "content"),
-			CreatedAt:   remoteTime(value, "created_at"),
+			MessageID:              remoteString(value, "message_id"),
+			GuildID:                remoteString(value, "guild_id"),
+			ChannelID:              remoteString(value, "channel_id"),
+			ChannelName:            remoteString(value, "channel_name"),
+			ChannelMetadataPresent: true,
+			AuthorID:               remoteString(value, "author_id"),
+			AuthorName:             remoteString(value, "author_username"),
+			Content:                remoteString(value, "content"),
+			CreatedAt:              remoteTime(value, "created_at"),
 		})
 	}
 	return out, nil
@@ -91,15 +92,16 @@ func (r *runtime) runRemoteMessages(opts store.MessageListOptions, dm bool) ([]s
 	out := make([]store.MessageRow, 0, len(result.Values))
 	for _, value := range result.Values {
 		out = append(out, store.MessageRow{
-			MessageID:   remoteString(value, "message_id"),
-			GuildID:     remoteString(value, "guild_id"),
-			ChannelID:   remoteString(value, "channel_id"),
-			ChannelName: remoteString(value, "channel_name"),
-			AuthorID:    remoteString(value, "author_id"),
-			AuthorName:  remoteString(value, "author_username"),
-			Content:     remoteString(value, "content"),
-			CreatedAt:   remoteTime(value, "created_at"),
-			Source:      "remote",
+			MessageID:              remoteString(value, "message_id"),
+			GuildID:                remoteString(value, "guild_id"),
+			ChannelID:              remoteString(value, "channel_id"),
+			ChannelName:            remoteString(value, "channel_name"),
+			ChannelMetadataPresent: true,
+			AuthorID:               remoteString(value, "author_id"),
+			AuthorName:             remoteString(value, "author_username"),
+			Content:                remoteString(value, "content"),
+			CreatedAt:              remoteTime(value, "created_at"),
+			Source:                 "remote",
 		})
 	}
 	return out, nil

--- a/internal/store/catalog_integrity_test.go
+++ b/internal/store/catalog_integrity_test.go
@@ -72,6 +72,27 @@ func TestCatalogIntegrityReportsOrphanedMessageChannels(t *testing.T) {
 	require.Equal(t, [][]string{{"orphan-message"}}, rows)
 }
 
+func TestCatalogIntegrityOrdersVariablePrecisionTimestampsChronologically(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	s, err := Open(ctx, filepath.Join(t.TempDir(), "discrawl.db"))
+	require.NoError(t, err)
+	defer func() { _ = s.Close() }()
+
+	for _, message := range []MessageRecord{
+		{ID: "first", GuildID: "guild-1", ChannelID: "missing-first", MessageType: 0, CreatedAt: "2026-08-02T12:00:00Z", RawJSON: `{}`},
+		{ID: "second", GuildID: "guild-1", ChannelID: "missing-second", MessageType: 0, CreatedAt: "2026-08-02T12:00:00.5Z", RawJSON: `{}`},
+	} {
+		require.NoError(t, s.UpsertMessage(ctx, message))
+	}
+
+	integrity, err := s.CatalogIntegrity(ctx)
+	require.NoError(t, err)
+	require.Equal(t, time.Date(2026, 8, 2, 12, 0, 0, 0, time.UTC), integrity.OldestAffectedAt)
+	require.Equal(t, time.Date(2026, 8, 2, 12, 0, 0, 500_000_000, time.UTC), integrity.NewestAffectedAt)
+}
+
 func TestHasOrphanedMessageChannelsReturnsUndeterminedOnCancelledContext(t *testing.T) {
 	t.Parallel()
 
@@ -117,7 +138,8 @@ func TestCatalogIntegrityProbeLargeCompleteFixture(t *testing.T) {
 
 	probeStarted := time.Now()
 	state, err := s.HasOrphanedMessageChannels(ctx)
+	probeDuration := time.Since(probeStarted)
 	require.NoError(t, err)
-	require.Equal(t, CatalogComplete, state)
-	t.Logf("healthy-catalog probe duration: %s", time.Since(probeStarted))
+	require.Equalf(t, CatalogComplete, state, "healthy-catalog probe duration: %s", probeDuration)
+	t.Logf("healthy-catalog probe duration: %s", probeDuration)
 }

--- a/internal/store/catalog_integrity_test.go
+++ b/internal/store/catalog_integrity_test.go
@@ -45,6 +45,11 @@ func TestCatalogIntegrityReportsOrphanedMessageChannels(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, results, 1)
 	require.Empty(t, results[0].ChannelName)
+	require.False(t, results[0].ChannelMetadataPresent)
+	messages, err := s.ListMessages(ctx, MessageListOptions{IncludeEmpty: true})
+	require.NoError(t, err)
+	require.Len(t, messages, 1)
+	require.False(t, messages[0].ChannelMetadataPresent)
 
 	require.NoError(t, s.UpsertChannel(ctx, ChannelRecord{
 		ID: "missing-channel", GuildID: "guild-1", Kind: "thread_public", Name: "recovered-thread", RawJSON: `{}`,
@@ -54,11 +59,16 @@ func TestCatalogIntegrityReportsOrphanedMessageChannels(t *testing.T) {
 	require.Equal(t, CatalogIntegrity{}, integrity)
 	state, err = s.HasOrphanedMessageChannels(ctx)
 	require.NoError(t, err)
-	require.Equal(t, CatalogComplete, state)
+	require.Equal(t, CatalogConsistent, state)
 	results, err = s.SearchMessages(ctx, SearchOptions{Query: "catalog witness", Limit: 10})
 	require.NoError(t, err)
 	require.Len(t, results, 1)
 	require.Equal(t, "recovered-thread", results[0].ChannelName)
+	require.True(t, results[0].ChannelMetadataPresent)
+	messages, err = s.ListMessages(ctx, MessageListOptions{IncludeEmpty: true})
+	require.NoError(t, err)
+	require.Len(t, messages, 1)
+	require.True(t, messages[0].ChannelMetadataPresent)
 	_, rows, err := s.ReadOnlyQuery(ctx, `
 		select m.id
 		from messages m
@@ -140,6 +150,6 @@ func TestCatalogIntegrityProbeLargeCompleteFixture(t *testing.T) {
 	state, err := s.HasOrphanedMessageChannels(ctx)
 	probeDuration := time.Since(probeStarted)
 	require.NoError(t, err)
-	require.Equalf(t, CatalogComplete, state, "healthy-catalog probe duration: %s", probeDuration)
+	require.Equalf(t, CatalogConsistent, state, "healthy-catalog probe duration: %s", probeDuration)
 	t.Logf("healthy-catalog probe duration: %s", probeDuration)
 }

--- a/internal/store/catalog_integrity_test.go
+++ b/internal/store/catalog_integrity_test.go
@@ -1,0 +1,123 @@
+package store
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCatalogIntegrityReportsOrphanedMessageChannels(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	s, err := Open(ctx, filepath.Join(t.TempDir(), "discrawl.db"))
+	require.NoError(t, err)
+	defer func() { _ = s.Close() }()
+
+	created := time.Date(2026, 8, 2, 12, 0, 0, 0, time.UTC)
+	require.NoError(t, s.UpsertMessage(ctx, MessageRecord{
+		ID:                "orphan-message",
+		GuildID:           "guild-1",
+		ChannelID:         "missing-channel",
+		MessageType:       0,
+		CreatedAt:         created.Format(time.RFC3339Nano),
+		Content:           "catalog witness",
+		NormalizedContent: "catalog witness",
+		RawJSON:           `{}`,
+	}))
+
+	integrity, err := s.CatalogIntegrity(ctx)
+	require.NoError(t, err)
+	require.Equal(t, 1, integrity.OrphanedMessageCount)
+	require.Equal(t, 1, integrity.OrphanedChannelCount)
+	require.Equal(t, created, integrity.OldestAffectedAt)
+	require.Equal(t, created, integrity.NewestAffectedAt)
+
+	state, err := s.HasOrphanedMessageChannels(ctx)
+	require.NoError(t, err)
+	require.Equal(t, CatalogIncomplete, state)
+	results, err := s.SearchMessages(ctx, SearchOptions{Query: "catalog witness", Limit: 10})
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	require.Empty(t, results[0].ChannelName)
+
+	require.NoError(t, s.UpsertChannel(ctx, ChannelRecord{
+		ID: "missing-channel", GuildID: "guild-1", Kind: "thread_public", Name: "recovered-thread", RawJSON: `{}`,
+	}))
+	integrity, err = s.CatalogIntegrity(ctx)
+	require.NoError(t, err)
+	require.Equal(t, CatalogIntegrity{}, integrity)
+	state, err = s.HasOrphanedMessageChannels(ctx)
+	require.NoError(t, err)
+	require.Equal(t, CatalogComplete, state)
+	results, err = s.SearchMessages(ctx, SearchOptions{Query: "catalog witness", Limit: 10})
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	require.Equal(t, "recovered-thread", results[0].ChannelName)
+	_, rows, err := s.ReadOnlyQuery(ctx, `
+		select m.id
+		from messages m
+		left join channels c on c.id = m.channel_id
+		where m.id = 'orphan-message' and c.name = 'recovered-thread'
+	`)
+	require.NoError(t, err)
+	require.Equal(t, [][]string{{"orphan-message"}}, rows)
+	_, rows, err = s.ReadOnlyQuery(ctx, `select message_id from message_fts where message_fts match 'catalog witness'`)
+	require.NoError(t, err)
+	require.Equal(t, [][]string{{"orphan-message"}}, rows)
+}
+
+func TestHasOrphanedMessageChannelsReturnsUndeterminedOnCancelledContext(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	s, err := Open(context.Background(), filepath.Join(t.TempDir(), "discrawl.db"))
+	require.NoError(t, err)
+	defer func() { _ = s.Close() }()
+	cancel()
+
+	state, err := s.HasOrphanedMessageChannels(ctx)
+	require.NoError(t, err)
+	require.Equal(t, CatalogUndetermined, state)
+}
+
+func TestCatalogIntegrityProbeLargeCompleteFixture(t *testing.T) {
+	if os.Getenv("DISCRAWL_TEST_LARGE") != "1" {
+		t.Skip("set DISCRAWL_TEST_LARGE=1 to run the catalog-integrity calibration fixture")
+	}
+
+	ctx := context.Background()
+	s, err := Open(ctx, filepath.Join(t.TempDir(), "discrawl.db"))
+	require.NoError(t, err)
+	defer func() { _ = s.Close() }()
+	require.NoError(t, s.UpsertChannel(ctx, ChannelRecord{ID: "catalog-channel", GuildID: "guild-1", Kind: "text", Name: "catalog", RawJSON: `{}`}))
+
+	started := time.Now()
+	tx, err := s.DB().BeginTx(ctx, nil)
+	require.NoError(t, err)
+	stmt, err := tx.PrepareContext(ctx, `
+		insert into messages(
+			id, guild_id, channel_id, message_type, created_at, content,
+			normalized_content, raw_json, updated_at
+		) values(?, 'guild-1', 'catalog-channel', 0, '2026-08-02T00:00:00Z', '', '', '{}', '2026-08-02T00:00:00Z')
+	`)
+	require.NoError(t, err)
+	defer func() { _ = stmt.Close() }()
+	for i := range 465820 {
+		_, err = stmt.ExecContext(ctx, fmt.Sprintf("%020d", i+1))
+		require.NoError(t, err)
+	}
+	require.NoError(t, tx.Commit())
+	t.Logf("fixture build duration: %s", time.Since(started))
+
+	probeStarted := time.Now()
+	state, err := s.HasOrphanedMessageChannels(ctx)
+	require.NoError(t, err)
+	require.Equal(t, CatalogComplete, state)
+	t.Logf("healthy-catalog probe duration: %s", time.Since(probeStarted))
+}

--- a/internal/store/messages.go
+++ b/internal/store/messages.go
@@ -35,22 +35,23 @@ type MentionListOptions struct {
 }
 
 type MessageRow struct {
-	MessageID       string    `json:"message_id"`
-	GuildID         string    `json:"guild_id"`
-	GuildName       string    `json:"guild_name,omitempty"`
-	ChannelID       string    `json:"channel_id"`
-	ChannelName     string    `json:"channel_name"`
-	AuthorID        string    `json:"author_id"`
-	AuthorName      string    `json:"author_name"`
-	Content         string    `json:"content"`
-	DisplayContent  string    `json:"display_content,omitempty"`
-	CreatedAt       time.Time `json:"created_at"`
-	ReplyToMessage  string    `json:"reply_to_message_id,omitempty"`
-	Source          string    `json:"source,omitempty"`
-	HasAttachments  bool      `json:"has_attachments"`
-	AttachmentNames string    `json:"attachment_names,omitempty"`
-	AttachmentText  string    `json:"attachment_text,omitempty"`
-	Pinned          bool      `json:"pinned"`
+	MessageID              string    `json:"message_id"`
+	GuildID                string    `json:"guild_id"`
+	GuildName              string    `json:"guild_name,omitempty"`
+	ChannelID              string    `json:"channel_id"`
+	ChannelName            string    `json:"channel_name"`
+	ChannelMetadataPresent bool      `json:"-"`
+	AuthorID               string    `json:"author_id"`
+	AuthorName             string    `json:"author_name"`
+	Content                string    `json:"content"`
+	DisplayContent         string    `json:"display_content,omitempty"`
+	CreatedAt              time.Time `json:"created_at"`
+	ReplyToMessage         string    `json:"reply_to_message_id,omitempty"`
+	Source                 string    `json:"source,omitempty"`
+	HasAttachments         bool      `json:"has_attachments"`
+	AttachmentNames        string    `json:"attachment_names,omitempty"`
+	AttachmentText         string    `json:"attachment_text,omitempty"`
+	Pinned                 bool      `json:"pinned"`
 }
 
 func (s *Store) ListMessages(ctx context.Context, opts MessageListOptions) ([]MessageRow, error) {
@@ -89,6 +90,7 @@ func (s *Store) ListMessages(ctx context.Context, opts MessageListOptions) ([]Me
 			coalesce(g.name, ''),
 			m.channel_id,
 			coalesce(c.name, ''),
+			c.id is not null,
 			coalesce(m.author_id, ''),
 			coalesce(
 				nullif(mem.display_name, ''),
@@ -158,6 +160,7 @@ func (s *Store) ListMessages(ctx context.Context, opts MessageListOptions) ([]Me
 			&row.GuildName,
 			&row.ChannelID,
 			&row.ChannelName,
+			&row.ChannelMetadataPresent,
 			&row.AuthorID,
 			&row.AuthorName,
 			&row.Content,
@@ -227,6 +230,7 @@ func (s *Store) hydrateMessageThreadContext(ctx context.Context, rows []MessageR
 			coalesce(g.name, ''),
 			m.channel_id,
 			coalesce(c.name, ''),
+			c.id is not null,
 			coalesce(m.author_id, ''),
 			coalesce(
 				nullif(mem.display_name, ''),
@@ -285,6 +289,7 @@ func scanMessageRows(rows rowScanner) ([]MessageRow, error) {
 			&row.GuildName,
 			&row.ChannelID,
 			&row.ChannelName,
+			&row.ChannelMetadataPresent,
 			&row.AuthorID,
 			&row.AuthorName,
 			&row.Content,

--- a/internal/store/query.go
+++ b/internal/store/query.go
@@ -82,7 +82,7 @@ func (s *Store) CatalogIntegrity(ctx context.Context) (CatalogIntegrity, error) 
 	}, nil
 }
 
-func (s *Store) HasOrphanedMessageChannels(ctx context.Context) (CatalogCompleteness, error) {
+func (s *Store) HasOrphanedMessageChannels(ctx context.Context) (CatalogIntegrityState, error) {
 	queryCtx, cancel := context.WithTimeout(ctx, catalogIntegrityProbeTimeout)
 	defer cancel()
 	present, err := s.q.HasOrphanedMessageChannels(queryCtx)
@@ -95,7 +95,7 @@ func (s *Store) HasOrphanedMessageChannels(ctx context.Context) (CatalogComplete
 	if present {
 		return CatalogIncomplete, nil
 	}
-	return CatalogComplete, nil
+	return CatalogConsistent, nil
 }
 
 func (s *Store) SearchMessages(ctx context.Context, opts SearchOptions) ([]SearchResult, error) {
@@ -141,6 +141,7 @@ func (s *Store) SearchMessages(ctx context.Context, opts SearchOptions) ([]Searc
 		)
 		select
 			m.id, m.guild_id, m.channel_id, coalesce(c.name, recent_matches.channel_name),
+			c.id is not null,
 			coalesce(m.author_id, ''), recent_matches.author_name,
 			case
 				when trim(coalesce(m.content, '')) <> '' then m.content
@@ -171,7 +172,7 @@ func (s *Store) SearchMessages(ctx context.Context, opts SearchOptions) ([]Searc
 	for rows.Next() {
 		var row SearchResult
 		var created string
-		if err := rows.Scan(&row.MessageID, &row.GuildID, &row.ChannelID, &row.ChannelName, &row.AuthorID, &row.AuthorName, &row.Content, &created); err != nil {
+		if err := rows.Scan(&row.MessageID, &row.GuildID, &row.ChannelID, &row.ChannelName, &row.ChannelMetadataPresent, &row.AuthorID, &row.AuthorName, &row.Content, &created); err != nil {
 			return nil, err
 		}
 		row.CreatedAt = parseTime(created)
@@ -395,6 +396,7 @@ func (s *Store) searchResultDetails(ctx context.Context, messageIDs []string) (m
 			m.guild_id,
 			m.channel_id,
 			coalesce(c.name, ''),
+			c.id is not null,
 			coalesce(m.author_id, ''),
 			`+authorExpr+`,
 			case
@@ -415,7 +417,7 @@ func (s *Store) searchResultDetails(ctx context.Context, messageIDs []string) (m
 	for rows.Next() {
 		var row SearchResult
 		var created string
-		if err := rows.Scan(&row.MessageID, &row.GuildID, &row.ChannelID, &row.ChannelName, &row.AuthorID, &row.AuthorName, &row.Content, &created); err != nil {
+		if err := rows.Scan(&row.MessageID, &row.GuildID, &row.ChannelID, &row.ChannelName, &row.ChannelMetadataPresent, &row.AuthorID, &row.AuthorName, &row.Content, &created); err != nil {
 			return nil, err
 		}
 		row.CreatedAt = parseTime(created)
@@ -637,6 +639,7 @@ func (s *Store) searchFallback(ctx context.Context, opts SearchOptions) ([]Searc
 			m.guild_id,
 			m.channel_id,
 			coalesce(c.name, ''),
+			c.id is not null,
 			coalesce(m.author_id, ''),
 			'',
 			case
@@ -658,7 +661,7 @@ func (s *Store) searchFallback(ctx context.Context, opts SearchOptions) ([]Searc
 	for rows.Next() {
 		var row SearchResult
 		var created string
-		if err := rows.Scan(&row.MessageID, &row.GuildID, &row.ChannelID, &row.ChannelName, &row.AuthorID, &row.AuthorName, &row.Content, &created); err != nil {
+		if err := rows.Scan(&row.MessageID, &row.GuildID, &row.ChannelID, &row.ChannelName, &row.ChannelMetadataPresent, &row.AuthorID, &row.AuthorName, &row.Content, &created); err != nil {
 			return nil, err
 		}
 		row.CreatedAt = parseTime(created)

--- a/internal/store/query.go
+++ b/internal/store/query.go
@@ -18,6 +18,7 @@ import (
 const (
 	queryTimeout                         = 15 * time.Second
 	semanticQueryTimeout                 = 2 * time.Minute
+	catalogIntegrityProbeTimeout         = 2 * time.Second
 	queryRowLimit                        = 50000
 	searchCandidateFloor                 = 200
 	searchCandidateCap                   = 5000
@@ -64,6 +65,37 @@ func (s *Store) ChannelMessageBounds(ctx context.Context, channelID string) (str
 		return "", "", err
 	}
 	return row.OldestID, row.NewestID, nil
+}
+
+func (s *Store) CatalogIntegrity(ctx context.Context) (CatalogIntegrity, error) {
+	queryCtx, cancel := withQueryTimeout(ctx)
+	defer cancel()
+	row, err := s.q.CatalogIntegrity(queryCtx)
+	if err != nil {
+		return CatalogIntegrity{}, err
+	}
+	return CatalogIntegrity{
+		OrphanedMessageCount: int(row.OrphanedMessageCount),
+		OrphanedChannelCount: int(row.OrphanedChannelCount),
+		OldestAffectedAt:     parseTime(row.OldestAffectedAt),
+		NewestAffectedAt:     parseTime(row.NewestAffectedAt),
+	}, nil
+}
+
+func (s *Store) HasOrphanedMessageChannels(ctx context.Context) (CatalogCompleteness, error) {
+	queryCtx, cancel := context.WithTimeout(ctx, catalogIntegrityProbeTimeout)
+	defer cancel()
+	present, err := s.q.HasOrphanedMessageChannels(queryCtx)
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return CatalogUndetermined, nil
+	}
+	if err != nil {
+		return CatalogUndetermined, err
+	}
+	if present {
+		return CatalogIncomplete, nil
+	}
+	return CatalogComplete, nil
 }
 
 func (s *Store) SearchMessages(ctx context.Context, opts SearchOptions) ([]SearchResult, error) {

--- a/internal/store/sqlc/queries.sql
+++ b/internal/store/sqlc/queries.sql
@@ -67,9 +67,23 @@ select count(*) as count from messages;
 -- name: CatalogIntegrity :one
 select
 	count(*) as orphaned_message_count,
-	count(distinct m.channel_id) as orphaned_channel_count,
-	cast(coalesce(min(m.created_at), '') as text) as oldest_affected_at,
-	cast(coalesce(max(m.created_at), '') as text) as newest_affected_at
+	count(distinct coalesce(m.channel_id, '')) as orphaned_channel_count,
+	cast(coalesce((
+		select m2.created_at
+		from messages m2
+		left join channels c2 on c2.id = m2.channel_id
+		where c2.id is null
+		order by julianday(m2.created_at), m2.id
+		limit 1
+	), '') as text) as oldest_affected_at,
+	cast(coalesce((
+		select m2.created_at
+		from messages m2
+		left join channels c2 on c2.id = m2.channel_id
+		where c2.id is null
+		order by julianday(m2.created_at) desc, m2.id desc
+		limit 1
+	), '') as text) as newest_affected_at
 from messages m
 left join channels c on c.id = m.channel_id
 where c.id is null;

--- a/internal/store/sqlc/queries.sql
+++ b/internal/store/sqlc/queries.sql
@@ -64,6 +64,25 @@ select count(*) as count from channels;
 -- name: CountMessages :one
 select count(*) as count from messages;
 
+-- name: CatalogIntegrity :one
+select
+	count(*) as orphaned_message_count,
+	count(distinct m.channel_id) as orphaned_channel_count,
+	cast(coalesce(min(m.created_at), '') as text) as oldest_affected_at,
+	cast(coalesce(max(m.created_at), '') as text) as newest_affected_at
+from messages m
+left join channels c on c.id = m.channel_id
+where c.id is null;
+
+-- name: HasOrphanedMessageChannels :one
+select exists(
+	select 1
+	from messages m
+	left join channels c on c.id = m.channel_id
+	where c.id is null
+	limit 1
+) as present;
+
 -- name: CountMembers :one
 select count(*) as count from members where deleted_at is null;
 

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -28,6 +28,21 @@ type Store struct {
 	path string
 }
 
+type CatalogIntegrity struct {
+	OrphanedMessageCount int       `json:"orphaned_message_count"`
+	OrphanedChannelCount int       `json:"orphaned_channel_count"`
+	OldestAffectedAt     time.Time `json:"oldest_affected_at,omitzero"`
+	NewestAffectedAt     time.Time `json:"newest_affected_at,omitzero"`
+}
+
+type CatalogCompleteness string
+
+const (
+	CatalogComplete     CatalogCompleteness = "complete"
+	CatalogIncomplete   CatalogCompleteness = "incomplete"
+	CatalogUndetermined CatalogCompleteness = "undetermined"
+)
+
 type Status struct {
 	DBPath             string    `json:"db_path"`
 	GuildCount         int       `json:"guild_count"`

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -35,12 +35,12 @@ type CatalogIntegrity struct {
 	NewestAffectedAt     time.Time `json:"newest_affected_at,omitzero"`
 }
 
-type CatalogCompleteness string
+type CatalogIntegrityState string
 
 const (
-	CatalogComplete     CatalogCompleteness = "complete"
-	CatalogIncomplete   CatalogCompleteness = "incomplete"
-	CatalogUndetermined CatalogCompleteness = "undetermined"
+	CatalogConsistent   CatalogIntegrityState = "consistent"
+	CatalogIncomplete   CatalogIntegrityState = "incomplete"
+	CatalogUndetermined CatalogIntegrityState = "undetermined"
 )
 
 type Status struct {
@@ -68,14 +68,15 @@ type SearchOptions struct {
 }
 
 type SearchResult struct {
-	MessageID   string    `json:"message_id"`
-	GuildID     string    `json:"guild_id"`
-	ChannelID   string    `json:"channel_id"`
-	ChannelName string    `json:"channel_name"`
-	AuthorID    string    `json:"author_id"`
-	AuthorName  string    `json:"author_name"`
-	Content     string    `json:"content"`
-	CreatedAt   time.Time `json:"created_at"`
+	MessageID              string    `json:"message_id"`
+	GuildID                string    `json:"guild_id"`
+	ChannelID              string    `json:"channel_id"`
+	ChannelName            string    `json:"channel_name"`
+	ChannelMetadataPresent bool      `json:"-"`
+	AuthorID               string    `json:"author_id"`
+	AuthorName             string    `json:"author_name"`
+	Content                string    `json:"content"`
+	CreatedAt              time.Time `json:"created_at"`
 }
 
 type MentionRow struct {

--- a/internal/store/storedb/queries.sql.go
+++ b/internal/store/storedb/queries.sql.go
@@ -10,6 +10,36 @@ import (
 	"database/sql"
 )
 
+const catalogIntegrity = `-- name: CatalogIntegrity :one
+select
+	count(*) as orphaned_message_count,
+	count(distinct m.channel_id) as orphaned_channel_count,
+	cast(coalesce(min(m.created_at), '') as text) as oldest_affected_at,
+	cast(coalesce(max(m.created_at), '') as text) as newest_affected_at
+from messages m
+left join channels c on c.id = m.channel_id
+where c.id is null
+`
+
+type CatalogIntegrityRow struct {
+	OrphanedMessageCount int64
+	OrphanedChannelCount int64
+	OldestAffectedAt     string
+	NewestAffectedAt     string
+}
+
+func (q *Queries) CatalogIntegrity(ctx context.Context) (CatalogIntegrityRow, error) {
+	row := q.db.QueryRowContext(ctx, catalogIntegrity)
+	var i CatalogIntegrityRow
+	err := row.Scan(
+		&i.OrphanedMessageCount,
+		&i.OrphanedChannelCount,
+		&i.OldestAffectedAt,
+		&i.NewestAffectedAt,
+	)
+	return i, err
+}
+
 const channelMessageBounds = `-- name: ChannelMessageBounds :one
 select cast(coalesce(min(id), '') as text) as oldest_id,
        cast(coalesce(max(id), '') as text) as newest_id
@@ -355,6 +385,23 @@ type HasMessageEmbeddingsParams struct {
 
 func (q *Queries) HasMessageEmbeddings(ctx context.Context, arg HasMessageEmbeddingsParams) (bool, error) {
 	row := q.db.QueryRowContext(ctx, hasMessageEmbeddings, arg.Provider, arg.Model, arg.InputVersion)
+	var present bool
+	err := row.Scan(&present)
+	return present, err
+}
+
+const hasOrphanedMessageChannels = `-- name: HasOrphanedMessageChannels :one
+select exists(
+	select 1
+	from messages m
+	left join channels c on c.id = m.channel_id
+	where c.id is null
+	limit 1
+) as present
+`
+
+func (q *Queries) HasOrphanedMessageChannels(ctx context.Context) (bool, error) {
+	row := q.db.QueryRowContext(ctx, hasOrphanedMessageChannels)
 	var present bool
 	err := row.Scan(&present)
 	return present, err

--- a/internal/store/storedb/queries.sql.go
+++ b/internal/store/storedb/queries.sql.go
@@ -13,9 +13,23 @@ import (
 const catalogIntegrity = `-- name: CatalogIntegrity :one
 select
 	count(*) as orphaned_message_count,
-	count(distinct m.channel_id) as orphaned_channel_count,
-	cast(coalesce(min(m.created_at), '') as text) as oldest_affected_at,
-	cast(coalesce(max(m.created_at), '') as text) as newest_affected_at
+	count(distinct coalesce(m.channel_id, '')) as orphaned_channel_count,
+	cast(coalesce((
+		select m2.created_at
+		from messages m2
+		left join channels c2 on c2.id = m2.channel_id
+		where c2.id is null
+		order by julianday(m2.created_at), m2.id
+		limit 1
+	), '') as text) as oldest_affected_at,
+	cast(coalesce((
+		select m2.created_at
+		from messages m2
+		left join channels c2 on c2.id = m2.channel_id
+		where c2.id is null
+		order by julianday(m2.created_at) desc, m2.id desc
+		limit 1
+	), '') as text) as newest_affected_at
 from messages m
 left join channels c on c.id = m.channel_id
 where c.id is null


### PR DESCRIPTION
## Summary
- surface orphaned message-to-channel catalog state in diagnostics
- preserve missing metadata in human output and warn on unsafe empty raw-SQL identity results
- add regression and 465,820-row calibration coverage

## Verification
- `make check`
- `make test-large`

No archive repair, migration, restart, or live API operation is included.