### PR TITLE
chore(release): prepare v0.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 0.13.0 - 2026-08-03
 
 ### Changes
 


### PR DESCRIPTION
## Summary

- freeze the changelog for Discrawl v0.13.0 on August 3, 2026
- release the new catalog-integrity diagnostics and missing-channel annotations
- include Crawlkit v0.14.5 and the refreshed README

## Validation

- `git diff --check`
- `make tidy-check fmt`
- `GOLANGCI_LINT_CACHE=/tmp/discrawl-release-0-13-0-golangci-cache make lint`
- `make test-coverage test-race smoke`
- `GOWORK=off go run github.com/goreleaser/goreleaser/v2@v2.17.1 release --snapshot --clean --skip=publish`
- autoreview clean

## Release

After this lands, dispatch `.github/workflows/release-unified.yml` with `version=0.13.0` from the exact protected `main` head.
