### PR TITLE
fix: trace live tail event outcomes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Maintenance
 
-- Update Crawlkit to v0.14.6, the modernc SQLite stack to v1.56.0, and refresh Go analysis tooling.
+- Update Crawlkit to v0.14.6, Kong to v1.16.1, the modernc SQLite stack to v1.56.0, and refresh Go analysis tooling.
 
 ## 0.13.0 - 2026-08-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixes
+
+- Trace live Discord message receipt, handling, scope filtering, and archive completion in verbose tail logs without exposing message content or author metadata.
+
 ### Maintenance
 
 - Update Crawlkit to v0.14.6, the modernc SQLite stack to v1.56.0, and refresh Go analysis tooling.

--- a/docs/commands/tail.md
+++ b/docs/commands/tail.md
@@ -6,6 +6,7 @@ Runs the live Discord Gateway tail and a periodic repair loop.
 
 ```bash
 discrawl tail
+discrawl --verbose tail
 discrawl tail --with-embeddings
 discrawl tail --guild 123456789012345678
 discrawl tail --repair-every 30m
@@ -15,7 +16,8 @@ discrawl tail --replay-failures-only
 ## What it does
 
 - connects to the Discord Gateway with the configured bot token
-- writes new messages, edits, and deletes into the local archive as they arrive
+- writes new messages, edits, and deletes in the configured guild, category,
+  and channel scope into the local archive as they arrive
 - periodically runs a repair pass to catch anything the live stream missed
 - optionally queues live, replayed, and repair messages for background embedding
 - can replay a bounded set of unresolved exact-message failures without
@@ -33,6 +35,9 @@ discrawl tail --replay-failures-only
 
 - requires a working Discord bot token
 - not available in Git-only mode (`discord.token_source = "none"`)
+- `discrawl --verbose tail` traces Gateway receipt, worker handling, scope
+  filtering, and successful archive writes with event and Discord IDs but no
+  message content or author metadata
 - terminates cleanly on SIGINT / SIGTERM and treats cancellation as normal exit
 - replay-only mode uses the normal exclusive writer lock and does not create
   Gateway message events or update `tail:last_event`

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/openclaw/discrawl
 go 1.26.5
 
 require (
-	github.com/alecthomas/kong v1.16.0
+	github.com/alecthomas/kong v1.16.1
 	github.com/bwmarrin/discordgo v0.29.0
 	github.com/gorilla/websocket v1.5.3
 	github.com/stretchr/testify v1.11.1

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/alecthomas/assert/v2 v2.11.0 h1:2Q9r3ki8+JYXvGsDyBXwH3LcJ+WK5D0gc5E8vS6K3D0=
 github.com/alecthomas/assert/v2 v2.11.0/go.mod h1:Bze95FyfUr7x34QZrjL+XP+0qgp/zg8yS+TtBj1WA3k=
-github.com/alecthomas/kong v1.16.0 h1:g92/kUxBcdcTPOM79yE63viJgtcp5dNyrB3/O2cjYT4=
-github.com/alecthomas/kong v1.16.0/go.mod h1:wrlbXem1CWqUV5Vbmss5ISYhsVPkBb1Yo7YKJghju2I=
+github.com/alecthomas/kong v1.16.1 h1:ixhCt93XkJ98kGposQ54+bl0IK6XwqB40AsMynU7Z8E=
+github.com/alecthomas/kong v1.16.1/go.mod h1:wrlbXem1CWqUV5Vbmss5ISYhsVPkBb1Yo7YKJghju2I=
 github.com/alecthomas/repr v0.5.2 h1:SU73FTI9D1P5UNtvseffFSGmdNci/O6RsqzeXJtP0Qs=
 github.com/alecthomas/repr v0.5.2/go.mod h1:Fr0507jx4eOXV7AlPV6AVZLYrLIuIeSOWtW57eE/O/4=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1 h1:HwpRHbFMcZLEVr42D4p7XBqjyuxQH5SMiErDT4WkJ2k=

--- a/internal/discord/client.go
+++ b/internal/discord/client.go
@@ -35,6 +35,21 @@ type TailReadyHandler interface {
 	OnTailReady(context.Context) error
 }
 
+// TailEventObservation identifies a message event received from the Gateway.
+// It intentionally excludes message content and author metadata.
+type TailEventObservation struct {
+	EventType string
+	Stage     string
+	Reason    string
+	GuildID   string
+	ChannelID string
+	MessageID string
+}
+
+type tailEventObserver interface {
+	OnTailEventObserved(TailEventObservation)
+}
+
 type TailFailureStage string
 
 const (
@@ -401,6 +416,7 @@ func (c *Client) Tail(ctx context.Context, handler EventHandler) error {
 	orderedWorkCh := make(chan tailTask, c.tailQueueSize)
 	failureHandler, _ := handler.(tailFailureHandler)
 	failureRecorder, _ := handler.(tailFailureRecorder)
+	eventObserver, _ := handler.(tailEventObserver)
 	failureCircuits := map[tailFailureClass]*tailFailureCircuit{
 		tailFailureClassOrdered: {limit: defaultTailHandlerFailureLimit},
 		tailFailureClassMember:  {limit: defaultTailHandlerFailureLimit},
@@ -515,13 +531,15 @@ func (c *Client) Tail(ctx context.Context, handler EventHandler) error {
 		if evt != nil {
 			msg = evt.Message
 		}
-		c.enqueueTailTask(tailCtx, orderedWorkCh, fatal, newMessageTailTask(
+		task := newMessageTailTask(
 			"MESSAGE_CREATE",
 			func(taskCtx context.Context) error {
 				return handler.OnMessageCreate(taskCtx, msg)
 			},
 			msg,
-		))
+		)
+		reportTailEventObserved(eventObserver, task, "gateway_received", "")
+		c.enqueueTailTask(tailCtx, orderedWorkCh, fatal, task)
 	})
 	addHandler(func(session *discordgo.Session, evt *discordgo.MessageUpdate) {
 		var msg, before *discordgo.Message
@@ -537,6 +555,8 @@ func (c *Client) Tail(ctx context.Context, handler EventHandler) error {
 		)
 		task.run = func(taskCtx context.Context) error {
 			if filter, ok := handler.(tailGuildFilter); ok && msg != nil && !filter.TailAllowsGuild(msg.GuildID) {
+				reportTailEventObserved(eventObserver, task, "handler_started", "")
+				reportTailEventObserved(eventObserver, task, "ignored", "guild_scope")
 				return nil
 			}
 			var refetchErr error
@@ -569,6 +589,7 @@ func (c *Client) Tail(ctx context.Context, handler EventHandler) error {
 			}
 			return errors.Join(refetchErr, handlerErr)
 		}
+		reportTailEventObserved(eventObserver, task, "gateway_received", "")
 		c.enqueueTailTask(tailCtx, orderedWorkCh, fatal, task)
 	})
 	addHandler(func(_ *discordgo.Session, evt *discordgo.MessageDelete) {
@@ -577,14 +598,16 @@ func (c *Client) Tail(ctx context.Context, handler EventHandler) error {
 			msg = evt.Message
 			before = evt.BeforeDelete
 		}
-		c.enqueueTailTask(tailCtx, orderedWorkCh, fatal, newMessageTailTask(
+		task := newMessageTailTask(
 			"MESSAGE_DELETE",
 			func(taskCtx context.Context) error {
 				return handler.OnMessageDelete(taskCtx, evt)
 			},
 			msg,
 			before,
-		))
+		)
+		reportTailEventObserved(eventObserver, task, "gateway_received", "")
+		c.enqueueTailTask(tailCtx, orderedWorkCh, fatal, task)
 	})
 	addHandler(func(_ *discordgo.Session, evt *discordgo.ChannelCreate) {
 		var channel *discordgo.Channel
@@ -779,6 +802,20 @@ func (c *Client) Tail(ctx context.Context, handler EventHandler) error {
 		return err
 	}
 	return nil
+}
+
+func reportTailEventObserved(observer tailEventObserver, task tailTask, stage, reason string) {
+	if observer == nil {
+		return
+	}
+	observer.OnTailEventObserved(TailEventObservation{
+		EventType: task.eventType,
+		Stage:     stage,
+		Reason:    reason,
+		GuildID:   task.guildID,
+		ChannelID: task.channelID,
+		MessageID: task.messageID,
+	})
 }
 
 func (c *Client) enqueueTailTask(

--- a/internal/discord/client_test.go
+++ b/internal/discord/client_test.go
@@ -1126,7 +1126,9 @@ func TestTailReceivesGatewayEvents(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	handler := &recordingHandler{}
+	handler := &observingRecordingHandler{
+		observations: make(chan TailEventObservation, 3),
+	}
 	go func() {
 		time.Sleep(100 * time.Millisecond)
 		cancel()
@@ -1139,6 +1141,16 @@ func TestTailReceivesGatewayEvents(t *testing.T) {
 	require.Equal(t, 1, handler.memberUpserts)
 	require.Equal(t, 1, handler.memberDeletes)
 	require.Equal(t, 1, handler.ready)
+	require.Len(t, handler.observations, 3)
+	require.Equal(t, TailEventObservation{
+		EventType: "MESSAGE_CREATE",
+		Stage:     "gateway_received",
+		GuildID:   "g1",
+		ChannelID: "c1",
+		MessageID: "m1",
+	}, <-handler.observations)
+	require.Equal(t, "MESSAGE_UPDATE", (<-handler.observations).EventType)
+	require.Equal(t, "MESSAGE_DELETE", (<-handler.observations).EventType)
 	require.Zero(t, discordSessionHandlerCount(client.session))
 }
 
@@ -2804,6 +2816,7 @@ func TestTailMessageUpdateSkipsRefetchForFilteredGuild(t *testing.T) {
 	handler := &guildFilteringUpdateHandler{
 		allowedGuild: "g-selected",
 		filtered:     make(chan struct{}),
+		observations: make(chan TailEventObservation, 3),
 	}
 	var refetchCalls atomic.Int32
 	now := time.Now().UTC().Format(time.RFC3339)
@@ -2845,6 +2858,17 @@ func TestTailMessageUpdateSkipsRefetchForFilteredGuild(t *testing.T) {
 	require.NoError(t, client.Tail(tailCtx, handler))
 	require.Zero(t, refetchCalls.Load())
 	require.Zero(t, handler.updates)
+	require.Equal(t, TailEventObservation{
+		EventType: "MESSAGE_UPDATE",
+		Stage:     "gateway_received",
+		GuildID:   "g-excluded",
+		ChannelID: "c1",
+		MessageID: "m1",
+	}, <-handler.observations)
+	require.Equal(t, "handler_started", (<-handler.observations).Stage)
+	ignored := <-handler.observations
+	require.Equal(t, "ignored", ignored.Stage)
+	require.Equal(t, "guild_scope", ignored.Reason)
 }
 
 func TestTailMessageUpdateRejectsConflictingRefetchIdentity(t *testing.T) {
@@ -3399,6 +3423,15 @@ type recordingHandler struct {
 	ready         int
 }
 
+type observingRecordingHandler struct {
+	recordingHandler
+	observations chan TailEventObservation
+}
+
+func (h *observingRecordingHandler) OnTailEventObserved(event TailEventObservation) {
+	h.observations <- event
+}
+
 type gatewayOpenFailureHandler struct {
 	recordingHandler
 	recordCalls atomic.Int32
@@ -3920,7 +3953,12 @@ type guildFilteringUpdateHandler struct {
 	recordingHandler
 	allowedGuild string
 	filtered     chan struct{}
+	observations chan TailEventObservation
 	filterOnce   sync.Once
+}
+
+func (h *guildFilteringUpdateHandler) OnTailEventObserved(event TailEventObservation) {
+	h.observations <- event
 }
 
 func (h *guildFilteringUpdateHandler) TailAllowsGuild(guildID string) bool {

--- a/internal/syncer/syncer_tail_test.go
+++ b/internal/syncer/syncer_tail_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
@@ -1748,6 +1749,66 @@ func TestTailReadyCallback(t *testing.T) {
 
 	handler.onReady = nil
 	require.NoError(t, handler.OnTailReady(context.Background()))
+}
+
+func TestTailEventTraceLogsSafeStagesAndScopeOutcomes(t *testing.T) {
+	ctx := context.Background()
+	s, err := store.Open(ctx, filepath.Join(t.TempDir(), "discrawl.db"))
+	require.NoError(t, err)
+	defer func() { _ = s.Close() }()
+
+	out := &lockedBuffer{}
+	logger := slog.New(slog.NewTextHandler(out, &slog.HandlerOptions{
+		Level: slog.LevelDebug,
+		ReplaceAttr: func(_ []string, attr slog.Attr) slog.Attr {
+			if attr.Key == slog.TimeKey {
+				return slog.Attr{}
+			}
+			return attr
+		},
+	}))
+	handler := &tailHandler{
+		guilds:     makeGuildSet([]string{"g1"}),
+		store:      s,
+		logger:     logger,
+		exclusions: newChannelScope([]string{"blocked"}, nil, nil),
+	}
+	message := &discordgo.Message{
+		ID:        "100000000000000001",
+		GuildID:   "g1",
+		ChannelID: "c1",
+		Content:   "sensitive canary content",
+		Timestamp: time.Now().UTC(),
+		Author:    &discordgo.User{ID: "private-user", Username: "private-name"},
+	}
+	handler.OnTailEventObserved(discordclient.TailEventObservation{
+		EventType: "MESSAGE_CREATE",
+		GuildID:   message.GuildID,
+		ChannelID: message.ChannelID,
+		MessageID: message.ID,
+	})
+	require.NoError(t, handler.OnMessageCreate(ctx, message))
+
+	wrongGuild := *message
+	wrongGuild.ID = "100000000000000002"
+	wrongGuild.GuildID = "g2"
+	require.NoError(t, handler.OnMessageCreate(ctx, &wrongGuild))
+
+	blocked := *message
+	blocked.ID = "100000000000000003"
+	blocked.ChannelID = "blocked"
+	require.NoError(t, handler.OnMessageCreate(ctx, &blocked))
+
+	logged := out.String()
+	require.Contains(t, logged, `level=DEBUG msg="tail event trace" event_type=MESSAGE_CREATE stage=gateway_received`)
+	require.Contains(t, logged, "stage=handler_started")
+	require.Contains(t, logged, "stage=archived")
+	require.Contains(t, logged, "stage=ignored reason=guild_scope")
+	require.Contains(t, logged, "stage=ignored reason=channel_scope")
+	require.Contains(t, logged, "message_id=100000000000000001")
+	require.NotContains(t, logged, message.Content)
+	require.NotContains(t, logged, message.Author.ID)
+	require.NotContains(t, logged, message.Author.Username)
 }
 
 func TestRunTailLogsSafeEventFailureMetadata(t *testing.T) {

--- a/internal/syncer/tail.go
+++ b/internal/syncer/tail.go
@@ -249,9 +249,34 @@ func (t *tailHandler) OnTailFailure(failure discordclient.TailFailure) {
 	t.logger.Warn("tail event handler failed", attrs...)
 }
 
+func (t *tailHandler) OnTailEventObserved(event discordclient.TailEventObservation) {
+	stage := event.Stage
+	if stage == "" {
+		stage = "gateway_received"
+	}
+	t.logTailEvent(
+		event.EventType,
+		stage,
+		event.Reason,
+		event.GuildID,
+		event.ChannelID,
+		event.MessageID,
+	)
+}
+
 func (t *tailHandler) OnMessageCreate(ctx context.Context, msg *discordgo.Message) error {
 	discordclient.UpdateTailFailureStage(ctx, discordclient.TailFailureStageHandler)
-	if msg == nil || !t.allowGuild(msg.GuildID) || t.excludeChannel(msg.ChannelID) {
+	t.logTailMessage("MESSAGE_CREATE", "handler_started", "", msg)
+	if msg == nil {
+		t.logTailMessage("MESSAGE_CREATE", "ignored", "missing_event", msg)
+		return nil
+	}
+	if !t.allowGuild(msg.GuildID) {
+		t.logTailMessage("MESSAGE_CREATE", "ignored", "guild_scope", msg)
+		return nil
+	}
+	if t.excludeChannel(msg.ChannelID) {
+		t.logTailMessage("MESSAGE_CREATE", "ignored", "channel_scope", msg)
 		return nil
 	}
 	discordclient.UpdateTailFailureStage(ctx, discordclient.TailFailureStageMessageBuild)
@@ -275,15 +300,26 @@ func (t *tailHandler) OnMessageCreate(ctx context.Context, msg *discordgo.Messag
 	if err := t.store.AdvanceChannelLatestMessageID(ctx, msg.ChannelID, msg.ID); err != nil {
 		return err
 	}
-	return t.resolveMessageFailure(ctx, msg.GuildID, msg.ChannelID, msg.ID, "create")
+	if err := t.resolveMessageFailure(ctx, msg.GuildID, msg.ChannelID, msg.ID, "create"); err != nil {
+		return err
+	}
+	t.logTailMessage("MESSAGE_CREATE", "archived", "", msg)
+	return nil
 }
 
 func (t *tailHandler) OnMessageUpdate(ctx context.Context, msg *discordgo.Message) error {
 	discordclient.UpdateTailFailureStage(ctx, discordclient.TailFailureStageHandler)
+	t.logTailMessage("MESSAGE_UPDATE", "handler_started", "", msg)
 	if msg == nil {
+		t.logTailMessage("MESSAGE_UPDATE", "ignored", "missing_event", msg)
 		return nil
 	}
-	if t.excludeChannel(msg.ChannelID) || (msg.GuildID != "" && !t.allowGuild(msg.GuildID)) {
+	if msg.GuildID != "" && !t.allowGuild(msg.GuildID) {
+		t.logTailMessage("MESSAGE_UPDATE", "ignored", "guild_scope", msg)
+		return nil
+	}
+	if t.excludeChannel(msg.ChannelID) {
+		t.logTailMessage("MESSAGE_UPDATE", "ignored", "channel_scope", msg)
 		return nil
 	}
 	var err error
@@ -291,7 +327,16 @@ func (t *tailHandler) OnMessageUpdate(ctx context.Context, msg *discordgo.Messag
 	if err != nil {
 		return err
 	}
-	if msg == nil || !t.allowGuild(msg.GuildID) || t.excludeChannel(msg.ChannelID) {
+	if msg == nil {
+		t.logTailMessage("MESSAGE_UPDATE", "ignored", "incomplete_event", msg)
+		return nil
+	}
+	if !t.allowGuild(msg.GuildID) {
+		t.logTailMessage("MESSAGE_UPDATE", "ignored", "guild_scope", msg)
+		return nil
+	}
+	if t.excludeChannel(msg.ChannelID) {
+		t.logTailMessage("MESSAGE_UPDATE", "ignored", "channel_scope", msg)
 		return nil
 	}
 	discordclient.UpdateTailFailureStage(ctx, discordclient.TailFailureStageMessageBuild)
@@ -311,7 +356,11 @@ func (t *tailHandler) OnMessageUpdate(ctx context.Context, msg *discordgo.Messag
 	if err := t.store.SetSyncState(ctx, "tail:last_event", msg.ID); err != nil {
 		return err
 	}
-	return t.resolveMessageFailure(ctx, msg.GuildID, msg.ChannelID, msg.ID, "update")
+	if err := t.resolveMessageFailure(ctx, msg.GuildID, msg.ChannelID, msg.ID, "update"); err != nil {
+		return err
+	}
+	t.logTailMessage("MESSAGE_UPDATE", "archived", "", msg)
+	return nil
 }
 
 func (t *tailHandler) messageUpdateSnapshot(ctx context.Context, msg *discordgo.Message) (*discordgo.Message, error) {
@@ -381,7 +430,17 @@ func isPartialMessageUpdate(msg *discordgo.Message) bool {
 
 func (t *tailHandler) OnMessageDelete(ctx context.Context, evt *discordgo.MessageDelete) error {
 	discordclient.UpdateTailFailureStage(ctx, discordclient.TailFailureStageHandler)
-	if evt == nil || !t.allowGuild(evt.GuildID) || t.excludeChannel(evt.ChannelID) {
+	t.logTailDelete("MESSAGE_DELETE", "handler_started", "", evt)
+	if evt == nil {
+		t.logTailDelete("MESSAGE_DELETE", "ignored", "missing_event", evt)
+		return nil
+	}
+	if !t.allowGuild(evt.GuildID) {
+		t.logTailDelete("MESSAGE_DELETE", "ignored", "guild_scope", evt)
+		return nil
+	}
+	if t.excludeChannel(evt.ChannelID) {
+		t.logTailDelete("MESSAGE_DELETE", "ignored", "channel_scope", evt)
 		return nil
 	}
 	discordclient.UpdateTailFailureStage(ctx, discordclient.TailFailureStageCanonicalDelete)
@@ -392,7 +451,47 @@ func (t *tailHandler) OnMessageDelete(ctx context.Context, evt *discordgo.Messag
 	if err := t.store.SetSyncState(ctx, "tail:last_event", evt.ID); err != nil {
 		return err
 	}
-	return t.resolveMessageFailure(ctx, evt.GuildID, evt.ChannelID, evt.ID, "delete")
+	if err := t.resolveMessageFailure(ctx, evt.GuildID, evt.ChannelID, evt.ID, "delete"); err != nil {
+		return err
+	}
+	t.logTailDelete("MESSAGE_DELETE", "archived", "", evt)
+	return nil
+}
+
+func (t *tailHandler) logTailMessage(eventType, stage, reason string, msg *discordgo.Message) {
+	if msg == nil {
+		t.logTailEvent(eventType, stage, reason, "", "", "")
+		return
+	}
+	t.logTailEvent(eventType, stage, reason, msg.GuildID, msg.ChannelID, msg.ID)
+}
+
+func (t *tailHandler) logTailDelete(eventType, stage, reason string, evt *discordgo.MessageDelete) {
+	if evt == nil {
+		t.logTailEvent(eventType, stage, reason, "", "", "")
+		return
+	}
+	t.logTailEvent(eventType, stage, reason, evt.GuildID, evt.ChannelID, evt.ID)
+}
+
+func (t *tailHandler) logTailEvent(eventType, stage, reason, guildID, channelID, messageID string) {
+	if t == nil || t.logger == nil || !t.logger.Enabled(context.Background(), slog.LevelDebug) {
+		return
+	}
+	attrs := []any{"event_type", eventType, "stage", stage}
+	if reason != "" {
+		attrs = append(attrs, "reason", reason)
+	}
+	if guildID != "" {
+		attrs = append(attrs, "guild_id", guildID)
+	}
+	if channelID != "" {
+		attrs = append(attrs, "channel_id", channelID)
+	}
+	if messageID != "" {
+		attrs = append(attrs, "message_id", messageID)
+	}
+	t.logger.Debug("tail event trace", attrs...)
 }
 
 func (t *tailHandler) OnChannelUpsert(ctx context.Context, channel *discordgo.Channel) error {


### PR DESCRIPTION
## Summary

- trace live message events through Gateway receipt, worker handling, scope filtering, and completed archive persistence under global verbose logging
- keep configured guild/category/channel filtering intact and clarify that scope in the tail command contract
- omit message content and author metadata from trace fields
- refresh Kong from 1.16.0 to 1.16.1 in the mandatory dependency pass

## Decision for #167

The reported loss did not reproduce on the unchanged current implementation: a live canary reached a fresh isolated archive in one second. The v0.2 comparison is not a reliable contract oracle because that release predates modern category/channel scope filtering.

The intended contract remains “archive arriving messages inside configured scope.” The actionable defect was that an operator could not distinguish Gateway receipt, worker progress, intentional scope filtering, and successful persistence. This change makes those outcomes observable without weakening the scope boundary or logging message/author data.

## Proof

- `make check`
  - module verify/tidy clean
  - formatting and all static/security analyzers clean
  - coverage 85.0%
  - race suite passed
  - CLI smoke passed
  - snapshot release built for Darwin, Linux, and Windows on amd64/arm64
- source-blind live validation with a fresh isolated config and database:
  - sent canary `discrawl-tail-proof-20260809-fixed-01`
  - Discord message id `1536191219586043966`
  - verbose trace showed, in order:
    - `stage=gateway_received`
    - `stage=handler_started`
    - `stage=archived`
  - SQLite returned the same id, channel, and exact canary content after one second
  - fabricated message id count was `0`
  - trace output contained neither canary content nor author metadata
- structured autoreview: one accepted update-scope tracing gap fixed; final review clean

Refs #167.
